### PR TITLE
feat: migrate GiveawayTask to executeTask() contract

### DIFF
--- a/inc/tasks/giveaway-task.php
+++ b/inc/tasks/giveaway-task.php
@@ -26,7 +26,7 @@ class GiveawayTask extends SystemTask {
 	 * @param array $params Task parameters (same shape as run-giveaway ability input).
 	 * @return void
 	 */
-	public function execute( int $jobId, array $params ): void {
+	public function executeTask( int $jobId, array $params ): void {
 		$ability = wp_get_ability( 'extrachill/run-giveaway' );
 
 		if ( ! $ability ) {


### PR DESCRIPTION
## Summary

- Renames `GiveawayTask::execute()` → `GiveawayTask::executeTask()` to match the updated `SystemTask` abstract contract in data-machine 0.72.0+.
- This is a **breaking change** — the plugin will fatal if deployed against an older data-machine that still declares `execute()` as the abstract method.

## Dependencies

- **Requires [data-machine#1153](https://github.com/Extra-Chill/data-machine/pull/1153)** to be merged and released first (or simultaneously via coordinated homeboy release).
- Both repos must be deployed together in a single big-bang release.

## What changed

A single method rename in `inc/tasks/giveaway-task.php`:

```diff
- public function execute( int $jobId, array $params ): void {
+ public function executeTask( int $jobId, array $params ): void {
```

No other logic, parameters, or behavior changes.

## Notes

- The datetime picker for `scheduled_at` in the giveaway UI is deferred to a follow-up PR — not blocking for this contract migration.