### PR TITLE
feat: Compose tab — block editor on the frontend

### DIFF
--- a/blocks/studio/src/app/tabs.js
+++ b/blocks/studio/src/app/tabs.js
@@ -8,6 +8,12 @@ export const getStudioTabs = () => [
 		preview: __( 'Team-gated Studio shell with tabbed workspace.', 'extrachill-studio' ),
 	},
 	{
+		id: 'compose',
+		pane: 'compose',
+		label: __( 'Compose', 'extrachill-studio' ),
+		preview: __( 'Write posts with the block editor — no wp-admin required.', 'extrachill-studio' ),
+	},
+	{
 		id: 'chat',
 		pane: 'chat',
 		label: __( 'Chat', 'extrachill-studio' ),

--- a/blocks/studio/src/tabs/compose/index.js
+++ b/blocks/studio/src/tabs/compose/index.js
@@ -1,0 +1,242 @@
+import { __, sprintf } from '@wordpress/i18n';
+import { createElement, useEffect, useRef, useState } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Compose Pane — Block editor for drafting posts.
+ *
+ * Mounts the Blocks Everywhere isolated block editor on a hidden textarea.
+ * Content is serialized as block markup and saved to wp/v2/posts with
+ * status: pending for admin review.
+ */
+const ComposePane = () => {
+	const editorContainerRef = useRef( null );
+	const textareaRef = useRef( null );
+	const editorMountedRef = useRef( false );
+
+	const [ title, setTitle ] = useState( '' );
+	const [ isSubmitting, setIsSubmitting ] = useState( false );
+	const [ status, setStatus ] = useState( '' );
+	const [ error, setError ] = useState( '' );
+	const [ editorReady, setEditorReady ] = useState( false );
+
+	// Mount the block editor on first render.
+	useEffect( () => {
+		if ( editorMountedRef.current ) {
+			return;
+		}
+
+		if ( ! textareaRef.current ) {
+			return;
+		}
+
+		// Blocks Everywhere exposes this globally when loaded.
+		if ( typeof window.blocksEverywhereCreateEditor === 'function' ) {
+			window.blocksEverywhereCreateEditor( textareaRef.current );
+			editorMountedRef.current = true;
+			setEditorReady( true );
+		} else {
+			setError( __( 'Block editor not available. Ensure Blocks Everywhere plugin is active.', 'extrachill-studio' ) );
+		}
+	}, [] );
+
+	/**
+	 * Get the content from the hidden textarea.
+	 * Blocks Everywhere syncs the editor content back to the textarea
+	 * on every change via its onSaveContent callback.
+	 */
+	const getContent = () => {
+		if ( textareaRef.current ) {
+			return textareaRef.current.value || '';
+		}
+		return '';
+	};
+
+	const submitForReview = async () => {
+		const content = getContent();
+
+		if ( ! title.trim() ) {
+			setError( __( 'Add a title before submitting.', 'extrachill-studio' ) );
+			setStatus( '' );
+			return;
+		}
+
+		if ( ! content.trim() ) {
+			setError( __( 'Write some content before submitting.', 'extrachill-studio' ) );
+			setStatus( '' );
+			return;
+		}
+
+		setIsSubmitting( true );
+		setError( '' );
+		setStatus( __( 'Submitting for review…', 'extrachill-studio' ) );
+
+		try {
+			const post = await apiFetch( {
+				path: '/wp/v2/posts',
+				method: 'POST',
+				data: {
+					title: title.trim(),
+					content,
+					status: 'pending',
+				},
+			} );
+
+			setStatus(
+				sprintf(
+					__( 'Post #%d submitted for review. An admin will review it before publishing.', 'extrachill-studio' ),
+					post.id
+				)
+			);
+			setTitle( '' );
+
+			// Clear the editor content.
+			if ( textareaRef.current ) {
+				textareaRef.current.value = '';
+
+				// Trigger an input event so Blocks Everywhere picks up the change.
+				textareaRef.current.dispatchEvent( new Event( 'input', { bubbles: true } ) );
+			}
+		} catch ( submitError ) {
+			setStatus( '' );
+			setError( submitError?.message || __( 'Failed to submit post.', 'extrachill-studio' ) );
+		} finally {
+			setIsSubmitting( false );
+		}
+	};
+
+	const saveDraft = async () => {
+		const content = getContent();
+
+		if ( ! title.trim() && ! content.trim() ) {
+			setError( __( 'Add a title or content before saving.', 'extrachill-studio' ) );
+			setStatus( '' );
+			return;
+		}
+
+		setIsSubmitting( true );
+		setError( '' );
+		setStatus( __( 'Saving draft…', 'extrachill-studio' ) );
+
+		try {
+			const post = await apiFetch( {
+				path: '/wp/v2/posts',
+				method: 'POST',
+				data: {
+					title: title.trim(),
+					content,
+					status: 'draft',
+				},
+			} );
+
+			setStatus(
+				sprintf(
+					__( 'Draft #%d saved. You can find it in your drafts.', 'extrachill-studio' ),
+					post.id
+				)
+			);
+		} catch ( saveError ) {
+			setStatus( '' );
+			setError( saveError?.message || __( 'Failed to save draft.', 'extrachill-studio' ) );
+		} finally {
+			setIsSubmitting( false );
+		}
+	};
+
+	return createElement(
+		'div',
+		{ className: 'ec-studio-pane ec-studio-pane--compose' },
+		createElement(
+			'div',
+			{ className: 'ec-studio-pane__grid ec-studio-pane__grid--compose' },
+
+			// Left: Editor
+			createElement(
+				'div',
+				{ className: 'ec-studio-panel ec-studio-panel--editor' },
+				createElement( 'span', { className: 'ec-studio-panel__eyebrow' }, __( 'Compose', 'extrachill-studio' ) ),
+
+				// Title input
+				createElement( 'input', {
+					type: 'text',
+					className: 'ec-studio-compose-title',
+					placeholder: __( 'Post title…', 'extrachill-studio' ),
+					value: title,
+					onChange: ( e ) => {
+						setTitle( e.target.value );
+						setError( '' );
+						setStatus( '' );
+					},
+				} ),
+
+				// Block editor container
+				createElement(
+					'div',
+					{
+						className: 'ec-studio-compose-editor',
+						ref: editorContainerRef,
+					},
+					createElement( 'textarea', {
+						id: 'ec-studio-compose-content',
+						ref: textareaRef,
+						style: { display: 'none' },
+						defaultValue: '',
+					} )
+				),
+
+				// Status messages
+				error
+					? createElement( 'p', { className: 'ec-studio-message ec-studio-message--error' }, error )
+					: null,
+				! error && status
+					? createElement( 'p', { className: 'ec-studio-message ec-studio-message--success' }, status )
+					: null,
+
+				// Actions
+				createElement(
+					'div',
+					{ className: 'ec-studio-composer__actions' },
+					createElement(
+						'button',
+						{
+							type: 'button',
+							className: 'button-1 button-medium',
+							onClick: submitForReview,
+							disabled: isSubmitting || ! editorReady,
+						},
+						isSubmitting ? __( 'Submitting…', 'extrachill-studio' ) : __( 'Submit for Review', 'extrachill-studio' )
+					),
+					createElement(
+						'button',
+						{
+							type: 'button',
+							className: 'button-1 button-medium button-secondary',
+							onClick: saveDraft,
+							disabled: isSubmitting || ! editorReady,
+						},
+						isSubmitting ? __( 'Saving…', 'extrachill-studio' ) : __( 'Save Draft', 'extrachill-studio' )
+					)
+				)
+			),
+
+			// Right: Info panel
+			createElement(
+				'div',
+				{ className: 'ec-studio-panel' },
+				createElement( 'span', { className: 'ec-studio-panel__eyebrow' }, __( 'How it works', 'extrachill-studio' ) ),
+				createElement( 'h3', null, __( 'Frontend publishing', 'extrachill-studio' ) ),
+				createElement( 'p', null, __( 'Write posts using the full block editor right here in Studio. No wp-admin required.', 'extrachill-studio' ) ),
+				createElement(
+					'ul',
+					null,
+					createElement( 'li', null, __( 'Use the block editor to compose rich content with images, embeds, and formatting.', 'extrachill-studio' ) ),
+					createElement( 'li', null, __( 'Save Draft keeps your work-in-progress without submitting.', 'extrachill-studio' ) ),
+					createElement( 'li', null, __( 'Submit for Review sends the post for admin approval.', 'extrachill-studio' ) ),
+					createElement( 'li', null, __( 'Once approved, the post goes live.', 'extrachill-studio' ) )
+				)
+			)
+		)
+	);
+};
+
+export default ComposePane;

--- a/blocks/studio/src/tabs/overview/index.js
+++ b/blocks/studio/src/tabs/overview/index.js
@@ -28,9 +28,10 @@ const OverviewPane = ( { context } ) => createElement(
 			createElement(
 				'ul',
 				null,
+				createElement( 'li', null, __( 'Compose posts with the full block editor — no wp-admin required.', 'extrachill-studio' ) ),
 				createElement( 'li', null, __( 'Generate print-ready QR codes from any URL.', 'extrachill-studio' ) ),
 				createElement( 'li', null, __( 'Manage social platforms with live auth status from Data Machine Socials.', 'extrachill-studio' ) ),
-				createElement( 'li', null, __( 'Publish to connected social platforms using the cross-post workflow.', 'extrachill-studio' ) )
+				createElement( 'li', null, __( 'Submit social posts for admin review before cross-posting.', 'extrachill-studio' ) )
 			)
 		)
 	)

--- a/blocks/studio/src/view.js
+++ b/blocks/studio/src/view.js
@@ -6,6 +6,7 @@ import '@extrachill/chat/css';
 import { mountComponent } from './app/mount';
 import { getStudioTabs } from './app/tabs';
 import OverviewPane from './tabs/overview';
+import ComposePane from './tabs/compose';
 import ChatPane from './tabs/chat';
 import QrCodesPane from './tabs/qr-codes';
 import SocialsPane from './tabs/socials';
@@ -14,6 +15,7 @@ const ROOT_SELECTOR = '[data-ec-studio-root]';
 
 const STUDIO_PANES = {
 	overview: OverviewPane,
+	compose: ComposePane,
 	chat: ChatPane,
 	'qr-codes': QrCodesPane,
 	socials: SocialsPane,

--- a/blocks/studio/style.css
+++ b/blocks/studio/style.css
@@ -455,3 +455,51 @@
 		max-height: 60vh;
 	}
 }
+
+/* Compose tab — block editor */
+.ec-studio-pane__grid--compose {
+	grid-template-columns: 2fr 1fr;
+}
+
+.ec-studio-panel--editor {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing-sm);
+}
+
+.ec-studio-compose-title {
+	width: 100%;
+	padding: var(--spacing-sm) var(--spacing-md);
+	font-size: var(--font-size-lg, 1.25rem);
+	font-weight: 700;
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius-sm, 4px);
+	background: var(--background-color);
+	color: var(--text-color);
+}
+
+.ec-studio-compose-title::placeholder {
+	color: var(--muted-text);
+	font-weight: 400;
+}
+
+.ec-studio-compose-editor {
+	min-height: 400px;
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius-sm, 4px);
+	overflow: hidden;
+}
+
+.ec-studio-compose-editor .blocks-everywhere {
+	min-height: 400px;
+}
+
+.ec-studio-compose-editor .block-editor-block-list__layout {
+	padding: var(--spacing-md);
+}
+
+@media (max-width: 768px) {
+	.ec-studio-pane__grid--compose {
+		grid-template-columns: 1fr;
+	}
+}

--- a/extrachill-studio.php
+++ b/extrachill-studio.php
@@ -31,6 +31,7 @@ define( 'EXTRACHILL_STUDIO_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 
 require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/assets.php';
 require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/social-drafts.php';
+require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/compose-editor.php';
 
 register_activation_hook( __FILE__, 'extrachill_studio_activate' );
 register_deactivation_hook( __FILE__, 'extrachill_studio_deactivate' );

--- a/inc/compose-editor.php
+++ b/inc/compose-editor.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Compose Editor — Blocks Everywhere integration for Studio.
+ *
+ * Loads the isolated block editor on the Studio homepage so team
+ * members can compose posts using the full Gutenberg experience.
+ * The editor mounts inside the Compose tab of the Studio React app.
+ *
+ * @package ExtraChillStudio
+ * @since   0.2.0
+ */
+
+namespace ExtraChillStudio;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Load Blocks Everywhere editor assets on the Studio homepage.
+ *
+ * We instantiate the bbPress handler (which is the most feature-complete
+ * handler in blocks-everywhere) but configure it for our own use via
+ * the editor settings filter. The handler's load_editor() method handles
+ * all Gutenberg asset loading, REST API setup, and editor initialization.
+ *
+ * The JS side uses window.blocksEverywhereCreateEditor to mount the
+ * editor on the textarea rendered in the Compose tab.
+ */
+function load_compose_editor() {
+	// Only on the front page of the studio site.
+	if ( ! is_front_page() && ! is_home() ) {
+		return;
+	}
+
+	// Require login and team membership.
+	if ( ! is_user_logged_in() ) {
+		return;
+	}
+
+	if ( function_exists( 'ec_is_team_member' ) && ! ec_is_team_member() ) {
+		return;
+	}
+
+	// Blocks Everywhere must be active.
+	if ( ! class_exists( 'Automattic\\Blocks_Everywhere\\Handler\\Handler' ) ) {
+		return;
+	}
+
+	// Use the bbPress handler as our base — it's the most complete.
+	// We configure it via the settings filter below.
+	$handler = new \Automattic\Blocks_Everywhere\Handler\bbPress();
+
+	// Load the editor targeting our compose textarea.
+	$handler->load_editor(
+		'#ec-studio-compose-content',
+		'.ec-studio-compose-editor'
+	);
+}
+add_action( 'wp', __NAMESPACE__ . '\\load_compose_editor' );
+
+/**
+ * Configure the block editor for Studio's compose context.
+ *
+ * @param array $settings Editor settings.
+ * @return array Modified settings.
+ */
+function configure_compose_editor( array $settings ): array {
+	// Set editor type so JS can identify Studio context.
+	$settings['editorType'] = 'studio';
+
+	// Configure allowed blocks — writing-focused.
+	$settings['iso']['blocks']['allowBlocks'] = apply_filters(
+		'extrachill_studio_allowed_blocks',
+		array(
+			'core/paragraph',
+			'core/heading',
+			'core/image',
+			'core/gallery',
+			'core/list',
+			'core/list-item',
+			'core/quote',
+			'core/separator',
+			'core/embed',
+		)
+	);
+
+	// Show the block inserter for a richer editing experience.
+	$settings['iso']['sidebar']['inserter'] = true;
+
+	// Allow common embed types.
+	$settings['iso']['allowEmbeds'] = array(
+		'youtube',
+		'vimeo',
+		'spotify',
+		'soundcloud',
+		'twitter',
+		'instagram',
+	);
+
+	// Upload permissions for logged-in team members.
+	$settings['editor']['hasUploadPermissions'] = current_user_can( 'upload_files' );
+
+	// Provide Studio-specific REST endpoints.
+	$settings['studio'] = array(
+		'postsEndpoint' => rest_url( 'wp/v2/posts' ),
+		'mediaEndpoint' => rest_url( 'extrachill/v1/media' ),
+	);
+
+	return $settings;
+}
+add_filter( 'blocks_everywhere_editor_settings', __NAMESPACE__ . '\\configure_compose_editor', 30 );
+
+/**
+ * Override allowed blocks for Studio context.
+ *
+ * The blocks_everywhere_allowed_blocks filter runs before our settings
+ * filter, so we add our blocks here to ensure they're in the allowlist.
+ *
+ * @param array $blocks Allowed blocks.
+ * @return array
+ */
+function allowed_blocks_for_studio( array $blocks ): array {
+	return array_unique( array_merge( $blocks, array(
+		'core/heading',
+		'core/image',
+		'core/gallery',
+		'core/embed',
+		'core/list',
+		'core/list-item',
+		'core/quote',
+		'core/separator',
+	) ) );
+}
+add_filter( 'blocks_everywhere_allowed_blocks', __NAMESPACE__ . '\\allowed_blocks_for_studio' );


### PR DESCRIPTION
## Summary

Embeds the full Gutenberg block editor in Studio's new **Compose** tab. Team members write rich content from the frontend — no wp-admin required. Posts go through the draft/review/publish flow from PR #9.

## How it works

```
compose-editor.php (PHP)
    ↓ loads blocks-everywhere assets on studio homepage
    ↓ configures allowed blocks, embeds, upload perms

compose/index.js (React)
    ↓ mounts editor via window.blocksEverywhereCreateEditor
    ↓ block content synced to hidden textarea

[Submit for Review] → POST wp/v2/posts (status: pending)
[Save Draft]        → POST wp/v2/posts (status: draft)
```

## Architecture

Uses the **existing** blocks-everywhere plugin (now activated on studio.extrachill.com) which wraps \`@chubes4/isolated-block-editor\`. No modifications to blocks-everywhere needed.

| Layer | Role |
|-------|------|
| \`blocks-everywhere\` plugin | Engine — loads Gutenberg, handles asset registration, REST setup |
| \`compose-editor.php\` | Studio handler — loads editor on homepage, configures blocks/embeds |
| \`compose/index.js\` | React component — mounts editor, handles title input, save/submit |
| \`social-drafts.php\` (PR #9) | Publish hook — fires cross-post when admin approves |

## Allowed blocks

\`core/paragraph\`, \`core/heading\`, \`core/image\`, \`core/gallery\`, \`core/list\`, \`core/list-item\`, \`core/quote\`, \`core/separator\`, \`core/embed\`

## Allowed embeds

YouTube, Vimeo, Spotify, SoundCloud, Twitter, Instagram

## Prerequisites

- \`blocks-everywhere\` activated on studio.extrachill.com ✅ (done)
- \`social-drafts.php\` merged ✅ (PR #9)

## Related

- Issue #8 (Vision: Isolated Block Editor + RTC)
- PR #9 (Social draft system)