### PR TITLE
feat: MediaPicker for main-site media library in Socials publish pane

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
 				"@extrachill/tokens": "^0.4.2"
 			},
 			"devDependencies": {
-				"@extrachill/api-client": "^0.4.0",
+				"@extrachill/api-client": "^0.5.0",
 				"@types/react": "^18.3.0",
 				"@types/wordpress__block-editor": "^15.0.5",
 				"@types/wordpress__blocks": "^15.10.2",
@@ -2666,9 +2666,9 @@
 			}
 		},
 		"node_modules/@extrachill/api-client": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/@extrachill/api-client/-/api-client-0.4.0.tgz",
-			"integrity": "sha512-2D/8cCEx4Eo56CSd1oLWJc+BFVFt+8twGvCQHGFbwIdsRTTjg6ZlJpsFXyXwTFHvZv5In6dQ+w2tCU/YHNCO/g==",
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@extrachill/api-client/-/api-client-0.5.0.tgz",
+			"integrity": "sha512-TaYPWXZV81UdHkRl5MqZo7R95oFMAzJFXrEDpNWaibEULop8jWitjc61vAOJRC1K95ttUsbRCo02UsfQF4mLSw==",
 			"dev": true,
 			"license": "GPL-2.0+"
 		},

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"@extrachill/tokens": "^0.4.2"
 	},
 	"devDependencies": {
-		"@extrachill/api-client": "^0.4.0",
+		"@extrachill/api-client": "^0.5.0",
 		"@types/react": "^18.3.0",
 		"@types/wordpress__block-editor": "^15.0.5",
 		"@types/wordpress__blocks": "^15.10.2",

--- a/src/blocks/studio/style.css
+++ b/src/blocks/studio/style.css
@@ -154,6 +154,98 @@
 	text-decoration: none;
 }
 
+/* Media Picker — network media library browser */
+.ec-studio-media-picker {
+	margin-bottom: var(--spacing-md);
+}
+
+.ec-studio-media-picker__grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+	gap: var(--spacing-sm);
+	list-style: none;
+	padding: 0;
+	margin: var(--spacing-md) 0;
+}
+
+.ec-studio-media-picker__tile {
+	position: relative;
+	aspect-ratio: 1 / 1;
+	overflow: hidden;
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius-md);
+	background: var(--background-color);
+	transition: border-color 120ms ease, transform 120ms ease;
+}
+
+.ec-studio-media-picker__tile:hover {
+	border-color: var(--link-color);
+}
+
+.ec-studio-media-picker__tile:focus-within {
+	outline: 2px solid var(--link-color);
+	outline-offset: 2px;
+}
+
+.ec-studio-media-picker__select-btn {
+	display: block;
+	width: 100%;
+	height: 100%;
+	padding: 0;
+	margin: 0;
+	border: 0;
+	background: transparent;
+	cursor: pointer;
+}
+
+.ec-studio-media-picker__select-btn img {
+	display: block;
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+}
+
+.ec-studio-media-picker__tile--upload {
+	background: var(--card-background);
+}
+
+.ec-studio-media-picker__upload-btn {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: var(--spacing-xs);
+	width: 100%;
+	height: 100%;
+	padding: var(--spacing-sm);
+	border: 0;
+	background: transparent;
+	color: var(--text-color);
+	font: inherit;
+	cursor: pointer;
+}
+
+.ec-studio-media-picker__upload-btn:disabled {
+	cursor: progress;
+	opacity: 0.6;
+}
+
+.ec-studio-media-picker__upload-icon {
+	font-size: 2rem;
+	line-height: 1;
+	font-weight: 300;
+	color: var(--muted-text);
+}
+
+.ec-studio-media-picker__upload-label {
+	font-size: var(--font-size-sm);
+	color: var(--muted-text);
+}
+
+.ec-studio-media-picker__footer {
+	margin-top: var(--spacing-sm);
+}
+
 .ec-studio-image-list {
 	display: grid;
 	gap: var(--spacing-sm);

--- a/src/blocks/studio/tabs/socials/media-picker/index.tsx
+++ b/src/blocks/studio/tabs/socials/media-picker/index.tsx
@@ -1,0 +1,306 @@
+import { __, sprintf } from '@wordpress/i18n';
+import { createElement, useEffect, useRef, useState, useCallback } from '@wordpress/element';
+import type { ReactElement, ChangeEvent } from 'react';
+import { ActionRow, FieldGroup, InlineStatus, Panel } from '@extrachill/components';
+import type { NetworkMediaItem } from '@extrachill/api-client';
+
+import { studioClient } from '../../../app/client';
+
+const h = createElement as typeof import( 'react' ).createElement;
+const PanelView = Panel as unknown as ( props: any ) => ReactElement;
+const ActionRowView = ActionRow as unknown as ( props: any ) => ReactElement;
+const FieldGroupView = FieldGroup as unknown as ( props: any ) => ReactElement;
+const InlineStatusView = InlineStatus as unknown as ( props: any ) => ReactElement;
+
+const PER_PAGE = 24;
+const SEARCH_DEBOUNCE_MS = 300;
+
+export interface MediaPickerProps {
+	/** Called when a media item is selected. Receives the canonical URL. */
+	onSelect: ( url: string, item: NetworkMediaItem ) => void;
+	/** Optional className for the outer wrapper. */
+	className?: string;
+}
+
+/**
+ * Network media picker.
+ *
+ * Browse and select images from the main editorial media library
+ * (blog 1) via the `/extrachill/v1/network-media` endpoint. Supports
+ * uploading new files directly into the main library — uploaded items
+ * become immediately selectable.
+ *
+ * Renders a grid of thumbnails with search and pagination ("Load more").
+ * The first tile is always the upload affordance.
+ *
+ * Selection is single-click — the parent receives the chosen URL and
+ * decides what to do with it (e.g. add to publish queue).
+ */
+const MediaPicker = ( { onSelect, className }: MediaPickerProps ): ReactElement => {
+	const [ items, setItems ] = useState< NetworkMediaItem[] >( [] );
+	const [ page, setPage ] = useState( 1 );
+	const [ totalPages, setTotalPages ] = useState( 1 );
+	const [ totalItems, setTotalItems ] = useState( 0 );
+	const [ searchInput, setSearchInput ] = useState( '' );
+	const [ activeSearch, setActiveSearch ] = useState( '' );
+	const [ isLoading, setIsLoading ] = useState( false );
+	const [ isUploading, setIsUploading ] = useState( false );
+	const [ error, setError ] = useState( '' );
+
+	const fileInputRef = useRef< HTMLInputElement | null >( null );
+	const searchDebounceRef = useRef< ReturnType< typeof setTimeout > | null >( null );
+
+	const fetchPage = useCallback(
+		async ( targetPage: number, search: string, mode: 'replace' | 'append' ): Promise< void > => {
+			setIsLoading( true );
+			setError( '' );
+
+			try {
+				const response = await studioClient.networkMedia.list( {
+					media_type: 'image',
+					search: search || undefined,
+					per_page: PER_PAGE,
+					page: targetPage,
+				} );
+
+				const fetched = Array.isArray( response?.items ) ? response.items : [];
+				setItems( ( current ) => ( mode === 'append' ? [ ...current, ...fetched ] : fetched ) );
+				setPage( response?.page || targetPage );
+				setTotalPages( response?.total_pages || 1 );
+				setTotalItems( response?.total || fetched.length );
+			} catch ( fetchError ) {
+				setError(
+					( fetchError as Error )?.message ||
+						__( 'Unable to load media library.', 'extrachill-studio' )
+				);
+				if ( mode === 'replace' ) {
+					setItems( [] );
+					setTotalPages( 1 );
+					setTotalItems( 0 );
+				}
+			} finally {
+				setIsLoading( false );
+			}
+		},
+		[]
+	);
+
+	// Initial load.
+	useEffect( () => {
+		fetchPage( 1, '', 'replace' );
+	}, [ fetchPage ] );
+
+	// Debounced search.
+	useEffect( () => {
+		if ( searchDebounceRef.current ) {
+			clearTimeout( searchDebounceRef.current );
+		}
+
+		searchDebounceRef.current = setTimeout( () => {
+			searchDebounceRef.current = null;
+			if ( searchInput !== activeSearch ) {
+				setActiveSearch( searchInput );
+				fetchPage( 1, searchInput, 'replace' );
+			}
+		}, SEARCH_DEBOUNCE_MS );
+
+		return () => {
+			if ( searchDebounceRef.current ) {
+				clearTimeout( searchDebounceRef.current );
+				searchDebounceRef.current = null;
+			}
+		};
+	}, [ searchInput, activeSearch, fetchPage ] );
+
+	const loadMore = useCallback( (): void => {
+		if ( page < totalPages && ! isLoading ) {
+			fetchPage( page + 1, activeSearch, 'append' );
+		}
+	}, [ page, totalPages, isLoading, activeSearch, fetchPage ] );
+
+	const triggerUpload = useCallback( (): void => {
+		fileInputRef.current?.click();
+	}, [] );
+
+	const handleFileChange = useCallback(
+		async ( event: ChangeEvent< HTMLInputElement > ): Promise< void > => {
+			const file = event.target.files?.[ 0 ];
+			if ( ! file ) return;
+
+			setIsUploading( true );
+			setError( '' );
+
+			try {
+				const formData = studioClient.networkMedia.buildUploadForm( file );
+				const uploaded = await studioClient.networkMedia.upload( formData );
+
+				// Prepend the new upload so it's immediately visible at the top.
+				setItems( ( current ) => [ uploaded, ...current ] );
+				setTotalItems( ( current ) => current + 1 );
+
+				// Auto-select the freshly uploaded image.
+				onSelect( uploaded.url, uploaded );
+			} catch ( uploadError ) {
+				setError(
+					( uploadError as Error )?.message ||
+						__( 'Upload failed.', 'extrachill-studio' )
+				);
+			} finally {
+				setIsUploading( false );
+				// Reset the input so the same file can be re-selected if needed.
+				if ( fileInputRef.current ) {
+					fileInputRef.current.value = '';
+				}
+			}
+		},
+		[ onSelect ]
+	);
+
+	const wrapperClass = [
+		'ec-studio-media-picker',
+		className || '',
+	]
+		.filter( Boolean )
+		.join( ' ' );
+
+	return h(
+		PanelView,
+		{ className: `ec-studio-panel ${ wrapperClass }`, compact: true },
+		// Search bar
+		h(
+			FieldGroupView,
+			{
+				label: __( 'Search media library', 'extrachill-studio' ),
+				htmlFor: 'ec-studio-media-picker-search',
+				help: totalItems > 0
+					? sprintf(
+						/* translators: %d: total number of media items */
+						__( '%d images in library', 'extrachill-studio' ),
+						totalItems
+					)
+					: null,
+			},
+			createElement( 'input', {
+				id: 'ec-studio-media-picker-search',
+				type: 'search',
+				value: searchInput,
+				onChange: ( event: ChangeEvent< HTMLInputElement > ) => setSearchInput( event.target.value ),
+				placeholder: __( 'Search by filename or title…', 'extrachill-studio' ),
+				autoComplete: 'off',
+			} )
+		),
+
+		error
+			? h( InlineStatusView, { tone: 'error', className: 'ec-studio-message' }, error )
+			: null,
+
+		// Hidden native file input wired to the upload tile.
+		createElement( 'input', {
+			ref: fileInputRef,
+			type: 'file',
+			accept: 'image/*',
+			onChange: handleFileChange,
+			style: { display: 'none' },
+		} ),
+
+		// Grid: upload tile + library tiles
+		createElement(
+			'ul',
+			{ className: 'ec-studio-media-picker__grid' },
+			// Upload tile (always first)
+			createElement(
+				'li',
+				{ className: 'ec-studio-media-picker__tile ec-studio-media-picker__tile--upload', key: '__upload__' },
+				createElement(
+					'button',
+					{
+						type: 'button',
+						className: 'ec-studio-media-picker__upload-btn',
+						onClick: triggerUpload,
+						disabled: isUploading,
+						'aria-label': __( 'Upload new image', 'extrachill-studio' ),
+					},
+					createElement( 'span', { className: 'ec-studio-media-picker__upload-icon', 'aria-hidden': true }, '+' ),
+					createElement(
+						'span',
+						{ className: 'ec-studio-media-picker__upload-label' },
+						isUploading
+							? __( 'Uploading…', 'extrachill-studio' )
+							: __( 'Upload', 'extrachill-studio' )
+					)
+				)
+			),
+			// Library tiles
+			...items.map( ( item ) =>
+				createElement(
+					'li',
+					{ key: item.sourceId, className: 'ec-studio-media-picker__tile' },
+					createElement(
+						'button',
+						{
+							type: 'button',
+							className: 'ec-studio-media-picker__select-btn',
+							onClick: () => onSelect( item.url, item ),
+							'aria-label': sprintf(
+								/* translators: %s: media item title */
+								__( 'Select %s', 'extrachill-studio' ),
+								item.title || item.sourceId
+							),
+							title: item.title || item.sourceId,
+						},
+						createElement( 'img', {
+							src: item.previewUrl || item.url,
+							alt: item.alt || item.title || '',
+							loading: 'lazy',
+						} )
+					)
+				)
+			)
+		),
+
+		// Footer: status + load more
+		h(
+			ActionRowView,
+			{ className: 'ec-studio-media-picker__footer' },
+			isLoading && items.length === 0
+				? createElement(
+					'span',
+					{ className: 'ec-studio-composer__hint' },
+					__( 'Loading…', 'extrachill-studio' )
+				)
+				: null,
+			! isLoading && items.length === 0
+				? createElement(
+					'span',
+					{ className: 'ec-studio-composer__hint' },
+					activeSearch
+						? __( 'No matches.', 'extrachill-studio' )
+						: __( 'No media yet — upload to get started.', 'extrachill-studio' )
+				)
+				: null,
+			page < totalPages
+				? createElement(
+					'button',
+					{
+						type: 'button',
+						className: 'button-1 button-medium',
+						onClick: loadMore,
+						disabled: isLoading,
+					},
+					isLoading
+						? __( 'Loading…', 'extrachill-studio' )
+						: __( 'Load more', 'extrachill-studio' )
+				)
+				: null,
+			page >= totalPages && items.length > 0
+				? createElement(
+					'span',
+					{ className: 'ec-studio-composer__hint' },
+					__( 'End of library.', 'extrachill-studio' )
+				)
+				: null
+		)
+	);
+};
+
+export default MediaPicker;

--- a/src/blocks/studio/tabs/socials/publish/index.ts
+++ b/src/blocks/studio/tabs/socials/publish/index.ts
@@ -1,18 +1,18 @@
 import { __, sprintf } from '@wordpress/i18n';
-import { createElement, useEffect, useState } from '@wordpress/element';
+import { createElement, useState } from '@wordpress/element';
 import type { ReactElement, ChangeEvent } from 'react';
-import { ActionRow, FieldGroup, InlineStatus, MediaField, Panel, PanelHeader } from '@extrachill/components';
+import { ActionRow, FieldGroup, InlineStatus, Panel, PanelHeader } from '@extrachill/components';
 
 import apiFetch from '@wordpress/api-fetch';
-import type { SocialPlatformConfig, SocialPublishResponse, SocialPublishResult } from '@extrachill/api-client';
-import { studioClient, uploadStudioFile } from '../../../app/client';
+import type { NetworkMediaItem, SocialPlatformConfig, SocialPublishResponse, SocialPublishResult } from '@extrachill/api-client';
+import { studioClient } from '../../../app/client';
+import MediaPicker from '../media-picker';
 
 const h = createElement as typeof import( 'react' ).createElement;
 const PanelView = Panel as unknown as ( props: any ) => ReactElement;
 const ActionRowView = ActionRow as unknown as ( props: any ) => ReactElement;
 const FieldGroupView = FieldGroup as unknown as ( props: any ) => ReactElement;
 const InlineStatusView = InlineStatus as unknown as ( props: any ) => ReactElement;
-const MediaFieldView = MediaField as unknown as ( props: any ) => ReactElement;
 
 export interface PlatformPublishPaneProps {
 	slug: string;
@@ -36,9 +36,6 @@ const PlatformPublishPane = ( { slug, label, username, config }: PlatformPublish
 	const [ caption, setCaption ] = useState( '' );
 	const [ imageUrlInput, setImageUrlInput ] = useState( '' );
 	const [ imageUrls, setImageUrls ] = useState< string[] >( [] );
-	const [ selectedFile, setSelectedFile ] = useState< File | null >( null );
-	const [ selectedFilePreviewUrl, setSelectedFilePreviewUrl ] = useState( '' );
-	const [ isUploading, setIsUploading ] = useState( false );
 	const [ isPublishing, setIsPublishing ] = useState( false );
 	const [ status, setStatus ] = useState( '' );
 	const [ error, setError ] = useState( '' );
@@ -47,20 +44,6 @@ const PlatformPublishPane = ( { slug, label, username, config }: PlatformPublish
 	const platformLabel = label || slug;
 	const charLimit = config.charLimit || 0;
 	const supportsImages = ( config.maxImages || 0 ) > 0 || config.supportsCarousel;
-
-	useEffect( () => {
-		if ( ! selectedFile ) {
-			setSelectedFilePreviewUrl( '' );
-			return;
-		}
-
-		const previewUrl = URL.createObjectURL( selectedFile );
-		setSelectedFilePreviewUrl( previewUrl );
-
-		return () => {
-			URL.revokeObjectURL( previewUrl );
-		};
-	}, [ selectedFile ] );
 
 	const addImageUrl = (): void => {
 		const nextUrl = imageUrlInput.trim();
@@ -80,36 +63,19 @@ const PlatformPublishPane = ( { slug, label, username, config }: PlatformPublish
 		setImageUrls( ( current ) => [ ...current, nextUrl ] );
 		setImageUrlInput( '' );
 		setError( '' );
-		setStatus( __( 'Image URL added to publish queue.', 'extrachill-studio' ) );
+		setStatus( __( 'External image URL added to publish queue.', 'extrachill-studio' ) );
 	};
 
-	const handleUpload = async (): Promise< void > => {
-		if ( ! selectedFile ) {
-			setError( __( 'Choose an image file to upload first.', 'extrachill-studio' ) );
-			return;
-		}
-
-		setIsUploading( true );
+	const handleMediaSelect = ( url: string, item: NetworkMediaItem ): void => {
+		setImageUrls( ( current ) => [ ...current, url ] );
 		setError( '' );
-		setStatus( __( 'Uploading image…', 'extrachill-studio' ) );
-
-		try {
-			const response = await uploadStudioFile( selectedFile );
-
-			if ( ! response?.url ) {
-				throw new Error( __( 'Upload did not return an image URL.', 'extrachill-studio' ) );
-			}
-
-			setImageUrls( ( current ) => [ ...current, response.url ] );
-			setSelectedFile( null );
-			setSelectedFilePreviewUrl( '' );
-			setStatus( __( 'Image uploaded and added to publish queue.', 'extrachill-studio' ) );
-		} catch ( uploadError ) {
-			setError( ( uploadError as Error )?.message || __( 'Image upload failed.', 'extrachill-studio' ) );
-			setStatus( '' );
-		} finally {
-			setIsUploading( false );
-		}
+		setStatus(
+			sprintf(
+				/* translators: %s: media item title or filename */
+				__( '%s added to publish queue.', 'extrachill-studio' ),
+				item.title || item.sourceId
+			)
+		);
 	};
 
 	const removeImageUrl = ( index: number ): void => {
@@ -247,9 +213,19 @@ const PlatformPublishPane = ( { slug, label, username, config }: PlatformPublish
 					} )
 				),
 				supportsImages
+					? h( MediaPicker, {
+						onSelect: handleMediaSelect,
+						className: 'ec-studio-pane__media-picker',
+					} )
+					: null,
+				supportsImages
 					? h(
 						FieldGroupView,
-						{ label: __( 'Image URL', 'extrachill-studio' ), htmlFor: `ec-studio-${ slug }-image-url` },
+						{
+							label: __( 'Or paste an external URL', 'extrachill-studio' ),
+							htmlFor: `ec-studio-${ slug }-image-url`,
+							help: __( 'Public image URLs (e.g. Dropbox, Drive) — for files not yet in the media library, prefer the Upload tile above.', 'extrachill-studio' ),
+						},
 						createElement( 'input', {
 							id: `ec-studio-${ slug }-image-url`,
 							type: 'url',
@@ -264,45 +240,17 @@ const PlatformPublishPane = ( { slug, label, username, config }: PlatformPublish
 					? h(
 						ActionRowView,
 						{ className: 'ec-studio-composer__actions' },
-						createElement( 'button', { type: 'button', className: 'button-1 button-medium', onClick: addImageUrl }, __( 'Add Image URL', 'extrachill-studio' ) ),
-						createElement( 'span', { className: 'ec-studio-composer__hint' }, __( 'Use a public image URL or upload a file below.', 'extrachill-studio' ) )
+						createElement(
+							'button',
+							{
+								type: 'button',
+								className: 'button-1 button-medium',
+								onClick: addImageUrl,
+								disabled: ! imageUrlInput.trim(),
+							},
+							__( 'Add External URL', 'extrachill-studio' )
+						)
 					)
-					: null,
-				supportsImages
-					? h( MediaFieldView, {
-						label: __( 'Upload image', 'extrachill-studio' ),
-						htmlFor: `ec-studio-${ slug }-upload`,
-						previewUrl: selectedFilePreviewUrl || null,
-						previewAlt: selectedFile?.name || __( 'Selected upload preview', 'extrachill-studio' ),
-						empty: __( 'No local image selected yet.', 'extrachill-studio' ),
-						actions: h(
-							ActionRowView,
-							null,
-							createElement( 'input', {
-								id: `ec-studio-${ slug }-upload`,
-								type: 'file',
-								accept: 'image/*',
-								onChange: ( event: ChangeEvent< HTMLInputElement > ) => {
-									setSelectedFile( event.target.files?.[ 0 ] || null );
-									setError( '' );
-									setStatus( '' );
-								},
-							} ),
-							createElement(
-								'button',
-								{
-									type: 'button',
-									className: 'button-1 button-medium',
-									onClick: handleUpload,
-									disabled: isUploading || ! selectedFile,
-								},
-								isUploading ? __( 'Uploading…', 'extrachill-studio' ) : __( 'Upload Image', 'extrachill-studio' )
-							),
-							selectedFile
-								? createElement( 'span', { className: 'ec-studio-composer__hint' }, selectedFile.name )
-								: null
-						),
-					} )
 					: null,
 				error ? h( InlineStatusView, { tone: 'error', className: 'ec-studio-message' }, error ) : null,
 				! error && status ? h( InlineStatusView, { tone: 'success', className: 'ec-studio-message' }, status ) : null,


### PR DESCRIPTION
## Summary

Replaces the URL input + local file upload UI in the Socials publish pane with a unified \`MediaPicker\` component that browses and uploads to the main editorial media library (blog 1) via \`/extrachill/v1/network-media\`.

This is **PR 4 of 4** in the network-media-library cluster — completing Phase 1 of [extrachill-multisite#2](https://github.com/Extra-Chill/extrachill-multisite/issues/2).

## What ships

### \`tabs/socials/media-picker/index.tsx\` (new)

Reusable headless picker:

- **Grid layout**: thumbnail per attachment, square aspect ratio
- **Upload tile**: first cell is always 'Upload' — click to file-pick, drops file directly into main media library, auto-selects on completion
- **Search**: 300ms debounced, queries the \`search\` param
- **Pagination**: 24 items per page, 'Load more' button to append
- **Single-click selection**: parent receives canonical URL + full \`NetworkMediaItem\`
- **Image-only filter**: hardcoded \`media_type=image\` for v1 (Socials use case)

### \`PlatformPublishPane\` integration

Old:
\`\`\`
[ Image URL input field ]
[ Add Image URL button ]
[ MediaField: file upload preview + Upload Image button ]
\`\`\`

New:
\`\`\`
[ MediaPicker grid: search, upload tile, library thumbnails ]
[ Or paste an external URL field ] (small, for Dropbox/Drive links)
[ Add External URL button ]
\`\`\`

The external URL paste field stays for genuinely external images (Dropbox links, etc.), but becomes a secondary affordance below the picker.

## Why a custom picker, not core's MediaUpload

WP core's \`MediaUpload\` component is admin-only and uses jQuery-based \`wp.media()\`. It's not designed for frontend use, doesn't easily support cross-site queries, and would fight the framework. The custom picker hits our typed \`/extrachill/v1/network-media\` endpoint directly — single source of truth, no jQuery, full control over UX.

## Coordinated rollout

This is the final PR in the cluster:

1. ✅ extrachill-multisite#10 — \`network-media-list\` and \`network-media-upload\` abilities (deployed v1.12.0)
2. ✅ extrachill-api#21 — REST route wrapping the abilities (deployed v0.15.2 after 2 hotfixes)
3. ✅ extrachill-api-client#7 — \`NetworkMediaResource\` (published @0.5.0 to npm via \`homeboy release\`)
4. **studio (this PR)** — picker UI consumer

Bumps \`@extrachill/api-client\` dep to \`^0.5.0\`.

## Test plan

- ✅ \`npm run typecheck\` clean (one pre-existing unrelated unused-var)
- ✅ \`npm run build\` clean — webpack compiled successfully
- ✅ Backend live REST smoke test confirmed 12,595 attachments accessible from Studio with \`media_type=image\` + \`search\` filtering
- ⏳ Manual sidebar smoke check on studio.extrachill.com after deploy

## Future hooks

The \`MediaPicker\` is intentionally headless and reusable. When the Blog tab needs main-site media access, it can drop in the same component with no API changes. When [extrachill-multisite#2](https://github.com/Extra-Chill/extrachill-multisite/issues/2) Phases 2+ extend the backend to all network sites + Redis caching, no client-side changes are needed — the contract is stable.