### PR TITLE
fix: fatal error — wp-components on frontend

### DIFF
--- a/blocks/studio/src/view.js
+++ b/blocks/studio/src/view.js
@@ -1,5 +1,5 @@
 import { createElement, useState } from '@wordpress/element';
-import { Tabs } from '@extrachill/components';
+import Tabs from '@extrachill/components/components/Tabs';
 import '@extrachill/components/styles/components.scss';
 import '@extrachill/chat/css';
 


### PR DESCRIPTION
## The problem

The Studio block crashes on the frontend because `wp-components` is listed as a dependency in `view.asset.php`. WordPress tries to load it on the frontend where it doesn't exist — it's a Gutenberg admin-only library.

**Root cause:** `view.js` imports `{ Tabs } from '@extrachill/components'` — the barrel export (`index.js`) also re-exports `DataTable`, `Pagination`, `SearchBox`, and `Modal`, all of which import from `@wordpress/components`. Webpack sees those imports and externalizes `wp-components` as a required script dependency, even though `Tabs` itself uses zero WP components.

## The fix

One line change:

```diff
-import { Tabs } from '@extrachill/components';
+import Tabs from '@extrachill/components/components/Tabs';
```

Direct import bypasses the barrel, webpack never sees `@wordpress/components`, and `view.asset.php` drops the dependency.

**Before:** `dependencies: ['react', 'react-jsx-runtime', 'wp-api-fetch', 'wp-components', 'wp-element', 'wp-i18n']`

**After:** `dependencies: ['react', 'react-jsx-runtime', 'wp-api-fetch', 'wp-element', 'wp-i18n']`