### PR TITLE
refactor: rely on shared studio shell defaults

### DIFF
--- a/src/blocks/studio/view.ts
+++ b/src/blocks/studio/view.ts
@@ -40,7 +40,6 @@ const StudioApp = ( { context }: { context: StudioContext } ): ReactElement => {
 							key: 'header',
 							title: context.headline,
 							description: context.description,
-							showDivider: false,
 						} ),
 						createElement( ResponsiveTabs, {
 							key: 'tabs',


### PR DESCRIPTION
## Summary
- remove the last explicit studio shell divider override
- rely on the canonical header and tabs defaults from `@extrachill/components`