### PR TITLE
feat: add persistent compose sidebar shell

### DIFF
--- a/inc/compose-editor.php
+++ b/inc/compose-editor.php
@@ -158,10 +158,23 @@ function configure_compose_editor( array $settings ): array {
 
 	// Show the block inserter in the shared sidebar mode, but detach the
 	// rendered sidebar into Studio's dedicated compose sidebar slot.
+	$settings['iso']['header'] = false;
 	$settings['iso']['sidebar']['inserter'] = true;
 	$settings['iso']['sidebar']['detached'] = array(
 		'target'    => '.ec-studio-compose-sidebar__slot',
 		'className' => 'ec-studio-compose-sidebar__content',
+		'persistent' => true,
+		'defaultView' => 'inserter',
+		'views' => array(
+			'inserter' => array(
+				'target'    => '.ec-studio-compose-sidebar__panel[data-sidebar-panel="insert"]',
+				'className' => 'ec-studio-compose-sidebar__view ec-studio-compose-sidebar__view--insert',
+			),
+			'listView' => array(
+				'target'    => '.ec-studio-compose-sidebar__panel[data-sidebar-panel="structure"]',
+				'className' => 'ec-studio-compose-sidebar__view ec-studio-compose-sidebar__view--structure',
+			),
+		),
 	);
 
 	// Allow common embed types.

--- a/inc/compose-editor.php
+++ b/inc/compose-editor.php
@@ -158,23 +158,12 @@ function configure_compose_editor( array $settings ): array {
 
 	// Show the block inserter in the shared sidebar mode, but detach the
 	// rendered sidebar into Studio's dedicated compose sidebar slot.
-	$settings['iso']['header'] = false;
 	$settings['iso']['sidebar']['inserter'] = true;
 	$settings['iso']['sidebar']['detached'] = array(
 		'target'    => '.ec-studio-compose-sidebar__slot',
 		'className' => 'ec-studio-compose-sidebar__content',
 		'persistent' => true,
 		'defaultView' => 'inserter',
-		'views' => array(
-			'inserter' => array(
-				'target'    => '.ec-studio-compose-sidebar__panel[data-sidebar-panel="insert"]',
-				'className' => 'ec-studio-compose-sidebar__view ec-studio-compose-sidebar__view--insert',
-			),
-			'listView' => array(
-				'target'    => '.ec-studio-compose-sidebar__panel[data-sidebar-panel="structure"]',
-				'className' => 'ec-studio-compose-sidebar__view ec-studio-compose-sidebar__view--structure',
-			),
-		),
 	);
 
 	// Allow common embed types.

--- a/src/blocks/studio/style.css
+++ b/src/blocks/studio/style.css
@@ -293,6 +293,7 @@
 /* Compose tab — block editor */
 .ec-studio-pane__grid--compose {
 	grid-template-columns: 2fr 1fr;
+	align-items: start;
 }
 
 .ec-studio-panel--editor {

--- a/src/blocks/studio/style.css
+++ b/src/blocks/studio/style.css
@@ -379,29 +379,8 @@
 	min-height: 0;
 	border: 1px solid var(--border-color);
 	border-radius: var(--border-radius-sm, 4px);
-	background: var(--background-color);
-}
-
-.ec-studio-compose-sidebar__tabs-shell {
-	padding: var(--spacing-sm);
-	border-bottom: 1px solid var(--border-color);
-	background: var(--card-background);
-}
-
-.ec-studio-compose-sidebar__tabs {
-	width: 100%;
-}
-
-.ec-studio-compose-sidebar__panels {
-	position: relative;
-	flex: 1;
-	min-height: 0;
-}
-
-.ec-studio-compose-sidebar__panel {
-	height: 100%;
-	min-height: 0;
 	overflow: hidden;
+	background: var(--background-color);
 }
 
 .ec-studio-compose-sidebar__content {
@@ -410,18 +389,8 @@
 	min-height: 0;
 }
 
-.ec-studio-compose-sidebar__view {
-	height: 100%;
-	min-height: 0;
-}
-
 .ec-studio-compose-sidebar__content .edit-widgets-layout__inserter-panel,
 .ec-studio-compose-sidebar__content .editor-list-view-sidebar {
-	height: 100%;
-}
-
-.ec-studio-compose-sidebar__view .edit-widgets-layout__inserter-panel,
-.ec-studio-compose-sidebar__view .editor-list-view-sidebar {
 	height: 100%;
 }
 

--- a/src/blocks/studio/style.css
+++ b/src/blocks/studio/style.css
@@ -379,8 +379,29 @@
 	min-height: 0;
 	border: 1px solid var(--border-color);
 	border-radius: var(--border-radius-sm, 4px);
-	overflow: hidden;
 	background: var(--background-color);
+}
+
+.ec-studio-compose-sidebar__tabs-shell {
+	padding: var(--spacing-sm);
+	border-bottom: 1px solid var(--border-color);
+	background: var(--card-background);
+}
+
+.ec-studio-compose-sidebar__tabs {
+	width: 100%;
+}
+
+.ec-studio-compose-sidebar__panels {
+	position: relative;
+	flex: 1;
+	min-height: 0;
+}
+
+.ec-studio-compose-sidebar__panel {
+	height: 100%;
+	min-height: 0;
+	overflow: hidden;
 }
 
 .ec-studio-compose-sidebar__content {
@@ -389,8 +410,18 @@
 	min-height: 0;
 }
 
+.ec-studio-compose-sidebar__view {
+	height: 100%;
+	min-height: 0;
+}
+
 .ec-studio-compose-sidebar__content .edit-widgets-layout__inserter-panel,
 .ec-studio-compose-sidebar__content .editor-list-view-sidebar {
+	height: 100%;
+}
+
+.ec-studio-compose-sidebar__view .edit-widgets-layout__inserter-panel,
+.ec-studio-compose-sidebar__view .editor-list-view-sidebar {
 	height: 100%;
 }
 

--- a/src/blocks/studio/tabs/compose/index.ts
+++ b/src/blocks/studio/tabs/compose/index.ts
@@ -6,7 +6,7 @@ import {
 	getOrCreateClientContextRegistry,
 	registerClientContextProvider,
 } from '@extrachill/chat';
-import { ActionRow, FieldGroup, InlineStatus, Panel, PanelHeader, ShellTabs } from '@extrachill/components';
+import { ActionRow, FieldGroup, InlineStatus, Panel, PanelHeader } from '@extrachill/components';
 import type { StudioPaneProps } from '../../types/studio';
 
 const h = createElement as typeof import( 'react' ).createElement;
@@ -14,7 +14,6 @@ const PanelView = Panel as unknown as ( props: any ) => ReactElement;
 const ActionRowView = ActionRow as unknown as ( props: any ) => ReactElement;
 const FieldGroupView = FieldGroup as unknown as ( props: any ) => ReactElement;
 const InlineStatusView = InlineStatus as unknown as ( props: any ) => ReactElement;
-const ShellTabsView = ShellTabs as unknown as ( props: any ) => ReactElement;
 
 declare global {
 	interface Window {
@@ -74,7 +73,6 @@ const ComposePane = ( _props: StudioPaneProps ): ReactElement => {
 	const [ status, setStatus ] = useState( '' );
 	const [ error, setError ] = useState( '' );
 	const [ editorReady, setEditorReady ] = useState( false );
-	const [ activeSidebarTab, setActiveSidebarTab ] = useState( 'insert' );
 
 	// Draft management state.
 	const [ drafts, setDrafts ] = useState< WpPost[] >( [] );
@@ -494,11 +492,6 @@ const ComposePane = ( _props: StudioPaneProps ): ReactElement => {
 			isLoadingDrafts ? __( 'Loading…', 'extrachill-studio' ) : __( 'No drafts yet', 'extrachill-studio' )
 		);
 
-	const sidebarTabs = [
-		{ id: 'insert', label: __( 'Insert', 'extrachill-studio' ) },
-		{ id: 'structure', label: __( 'Structure', 'extrachill-studio' ) },
-	];
-
 	return h(
 		'div',
 		{ className: 'ec-studio-pane ec-studio-pane--compose' },
@@ -585,38 +578,16 @@ const ComposePane = ( _props: StudioPaneProps ): ReactElement => {
 					)
 				)
 			),
-			h(
-				PanelView,
-				{ className: 'ec-studio-panel ec-studio-panel--compose-sidebar', compact: true },
-				h( PanelHeader, {
-					description: __( 'Browse blocks and structure without crowding the writing canvas.', 'extrachill-studio' ),
-				} ),
 				h(
-					'div',
-					{ className: 'ec-studio-compose-sidebar__slot' },
-					h( ShellTabsView, {
-						tabs: sidebarTabs,
-						active: activeSidebarTab,
-						onChange: setActiveSidebarTab,
-						className: 'ec-studio-compose-sidebar__tabs-shell',
-						tabsClassName: 'ec-studio-compose-sidebar__tabs',
+					PanelView,
+					{ className: 'ec-studio-panel ec-studio-panel--compose-sidebar', compact: true },
+					h( PanelHeader, {
+						description: __( 'Browse blocks and structure without crowding the writing canvas.', 'extrachill-studio' ),
 					} ),
-					createElement(
-						'div',
-						{ className: 'ec-studio-compose-sidebar__panels' },
-						createElement( 'div', {
-							className: `ec-studio-compose-sidebar__panel${ activeSidebarTab === 'insert' ? ' is-active' : '' }`,
-							'data-sidebar-panel': 'insert',
-							hidden: activeSidebarTab !== 'insert',
-						} ),
-						createElement( 'div', {
-							className: `ec-studio-compose-sidebar__panel${ activeSidebarTab === 'structure' ? ' is-active' : '' }`,
-							'data-sidebar-panel': 'structure',
-							hidden: activeSidebarTab !== 'structure',
-						} )
-					)
+					createElement( 'div', {
+						className: 'ec-studio-compose-sidebar__slot',
+					} )
 				)
-			)
 		)
 	);
 };

--- a/src/blocks/studio/tabs/compose/index.ts
+++ b/src/blocks/studio/tabs/compose/index.ts
@@ -6,7 +6,7 @@ import {
 	getOrCreateClientContextRegistry,
 	registerClientContextProvider,
 } from '@extrachill/chat';
-import { ActionRow, FieldGroup, InlineStatus, Panel, PanelHeader } from '@extrachill/components';
+import { ActionRow, FieldGroup, InlineStatus, Panel, PanelHeader, ShellTabs } from '@extrachill/components';
 import type { StudioPaneProps } from '../../types/studio';
 
 const h = createElement as typeof import( 'react' ).createElement;
@@ -14,6 +14,7 @@ const PanelView = Panel as unknown as ( props: any ) => ReactElement;
 const ActionRowView = ActionRow as unknown as ( props: any ) => ReactElement;
 const FieldGroupView = FieldGroup as unknown as ( props: any ) => ReactElement;
 const InlineStatusView = InlineStatus as unknown as ( props: any ) => ReactElement;
+const ShellTabsView = ShellTabs as unknown as ( props: any ) => ReactElement;
 
 declare global {
 	interface Window {
@@ -73,6 +74,7 @@ const ComposePane = ( _props: StudioPaneProps ): ReactElement => {
 	const [ status, setStatus ] = useState( '' );
 	const [ error, setError ] = useState( '' );
 	const [ editorReady, setEditorReady ] = useState( false );
+	const [ activeSidebarTab, setActiveSidebarTab ] = useState( 'insert' );
 
 	// Draft management state.
 	const [ drafts, setDrafts ] = useState< WpPost[] >( [] );
@@ -492,6 +494,11 @@ const ComposePane = ( _props: StudioPaneProps ): ReactElement => {
 			isLoadingDrafts ? __( 'Loading…', 'extrachill-studio' ) : __( 'No drafts yet', 'extrachill-studio' )
 		);
 
+	const sidebarTabs = [
+		{ id: 'insert', label: __( 'Insert', 'extrachill-studio' ) },
+		{ id: 'structure', label: __( 'Structure', 'extrachill-studio' ) },
+	];
+
 	return h(
 		'div',
 		{ className: 'ec-studio-pane ec-studio-pane--compose' },
@@ -584,9 +591,31 @@ const ComposePane = ( _props: StudioPaneProps ): ReactElement => {
 				h( PanelHeader, {
 					description: __( 'Browse blocks and structure without crowding the writing canvas.', 'extrachill-studio' ),
 				} ),
-				createElement( 'div', {
-					className: 'ec-studio-compose-sidebar__slot',
-				} )
+				h(
+					'div',
+					{ className: 'ec-studio-compose-sidebar__slot' },
+					h( ShellTabsView, {
+						tabs: sidebarTabs,
+						active: activeSidebarTab,
+						onChange: setActiveSidebarTab,
+						className: 'ec-studio-compose-sidebar__tabs-shell',
+						tabsClassName: 'ec-studio-compose-sidebar__tabs',
+					} ),
+					createElement(
+						'div',
+						{ className: 'ec-studio-compose-sidebar__panels' },
+						createElement( 'div', {
+							className: `ec-studio-compose-sidebar__panel${ activeSidebarTab === 'insert' ? ' is-active' : '' }`,
+							'data-sidebar-panel': 'insert',
+							hidden: activeSidebarTab !== 'insert',
+						} ),
+						createElement( 'div', {
+							className: `ec-studio-compose-sidebar__panel${ activeSidebarTab === 'structure' ? ' is-active' : '' }`,
+							'data-sidebar-panel': 'structure',
+							hidden: activeSidebarTab !== 'structure',
+						} )
+					)
+				)
 			)
 		)
 	);


### PR DESCRIPTION
## Summary
- switch Studio Compose to a persistent detached sidebar with the top editor header removed
- use shared @extrachill/components shell tabs to separate Insert and Structure sidebar views
- wire the compose sidebar to detached inserter and list view targets so the writing canvas stays clean