### PR TITLE
Remove .homeboy-build-meta.json sidecar

### DIFF
--- a/.homeboy-build-meta.json
+++ b/.homeboy-build-meta.json
@@ -1,8 +1,0 @@
-{
-  "commit": "e2062d2139af19153ef79fdff90b1cfd49f25f8b",
-  "git_ref": "main",
-  "tag": "v0.4.0",
-  "ahead_of_tag": 32,
-  "timestamp": "2026-04-01T19:57:40Z",
-  "dirty": true
-}


### PR DESCRIPTION
## Summary

- Removes the `.homeboy-build-meta.json` file that was accidentally committed to the repo
- This sidecar was generated by `homeboy build` for deploy artifact reuse, which has been removed in Extra-Chill/homeboy#1101
- `homeboy.json` is the single homeboy file per repo