### PR TITLE
feat: consume new /platforms array contract — drop client-side normalization

### DIFF
--- a/src/blocks/studio/tabs/socials/index.ts
+++ b/src/blocks/studio/tabs/socials/index.ts
@@ -2,13 +2,12 @@ import { __, sprintf } from '@wordpress/i18n';
 import { createElement, useEffect, useMemo, useState } from '@wordpress/element';
 import type { ComponentType, ReactElement } from 'react';
 import { InlineStatus, Panel, PanelHeader } from '@extrachill/components';
-import type { SocialPlatformsResponse } from '@extrachill/api-client';
+import type { SocialPlatformConfig } from '@extrachill/api-client';
 
 import { studioClient } from '../../app/client';
 import type { StudioPaneProps } from '../../types/studio';
-import type { SocialPlatformConfig } from '../../types/externals';
 import SocialsSidebar from './sidebar';
-import type { SidebarPlatform, CapabilityEntry } from './sidebar';
+import type { SidebarPlatform } from './sidebar';
 import PlatformPublishPane from './publish';
 import CommentsView from './comments';
 import GiveawayView from '../giveaway';
@@ -32,49 +31,9 @@ const VIEW_REGISTRY: Record< string, ComponentType< any > > = {
 	giveaway: GiveawayView,
 };
 
-/** Fallback when the handler doesn't declare capabilities. */
-const DEFAULT_CAPABILITIES: CapabilityEntry[] = [
-	{ slug: 'publish', label: 'Publish' },
-];
-
-interface PlatformEntry {
-	slug: string;
-	label: string;
-	authenticated: boolean;
-	username: string | null;
-	type: string;
-	capabilities: CapabilityEntry[];
-	config: SocialPlatformConfig;
-}
-
-/**
- * Normalize capabilities from the server response.
- *
- * Handles both the structured format ({ slug, label }[]) and a bare
- * string[] fallback for backwards compatibility with older handler versions.
- */
-const normalizeCapabilities = ( raw: unknown ): CapabilityEntry[] => {
-	if ( ! Array.isArray( raw ) || raw.length === 0 ) {
-		return DEFAULT_CAPABILITIES;
-	}
-
-	return raw.map( ( entry ) => {
-		if ( typeof entry === 'string' ) {
-			// Bare string fallback — capitalize for display.
-			return { slug: entry, label: entry.charAt( 0 ).toUpperCase() + entry.slice( 1 ) };
-		}
-
-		if ( entry && typeof entry === 'object' && typeof entry.slug === 'string' ) {
-			return { slug: entry.slug, label: entry.label || entry.slug };
-		}
-
-		return { slug: String( entry ), label: String( entry ) };
-	} );
-};
-
 const SocialsPane = ( { context }: StudioPaneProps ): ReactElement | null => {
 	const allowedSlugs = context.socialPlatforms;
-	const [ platforms, setPlatforms ] = useState< SocialPlatformsResponse >( {} );
+	const [ platforms, setPlatforms ] = useState< SocialPlatformConfig[] >( [] );
 	const [ error, setError ] = useState( '' );
 	const [ isLoading, setIsLoading ] = useState( true );
 	const [ activePlatform, setActivePlatform ] = useState< string | null >( null );
@@ -86,10 +45,10 @@ const SocialsPane = ( { context }: StudioPaneProps ): ReactElement | null => {
 			setError( '' );
 
 			try {
-				const data = await studioClient.socials.getPlatforms();
-				setPlatforms( data && typeof data === 'object' ? data : {} );
+				const response = await studioClient.socials.getPlatforms();
+				setPlatforms( Array.isArray( response?.platforms ) ? response.platforms : [] );
 			} catch ( fetchError ) {
-				setPlatforms( {} );
+				setPlatforms( [] );
 				setError( ( fetchError as Error )?.message || __( 'Unable to load social platforms.', 'extrachill-studio' ) );
 			} finally {
 				setIsLoading( false );
@@ -99,27 +58,18 @@ const SocialsPane = ( { context }: StudioPaneProps ): ReactElement | null => {
 		loadPlatforms();
 	}, [] );
 
-	/** Filter to authenticated, non-fetch platforms within the allowlist. */
-	const availablePlatforms: PlatformEntry[] = useMemo( () => {
-		const entries = Object.entries( platforms ).map( ( [ slug, config ] ) => {
-			const cfg = config as SocialPlatformConfig | undefined;
-
-			return {
-				slug,
-				label: cfg?.label || slug,
-				authenticated: cfg?.authenticated || false,
-				username: cfg?.username || null,
-				type: cfg?.type || 'publish',
-				capabilities: normalizeCapabilities( cfg?.capabilities ),
-				config: cfg || { label: slug },
-			};
-		} );
-
-		return entries.filter( ( item ) => {
-			if ( ! item.authenticated || item.type === 'fetch' ) {
+	/**
+	 * Filter to authenticated platforms within the optional allowlist.
+	 *
+	 * Server controls sort order (authenticated-first then alphabetical) and
+	 * pre-filters fetch handlers, so the client just renders in array order.
+	 */
+	const availablePlatforms: SocialPlatformConfig[] = useMemo( () => {
+		return platforms.filter( ( platform ) => {
+			if ( ! platform.authenticated ) {
 				return false;
 			}
-			if ( allowedSlugs.length > 0 && ! allowedSlugs.includes( item.slug ) ) {
+			if ( allowedSlugs.length > 0 && ! allowedSlugs.includes( platform.slug ) ) {
 				return false;
 			}
 			return true;
@@ -233,7 +183,7 @@ const SocialsPane = ( { context }: StudioPaneProps ): ReactElement | null => {
 			slug: selectedPlatform.slug,
 			label: selectedPlatform.label,
 			username: selectedPlatform.username,
-			config: selectedPlatform.config,
+			config: selectedPlatform,
 		} );
 	};
 

--- a/src/blocks/studio/tabs/socials/publish/index.ts
+++ b/src/blocks/studio/tabs/socials/publish/index.ts
@@ -4,9 +4,8 @@ import type { ReactElement, ChangeEvent } from 'react';
 import { ActionRow, FieldGroup, InlineStatus, MediaField, Panel, PanelHeader } from '@extrachill/components';
 
 import apiFetch from '@wordpress/api-fetch';
-import type { SocialPublishResponse, SocialPublishResult } from '@extrachill/api-client';
+import type { SocialPlatformConfig, SocialPublishResponse, SocialPublishResult } from '@extrachill/api-client';
 import { studioClient, uploadStudioFile } from '../../../app/client';
-import type { SocialPlatformConfig } from '../../../types/externals';
 
 const h = createElement as typeof import( 'react' ).createElement;
 const PanelView = Panel as unknown as ( props: any ) => ReactElement;

--- a/src/blocks/studio/types/externals.d.ts
+++ b/src/blocks/studio/types/externals.d.ts
@@ -27,20 +27,9 @@ declare module '@extrachill/components/components/Tabs' {
 	export default Tabs;
 }
 
-export interface SocialPlatformConfig {
-	label: string;
-	maxImages?: number;
-	aspectRatios?: string[];
-	defaultAspectRatio?: string;
-	charLimit?: number;
-	supportsCarousel?: boolean;
-	type?: string;
-	scopes?: string;
-	authenticated?: boolean;
-	username?: string | null;
-	/** Platform capabilities declared by the handler. Each entry has a slug and display label. */
-	capabilities?: Array< { slug: string; label: string } >;
-}
+// SocialPlatformConfig is exported from @extrachill/api-client — import from
+// there directly. The previous local re-declaration drifted out of sync with
+// the api-client contract; removed in the platforms-array-contract refactor.
 
 declare module '@extrachill/components' {
 	export interface TabItem {


### PR DESCRIPTION
## Summary

Consumes the cleaner `/platforms` REST contract from [data-machine-socials#131](https://github.com/Extra-Chill/data-machine-socials/pull/131) and the matching typed wrapper in [extrachill-api-client#6](https://github.com/Extra-Chill/extrachill-api-client/pull/6). Net **-62 lines** of client-side mess that the server now handles canonically.

## What goes away

| Removed | Why |
|---|---|
| `normalizeCapabilities()` helper (~20 lines) | Server canonicalises `capabilities` to `[{slug, label}]` before serialization. |
| `DEFAULT_CAPABILITIES` fallback | Server guarantees every entry has at least `[{slug:'publish',label:'Publish'}]`. |
| `Object.entries(platforms).map(([slug, config]) => …)` | Response is already an ordered array; iterate directly. |
| `type === 'fetch'` filter | Server filters fetch handlers (e.g. Reddit) before responding. |
| `PlatformEntry` intermediate shape | Use `SocialPlatformConfig` from api-client directly. |
| `config: cfg \|\| { label: slug }` defensive defaults | Server always provides a complete entry; nothing to default. |
| Local `SocialPlatformConfig` interface in `types/externals.d.ts` | Drifted out of sync with api-client. Use the api-client export as single source of truth. |

## What the SocialsPane logic looks like now

```ts
const response = await studioClient.socials.getPlatforms();
setPlatforms( Array.isArray( response?.platforms ) ? response.platforms : [] );

// later in useMemo:
const availablePlatforms = platforms.filter( p =>
  p.authenticated &&
  ( allowedSlugs.length === 0 || allowedSlugs.includes( p.slug ) )
);
```

That's the whole filter. Sort order, capability shape, fetch handler exclusion, slug presence — all owned by the server.

## Display order (server-controlled)

Authenticated first, then alphabetical by label. Live preview against current production handlers:

```
Authenticated:    Bluesky, Instagram, Twitter
Unauthenticated:  Facebook, LinkedIn, Pinterest, Threads
```

This replaces the previous registration-order surface (which mirrored line numbers in `data-machine-socials.php`).

## Coordinated rollout

This is **PR C** of a 3-PR cluster. Deploy order matters:

1. [data-machine-socials#131](https://github.com/Extra-Chill/data-machine-socials/pull/131) — REST contract (must deploy first)
2. [extrachill-api-client#6](https://github.com/Extra-Chill/extrachill-api-client/pull/6) — typed wrapper (must release before C deploys)
3. **C (this PR)** — Studio consumer

If C deploys before A, the studio sidebar will break (expects `response.platforms` array, gets old object shape).

## Test plan

- ✅ `npm run typecheck` clean (one pre-existing unrelated unused-var warning in compose tab)
- ✅ `npm run build` clean — webpack compiled successfully
- ⏳ Manual sidebar smoke check on studio.extrachill.com after full deploy