### PR TITLE
feat: tag-based publish routing + cross-site transfer

### DIFF
--- a/extrachill-studio.php
+++ b/extrachill-studio.php
@@ -31,6 +31,8 @@ define( 'EXTRACHILL_STUDIO_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 
 require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/assets.php';
 require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/social-drafts.php';
+require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/post-transfer.php';
+require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/publish-router.php';
 require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/compose-editor.php';
 
 register_activation_hook( __FILE__, 'extrachill_studio_activate' );

--- a/inc/post-transfer.php
+++ b/inc/post-transfer.php
@@ -1,0 +1,220 @@
+<?php
+/**
+ * Post Transfer — Cross-site post transfer for multisite.
+ *
+ * Transfers a complete WordPress post (content, meta, revisions,
+ * taxonomy terms, featured image, embedded media) from one subsite
+ * to another using only WordPress core APIs.
+ *
+ * @package ExtraChillStudio
+ * @since   0.2.0
+ */
+
+namespace ExtraChillStudio;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Transfer a post from one multisite subsite to another.
+ *
+ * Copies the post, all revisions, post meta, taxonomy terms,
+ * featured image, and rewrites embedded media URLs. Optionally
+ * deletes the source post after successful transfer.
+ *
+ * @param int  $source_post_id Post ID on the source site.
+ * @param int  $source_blog_id Source blog ID.
+ * @param int  $target_blog_id Target blog ID.
+ * @param bool $delete_source  Whether to delete the original after transfer.
+ * @return int|\WP_Error New post ID on target site, or WP_Error.
+ */
+function transfer_post( int $source_post_id, int $source_blog_id, int $target_blog_id, bool $delete_source = false ) {
+
+	// ── Step 1: Read everything from the source site ────────────────────
+
+	switch_to_blog( $source_blog_id );
+
+	$source_post = get_post( $source_post_id, ARRAY_A );
+	if ( ! $source_post ) {
+		restore_current_blog();
+		return new \WP_Error( 'invalid_post', 'Source post not found.' );
+	}
+
+	$source_meta = get_post_meta( $source_post_id );
+
+	$source_revisions = wp_get_post_revisions( $source_post_id, array(
+		'order'         => 'ASC',
+		'check_enabled' => false,
+	) );
+
+	// Taxonomy terms by name (IDs are per-site).
+	$source_taxonomies = array();
+	$taxonomies        = get_object_taxonomies( $source_post['post_type'] );
+	foreach ( $taxonomies as $taxonomy ) {
+		$terms = wp_get_object_terms( $source_post_id, $taxonomy, array( 'fields' => 'names' ) );
+		if ( ! is_wp_error( $terms ) && ! empty( $terms ) ) {
+			$source_taxonomies[ $taxonomy ] = $terms;
+		}
+	}
+
+	// Featured image URL.
+	$featured_image_url = null;
+	$thumbnail_id       = get_post_thumbnail_id( $source_post_id );
+	if ( $thumbnail_id ) {
+		$featured_image_url = wp_get_attachment_url( $thumbnail_id );
+	}
+
+	// Source uploads base URL for content rewriting.
+	$source_upload_dir = wp_get_upload_dir();
+	$source_base_url   = $source_upload_dir['baseurl'];
+
+	restore_current_blog();
+
+	// ── Step 2: Create the post on the target site ──────────────────────
+
+	switch_to_blog( $target_blog_id );
+
+	if ( ! function_exists( 'media_sideload_image' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/media.php';
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+		require_once ABSPATH . 'wp-admin/includes/image.php';
+	}
+
+	$new_post = array(
+		'post_title'            => $source_post['post_title'],
+		'post_content'          => $source_post['post_content'],
+		'post_excerpt'          => $source_post['post_excerpt'],
+		'post_status'           => $source_post['post_status'],
+		'post_type'             => $source_post['post_type'],
+		'post_author'           => $source_post['post_author'],
+		'post_date'             => $source_post['post_date'],
+		'post_date_gmt'         => $source_post['post_date_gmt'],
+		'post_modified'         => $source_post['post_modified'],
+		'post_modified_gmt'     => $source_post['post_modified_gmt'],
+		'post_name'             => $source_post['post_name'],
+		'post_password'         => $source_post['post_password'],
+		'post_content_filtered' => $source_post['post_content_filtered'],
+		'comment_status'        => $source_post['comment_status'],
+		'ping_status'           => $source_post['ping_status'],
+		'menu_order'            => $source_post['menu_order'],
+		'post_parent'           => 0,
+	);
+
+	// Prevent auto-revision on insert.
+	remove_action( 'post_updated', 'wp_save_post_revision' );
+	remove_action( 'wp_after_insert_post', 'wp_save_post_revision_on_insert' );
+
+	$new_post_id = wp_insert_post( wp_slash( $new_post ), true );
+
+	add_action( 'post_updated', 'wp_save_post_revision' );
+	add_action( 'wp_after_insert_post', 'wp_save_post_revision_on_insert' );
+
+	if ( is_wp_error( $new_post_id ) ) {
+		restore_current_blog();
+		return $new_post_id;
+	}
+
+	// ── Step 3: Copy post meta ──────────────────────────────────────────
+
+	$skip_meta_keys = array(
+		'_edit_lock',
+		'_edit_last',
+		'_wp_old_slug',
+		'_thumbnail_id',
+	);
+
+	foreach ( $source_meta as $meta_key => $meta_values ) {
+		if ( in_array( $meta_key, $skip_meta_keys, true ) ) {
+			continue;
+		}
+		foreach ( $meta_values as $meta_value ) {
+			add_post_meta( $new_post_id, $meta_key, $meta_value );
+		}
+	}
+
+	// ── Step 4: Copy taxonomy terms ─────────────────────────────────────
+
+	foreach ( $source_taxonomies as $taxonomy => $term_names ) {
+		if ( taxonomy_exists( $taxonomy ) ) {
+			wp_set_object_terms( $new_post_id, $term_names, $taxonomy );
+		}
+	}
+
+	// ── Step 5: Transfer featured image ─────────────────────────────────
+
+	if ( $featured_image_url ) {
+		$sideloaded = media_sideload_image( $featured_image_url, $new_post_id, null, 'id' );
+		if ( ! is_wp_error( $sideloaded ) ) {
+			set_post_thumbnail( $new_post_id, $sideloaded );
+		}
+	}
+
+	// ── Step 6: Rewrite embedded media URLs in content ──────────────────
+
+	$content                = $source_post['post_content'];
+	$source_base_url_quoted = preg_quote( $source_base_url, '/' );
+
+	if ( preg_match_all( '/' . $source_base_url_quoted . '\/[^\s"\'<>]+/i', $content, $matches ) ) {
+		$unique_urls     = array_unique( $matches[0] );
+		$url_replacements = array();
+
+		foreach ( $unique_urls as $old_url ) {
+			$sideloaded_id = media_sideload_image( $old_url, $new_post_id, null, 'id' );
+			if ( ! is_wp_error( $sideloaded_id ) ) {
+				$new_url = wp_get_attachment_url( $sideloaded_id );
+				if ( $new_url ) {
+					$url_replacements[ $old_url ] = $new_url;
+				}
+			}
+		}
+
+		if ( ! empty( $url_replacements ) ) {
+			$content = str_replace(
+				array_keys( $url_replacements ),
+				array_values( $url_replacements ),
+				$content
+			);
+
+			wp_update_post( array(
+				'ID'           => $new_post_id,
+				'post_content' => wp_slash( $content ),
+			) );
+		}
+	}
+
+	// ── Step 7: Copy revisions ──────────────────────────────────────────
+
+	foreach ( $source_revisions as $revision ) {
+		wp_insert_post( wp_slash( array(
+			'post_title'    => $revision->post_title,
+			'post_content'  => $revision->post_content,
+			'post_excerpt'  => $revision->post_excerpt,
+			'post_author'   => $revision->post_author,
+			'post_date'     => $revision->post_date,
+			'post_date_gmt' => $revision->post_date_gmt,
+			'post_parent'   => $new_post_id,
+			'post_type'     => 'revision',
+			'post_status'   => 'inherit',
+			'post_name'     => $new_post_id . '-revision-v1',
+		) ), true );
+	}
+
+	// ── Step 8: Record transfer provenance ──────────────────────────────
+
+	update_post_meta( $new_post_id, '_ec_transferred_from_blog', $source_blog_id );
+	update_post_meta( $new_post_id, '_ec_transferred_from_post', $source_post_id );
+	update_post_meta( $new_post_id, '_ec_transferred_at', current_time( 'mysql' ) );
+
+	restore_current_blog();
+
+	// ── Step 9: Delete source (optional) ────────────────────────────────
+
+	if ( $delete_source ) {
+		switch_to_blog( $source_blog_id );
+		wp_delete_post( $source_post_id, true );
+		restore_current_blog();
+	}
+
+	return $new_post_id;
+}

--- a/inc/publish-router.php
+++ b/inc/publish-router.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Publish Router — Tag-based routing for Studio posts.
+ *
+ * When a Studio post is published, its tags determine the outcome:
+ *
+ *   "blog"   → transfer to extrachill.com (blog ID 1)
+ *   "wire"   → transfer to wire.extrachill.com
+ *   "social" → cross-post to social platforms via DM Socials
+ *
+ * Tags can be combined: "blog" + "social" = transfer + cross-post.
+ * Posts without routing tags are published on studio only.
+ *
+ * @package ExtraChillStudio
+ * @since   0.2.0
+ */
+
+namespace ExtraChillStudio;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Tag → blog ID mapping for transfer destinations.
+ *
+ * Filterable so other plugins can add routing targets.
+ *
+ * @return array<string, int> Tag slug => blog ID.
+ */
+function get_transfer_routes(): array {
+	return apply_filters( 'extrachill_studio_transfer_routes', array(
+		'blog' => 1,   // extrachill.com
+		'wire' => 11,  // wire.extrachill.com
+	) );
+}
+
+/**
+ * Route a Studio post on publish based on its tags.
+ *
+ * Hooks into transition_post_status. Fires transfer and/or cross-post
+ * depending on which routing tags are present.
+ *
+ * @param string   $new_status New post status.
+ * @param string   $old_status Old post status.
+ * @param \WP_Post $post       Post object.
+ */
+function route_on_publish( string $new_status, string $old_status, \WP_Post $post ) {
+	// Only fire on transition TO publish.
+	if ( 'publish' !== $new_status || 'publish' === $old_status ) {
+		return;
+	}
+
+	// Only act on regular posts.
+	if ( 'post' !== $post->post_type ) {
+		return;
+	}
+
+	// Get the post's tags as slugs.
+	$tags      = wp_get_post_tags( $post->ID, array( 'fields' => 'slugs' ) );
+	$tag_slugs = is_array( $tags ) ? $tags : array();
+
+	if ( empty( $tag_slugs ) ) {
+		return;
+	}
+
+	$transfer_routes = get_transfer_routes();
+	$source_blog_id  = get_current_blog_id();
+	$results         = array();
+
+	// ── Handle transfers ────────────────────────────────────────────────
+
+	foreach ( $transfer_routes as $tag => $target_blog_id ) {
+		if ( ! in_array( $tag, $tag_slugs, true ) ) {
+			continue;
+		}
+
+		// Don't transfer to ourselves.
+		if ( $target_blog_id === $source_blog_id ) {
+			continue;
+		}
+
+		$new_id = transfer_post(
+			$post->ID,
+			$source_blog_id,
+			$target_blog_id,
+			false // Don't delete source yet — we may need it for cross-posting.
+		);
+
+		if ( is_wp_error( $new_id ) ) {
+			$results[] = array(
+				'action'    => 'transfer',
+				'target'    => $tag,
+				'blog_id'   => $target_blog_id,
+				'success'   => false,
+				'error'     => $new_id->get_error_message(),
+				'timestamp' => gmdate( 'c' ),
+			);
+		} else {
+			$results[] = array(
+				'action'    => 'transfer',
+				'target'    => $tag,
+				'blog_id'   => $target_blog_id,
+				'new_id'    => $new_id,
+				'success'   => true,
+				'timestamp' => gmdate( 'c' ),
+			);
+		}
+	}
+
+	// ── Handle social cross-posting ─────────────────────────────────────
+	// The "social" tag triggers cross-posting via social-drafts.php.
+	// That hook (on_publish_crosspost) already runs on transition_post_status
+	// and checks for _studio_social_platforms meta. We don't duplicate it here.
+	// If "social" is tagged but no platforms meta is set, nothing happens.
+
+	// ── Log routing results ─────────────────────────────────────────────
+
+	if ( ! empty( $results ) ) {
+		$existing_log = get_post_meta( $post->ID, '_studio_route_log', true ) ?: array();
+		$merged       = array_merge( $existing_log, $results );
+		update_post_meta( $post->ID, '_studio_route_log', $merged );
+	}
+
+	// ── Delete source if all transfers succeeded ────────────────────────
+
+	$transfers     = array_filter( $results, function ( $r ) {
+		return 'transfer' === $r['action'];
+	} );
+	$all_succeeded = ! empty( $transfers ) && count( array_filter( $transfers, function ( $r ) {
+		return ! empty( $r['success'] );
+	} ) ) === count( $transfers );
+
+	// Only delete if we did at least one transfer and all succeeded.
+	// Posts tagged "social" only (no transfer tags) stay on studio.
+	if ( $all_succeeded ) {
+		// Trash instead of force-delete for safety. Admin can clean up later.
+		wp_trash_post( $post->ID );
+	}
+}
+add_action( 'transition_post_status', __NAMESPACE__ . '\\route_on_publish', 5, 3 );
+
+/**
+ * Register the route log meta for REST visibility.
+ */
+function register_route_meta() {
+	register_post_meta( 'post', '_studio_route_log', array(
+		'type'          => 'array',
+		'description'   => 'Log of publish routing actions (transfers, cross-posts).',
+		'default'       => array(),
+		'single'        => true,
+		'show_in_rest'  => array(
+			'schema' => array(
+				'type'  => 'array',
+				'items' => array(
+					'type'       => 'object',
+					'properties' => array(
+						'action'    => array( 'type' => 'string' ),
+						'target'    => array( 'type' => 'string' ),
+						'blog_id'   => array( 'type' => 'integer' ),
+						'new_id'    => array( 'type' => 'integer' ),
+						'success'   => array( 'type' => 'boolean' ),
+						'error'     => array( 'type' => 'string' ),
+						'timestamp' => array( 'type' => 'string' ),
+					),
+				),
+			),
+		),
+		'auth_callback' => __NAMESPACE__ . '\\can_edit_social_meta',
+	) );
+}
+add_action( 'init', __NAMESPACE__ . '\\register_route_meta' );


### PR DESCRIPTION
## Summary

Tags on Studio posts determine what happens when an admin publishes:

| Tag | Action |
|-----|--------|
| \`blog\` | Transfer to extrachill.com (blog 1) |
| \`wire\` | Transfer to wire.extrachill.com (blog 11) |
| \`social\` | Cross-post to social platforms (existing PR #9 hook) |
| \`blog\` + \`social\` | Transfer + cross-post |
| No routing tags | Published on studio only |

## How transfer works

\`\`\`
post-transfer.php (the engine)
  1. switch_to_blog(source) → read post, meta, revisions, terms, media
  2. switch_to_blog(target) → wp_insert_post with preserved dates + author
  3. Copy all post meta (skip _edit_lock, _thumbnail_id, etc.)
  4. Set taxonomy terms by name (auto-creates if missing)
  5. Sideload featured image via media_sideload_image
  6. Regex-find all embedded media URLs → sideload → str_replace in content
  7. Copy revisions as post_type=revision with new post_parent
  8. Record provenance: _ec_transferred_from_blog, _ec_transferred_from_post
  9. Optionally delete/trash source
\`\`\`

## What gets preserved

- ✅ Post content (block markup transfers cleanly)
- ✅ All revisions (chronological order)
- ✅ Post meta (social meta, custom fields)
- ✅ Taxonomy terms (by name — auto-creates on target)
- ✅ Author (user IDs are global in multisite)
- ✅ Dates (post_date, post_modified preserved)
- ✅ Featured image (sideloaded to target uploads)
- ✅ Embedded media (URLs rewritten to target site)

## Safety

- Source post is **trashed** (not force-deleted) after successful transfer
- Transfer provenance recorded on target post for audit trail
- Route log stored in \`_studio_route_log\` meta (visible via REST)
- Routes are filterable via \`extrachill_studio_transfer_routes\`

## 100% WordPress core APIs

No custom tables, no external dependencies. Uses \`switch_to_blog()\`, \`wp_insert_post()\`, \`media_sideload_image()\`, \`wp_get_post_revisions()\`, \`wp_set_object_terms()\`.

## Related

- PR #9 — Social draft system (handles \`social\` tag routing)
- PR #10 — Compose tab (where posts are written)
- Issue #8 — Vision doc