### PR TITLE
feat: enable fullscreen mode in compose editor

### DIFF
--- a/extrachill-studio.php
+++ b/extrachill-studio.php
@@ -38,6 +38,26 @@ require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/abilities/run-giveaway.php';
 require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/tasks/giveaway-task.php';
 
 /**
+ * Register Studio's ability category before abilities are registered.
+ *
+ * @return void
+ */
+function extrachill_studio_register_ability_category() {
+	if ( ! function_exists( 'wp_register_ability_category' ) ) {
+		return;
+	}
+
+	wp_register_ability_category(
+		'extrachill',
+		array(
+			'label'       => __( 'Extra Chill', 'extrachill-studio' ),
+			'description' => __( 'Extra Chill platform tools and workflows.', 'extrachill-studio' ),
+		)
+	);
+}
+add_action( 'wp_abilities_api_categories_init', 'extrachill_studio_register_ability_category' );
+
+/**
  * Register the giveaway task with the Data Machine Task System.
  *
  * @param array $tasks Registered task classes.

--- a/inc/compose-editor.php
+++ b/inc/compose-editor.php
@@ -189,6 +189,18 @@ function configure_compose_editor( array $settings ): array {
 		'mediaEndpoint' => rest_url( 'extrachill/v1/media' ),
 	);
 
+	// Expose IBE's More Menu so writers can toggle fullscreen mode and
+	// keyboard shortcuts. Default to non-fullscreen on boot — users opt in
+	// via the menu (or Ctrl/Cmd+Shift+Alt+F). Fullscreen-state CSS lives
+	// in style.css under html.is-fullscreen-mode and hides Studio chrome
+	// that sits outside the editor skeleton (title input, toolbar, save
+	// actions, detached sidebar). See Phase 1 scoping in MEMORY.md.
+	$settings['iso']['moreMenu']                                = true;
+	$settings['iso']['defaultPreferences']                      = isset( $settings['iso']['defaultPreferences'] ) && is_array( $settings['iso']['defaultPreferences'] )
+		? $settings['iso']['defaultPreferences']
+		: array();
+	$settings['iso']['defaultPreferences']['fullscreenMode']    = false;
+
 	return $settings;
 }
 add_filter( 'blocks_everywhere_editor_settings', __NAMESPACE__ . '\\configure_compose_editor', 30 );

--- a/src/blocks/studio/style.css
+++ b/src/blocks/studio/style.css
@@ -528,6 +528,30 @@
 	}
 }
 
+/* ── Compose tab — fullscreen mode ──
+ * IBE's fullscreen toggle (More Menu → "Fullscreen mode") sets
+ * html.is-fullscreen-mode and pins .interface-interface-skeleton fixed
+ * to the viewport. Anything outside .iso-editor (Studio chrome: title
+ * input, toolbar, save actions, detached sidebar slot) becomes visually
+ * irrelevant in that state and would either bleed through or just sit
+ * uselessly underneath. Hide them so fullscreen reads as a clean
+ * content-only writing mode. Users exit via the same More Menu or the
+ * Ctrl/Cmd+Shift+Alt+F shortcut to regain access to title and submit.
+ */
+html.is-fullscreen-mode .ec-studio-compose-toolbar,
+html.is-fullscreen-mode .ec-studio-compose-title,
+html.is-fullscreen-mode .ec-studio-composer__actions,
+html.is-fullscreen-mode .ec-studio-panel--compose-sidebar {
+	display: none;
+}
+
+/* The compose editor panel needs to release its border + grid position
+ * so the fullscreen skeleton can take over the viewport cleanly. */
+html.is-fullscreen-mode .ec-studio-compose-editor {
+	border: 0;
+	min-height: 0;
+}
+
 /* ── Socials tab — sidebar + content layout ── */
 .ec-studio-socials-layout {
 	display: grid;

--- a/src/blocks/studio/tabs/compose/index.ts
+++ b/src/blocks/studio/tabs/compose/index.ts
@@ -429,7 +429,7 @@ const ComposePane = ( _props: StudioPaneProps ): ReactElement => {
 		try {
 			const path = activePostId ? `/wp/v2/posts/${ activePostId }` : '/wp/v2/posts';
 
-			const post = await apiFetch< WpPost >( {
+			await apiFetch< WpPost >( {
 				path,
 				method: 'POST',
 				data: {


### PR DESCRIPTION
## Summary

Phase 1 of Blocks Everywhere / Isolated Block Editor fullscreen integration. Studio only — community forum is fullscreen-hostile and intentionally deferred.

- Set `iso.moreMenu = true` in `configure_compose_editor()` so IBE's More Menu renders, exposing the **Fullscreen mode** toggle and keyboard shortcuts overlay
- Set `iso.defaultPreferences.fullscreenMode = false` so users start in normal mode and opt in via the menu (or `Ctrl/Cmd+Shift+Alt+F`)
- Add `html.is-fullscreen-mode` CSS overrides to hide Studio chrome that lives outside `.iso-editor` (title input, compose toolbar, save/submit actions, detached sidebar slot) — without these, fullscreen leaves those elements sitting uselessly underneath the fixed editor skeleton

## Why this works

IBE supports fullscreen natively. The fullscreen button lives inside the More Menu, which BE defaults to `false`. Our existing settings filter never overrode it — fullscreen has been one config flag away the whole time.

When fullscreen activates, IBE adds `is-fullscreen-mode` to `<html>` and pins `.interface-interface-skeleton` fixed to the viewport. Studio's title input, toolbar, save buttons, and detached sidebar all live outside that skeleton, so we hide them in fullscreen and the editor reads as a clean content-only writing mode.

## Caveats (acknowledged, not blockers)

- More Menu is all-or-nothing — turning on fullscreen also exposes keyboard shortcuts overlay, top-toolbar toggle, and code-editor mode. Studio is admin-gated (team members + manage_options) so code-editor mode is fine.
- Title input + submit/save buttons are inaccessible while fullscreen is active. To save or change the title, exit fullscreen. A future Phase 2 would move submit/save into IBE's `IsolatedFooter` slot to keep them reachable.

## Testing

- [ ] Visit studio.extrachill.com homepage as a team member
- [ ] Verify three-dot More Menu appears in editor toolbar
- [ ] Click "Fullscreen mode" and confirm editor expands to full viewport
- [ ] Confirm title input, toolbar, save buttons, and sidebar are hidden
- [ ] Exit fullscreen via menu or `Ctrl/Cmd+Shift+Alt+F`
- [ ] Confirm chrome reappears and content is preserved

## Related

Scoped in session at https://discord.com/channels/1381023524684042391/1498028996775120988