### PR TITLE
fix: lazy-load GiveawayTask to avoid load-order race with DM autoloader (#36)

### DIFF
--- a/extrachill-studio.php
+++ b/extrachill-studio.php
@@ -35,7 +35,18 @@ require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/social-drafts.php';
 require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/compose-editor.php';
 require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/abilities/resolve-instagram-media.php';
 require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/abilities/run-giveaway.php';
-require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/tasks/giveaway-task.php';
+
+/*
+ * Defer loading of GiveawayTask until after Data Machine has registered its
+ * PSR-4 autoloader. The class extends DataMachine\Engine\AI\System\Tasks\SystemTask,
+ * and PHP resolves the parent class at class-declaration time. Loading at the
+ * top of this file races DM's bootstrap and produces a fatal when DM's
+ * autoloader has not yet been registered (see issue #36). plugins_loaded
+ * priority 20 guarantees DM's main plugin file (priority 10) has run.
+ */
+add_action( 'plugins_loaded', static function () {
+	require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/tasks/giveaway-task.php';
+}, 20 );
 
 /**
  * Register Studio's ability category before abilities are registered.


### PR DESCRIPTION
## Summary

Defers the `require_once` for `inc/tasks/giveaway-task.php` from top-level to a `plugins_loaded` priority 20 callback in `extrachill-studio.php`. This eliminates the load-order race that produced HTTP 500 on studio.extrachill.com after the data-machine 0.103.14 → 0.107.0 upgrade.

Closes #36.

## Why

`GiveawayTask` extends `DataMachine\Engine\AI\System\Tasks\SystemTask`. PHP resolves the parent class at **class-declaration time**, which means it must be available the moment the file is included. The previous top-level `require_once` ran inside `wp-settings.php`'s plugin-loading loop, before any `plugins_loaded` action fired — and crucially, before DM had finished registering its PSR-4 autoloader. DM 0.107.0 changed bootstrap timing in a way that exposed this latent bug.

## Load-order trace (why priority 20 is correct)

```
wp-settings.php
  └── plugin loop
        ├── data-machine/data-machine.php       ← registers Composer autoloader
        ├── extrachill-studio/extrachill-studio.php
        │     └── add_action( 'plugins_loaded', …, 20 )   ← only registers callback
        └── (other plugins)
  └── do_action( 'plugins_loaded' )
        ├── priority 10  ← DM bootstrap callbacks finish here
        └── priority 20  ← our deferred require_once runs; SystemTask is now resolvable
```

DM's autoloader is registered when its plugin file is `require`d (priority irrelevant — it's during the plugin loop), but DM 0.107.0's `Requires Plugins: agents-api` header and its deferred bootstrap path mean the autoloader registration may itself happen on `plugins_loaded` priority 10. Priority 20 is the safe minimum that guarantees DM has finished before we reference its types.

## Audit of other `require_once` calls in `extrachill-studio.php`

Each top-level include was inspected for `extends`, `implements`, or top-level instantiation of DM/AgentsAPI namespaces:

| File | DM/AgentsAPI references | Action |
|---|---|---|
| `inc/assets.php` | none | leave at top level |
| `inc/breadcrumbs.php` | none | leave at top level |
| `inc/social-drafts.php` | `\DataMachine\Engine\Tasks\TaskScheduler::schedule()` inside function body, behind `class_exists()` guard | leave at top level (runtime resolution, not load time) |
| `inc/compose-editor.php` | none | leave at top level |
| `inc/abilities/resolve-instagram-media.php` | none | leave at top level |
| `inc/abilities/run-giveaway.php` | `wp_get_ability( 'datamachine/...' )` inside function bodies only | leave at top level (runtime resolution) |
| `inc/tasks/giveaway-task.php` | **`use DataMachine\Engine\AI\System\Tasks\SystemTask;` + `class GiveawayTask extends SystemTask`** at file scope | **deferred to `plugins_loaded` priority 20** |

Only `giveaway-task.php` declares a class that extends a DM type at file scope, so it's the only one that needs deferral. The `datamachine_tasks` filter callback at line 67 references `\ExtraChillStudio\Tasks\GiveawayTask::class`, which is a compile-time string token — it does not require the class to be loaded until the filter actually fires inside DM's `TaskRegistry::apply_filters()`, which happens well after `plugins_loaded`.

## Verification

- `php -l extrachill-studio.php` — no syntax errors
- `php -l inc/tasks/giveaway-task.php` — no syntax errors
- Reproduction confirmed: loading `inc/tasks/giveaway-task.php` in isolation still fatals with `Class "DataMachine\Engine\AI\System\Tasks\SystemTask" not found`, proving the file still has a hard dependency on the parent class. The fix is the load timing, not weakening the dependency.
- `homeboy lint --path . --changed-since main` — PHPCS clean on `extrachill-studio.php`. Standing baseline of 39 findings on `main` is unchanged; this PR adds zero new findings.

## Out of scope / not done

- Plugin **not** reactivated on production. Per task contract, the orchestrator will re-enable on blog 12 after merge + deploy.
- No release, no merge, no push to `main`.