### PR TITLE
feat: pin Instagram to top of socials sidebar

### DIFF
--- a/extrachill-studio.php
+++ b/extrachill-studio.php
@@ -48,6 +48,24 @@ add_filter( 'datamachine_tasks', function ( array $tasks ): array {
 	return $tasks;
 } );
 
+/**
+ * Pin Instagram to the top of the social platforms response.
+ *
+ * Studio's primary social workflow targets Instagram, so the platform
+ * sidebar should default to Instagram instead of the alphabetically-first
+ * authenticated platform. Studio prepends 'instagram' to whatever priority
+ * list other plugins may have set, rather than replacing it.
+ *
+ * Filter contract is documented in
+ * data-machine-socials/inc/RestApi.php::get_platforms (since v0.13.1).
+ *
+ * @param array $priority Ordered list of platform slugs.
+ * @return array
+ */
+add_filter( 'datamachine_socials_platform_priority', function ( array $priority ): array {
+	return array_values( array_unique( array_merge( array( 'instagram' ), $priority ) ) );
+} );
+
 register_activation_hook( __FILE__, 'extrachill_studio_activate' );
 register_deactivation_hook( __FILE__, 'extrachill_studio_deactivate' );
 


### PR DESCRIPTION
## Summary

Hooks the `datamachine_socials_platform_priority` filter (added in [data-machine-socials#132](https://github.com/Extra-Chill/data-machine-socials/pull/132)) to pin Instagram to the top of the Studio sidebar's social platform list.

This is **PR E** of a 2-PR pair. PR D adds the primitive in DM Socials; this PR consumes it.

## Why

Studio's primary social workflow targets Instagram. Today the sidebar lists:

```
1. Bluesky      ← auto-selected on load (alphabetically first authed)
2. Instagram
3. Twitter
```

Bluesky-as-default isn't right for Extra Chill. Instagram should be first and auto-selected.

After this change:

```
1. Instagram    ← pinned, auto-selected on load
2. Bluesky      A-Z among authed
3. Twitter      A-Z among authed
```

## Implementation

One filter callback in `extrachill-studio.php`:

```php
add_filter( 'datamachine_socials_platform_priority', function ( array $priority ): array {
    return array_values( array_unique( array_merge( array( 'instagram' ), $priority ) ) );
} );
```

`array_merge` instead of replacing — respects whatever other plugins might add later. Studio just prepends its preference. `array_unique` guards against duplicate entries if another plugin also tries to pin Instagram.

## No React changes needed

The auto-select behavior in `SocialsPane` already picks `availablePlatforms[0]`. Once Instagram is at index 0 (server-driven), auto-select picks Instagram automatically. No client-side code change.

## Coordinated rollout

Order: D deploys before E. Failure mode if E deploys first is graceful — filter just doesn't fire because the hook doesn't exist yet, sort falls back to v0.13.0 default (alphabetical within auth groups).

## Test plan

- ⏳ Hard refresh studio.extrachill.com Socials tab after both PRs deploy
- ⏳ Verify Instagram appears first in sidebar
- ⏳ Verify Instagram is auto-selected on load (no Bluesky default)