### PR TITLE
feat: rename Compose tab to Blog

### DIFF
--- a/src/blocks/studio/app/tabs.ts
+++ b/src/blocks/studio/app/tabs.ts
@@ -5,8 +5,8 @@ export const getStudioTabs = (): StudioTab[] => [
 	{
 		id: 'compose',
 		pane: 'compose',
-		label: __( 'Compose', 'extrachill-studio' ),
-		preview: __( 'Draft and submit posts using the block editor.', 'extrachill-studio' ),
+		label: __( 'Blog', 'extrachill-studio' ),
+		preview: __( 'Draft and submit blog posts using the block editor.', 'extrachill-studio' ),
 	},
 	{
 		id: 'socials',


### PR DESCRIPTION
Renames the user-visible tab label from 'Compose' to 'Blog' and updates the preview description to match. The internal slug `compose` is unchanged — file paths, CSS classes, BE context registration, autosaved drafts, and chat client_context payloads all continue to work without churn.