### PR TITLE
feat: socials publish-pane redesign — media-first layout + image thumbnail row

### DIFF
--- a/src/blocks/studio/style.css
+++ b/src/blocks/studio/style.css
@@ -246,39 +246,95 @@
 	margin-top: var(--spacing-sm);
 }
 
-.ec-studio-image-list {
-	display: grid;
+.ec-studio-image-thumbs {
+	display: flex;
+	flex-wrap: wrap;
 	gap: var(--spacing-sm);
 	list-style: none;
 	padding: 0;
 	margin: var(--spacing-md) 0 0;
 }
 
-.ec-studio-image-list__item {
+.ec-studio-image-thumbs__tile {
+	position: relative;
+	width: 80px;
+	height: 80px;
+	border-radius: var(--border-radius-md);
+	overflow: hidden;
+	background: var(--background-color);
+	border: 1px solid var(--border-color);
+	flex: 0 0 auto;
+}
+
+.ec-studio-image-thumbs__image {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+	display: block;
+}
+
+.ec-studio-image-thumbs__remove {
+	position: absolute;
+	top: 2px;
+	right: 2px;
+	width: 20px;
+	height: 20px;
+	padding: 0;
+	border: none;
+	border-radius: 50%;
+	background: rgba(0, 0, 0, 0.65);
+	color: #fff;
+	font-size: 14px;
+	line-height: 1;
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.ec-studio-image-thumbs__remove:hover,
+.ec-studio-image-thumbs__remove:focus-visible {
+	background: rgba(0, 0, 0, 0.85);
+	outline: none;
+}
+
+.ec-studio-image-thumbs__reorder {
+	position: absolute;
+	bottom: 2px;
+	left: 2px;
+	right: 2px;
 	display: flex;
 	justify-content: space-between;
-	align-items: center;
-	min-width: 0;
-	gap: var(--spacing-md);
-	padding: var(--spacing-sm) var(--spacing-md);
-	border: 1px solid var(--border-color);
-	border-radius: var(--border-radius-md);
-	background: var(--background-color);
+	gap: 2px;
+	pointer-events: none;
 }
 
-.ec-studio-image-list__url {
-	word-break: break-word;
-	font-size: var(--font-size-sm);
-}
-
-.ec-studio-image-list__remove {
-	background: transparent;
-	border: none;
-	color: var(--link-color);
-	cursor: pointer;
-	font: inherit;
+.ec-studio-image-thumbs__move {
+	pointer-events: auto;
+	width: 20px;
+	height: 20px;
 	padding: 0;
-	white-space: nowrap;
+	border: none;
+	border-radius: 50%;
+	background: rgba(0, 0, 0, 0.65);
+	color: #fff;
+	font-size: 14px;
+	line-height: 1;
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.ec-studio-image-thumbs__move:hover:not(:disabled),
+.ec-studio-image-thumbs__move:focus-visible:not(:disabled) {
+	background: rgba(0, 0, 0, 0.85);
+	outline: none;
+}
+
+.ec-studio-image-thumbs__move:disabled {
+	opacity: 0.3;
+	cursor: not-allowed;
 }
 
 .ec-studio-comment-list {
@@ -496,7 +552,6 @@
 	.ec-studio-compose-toolbar,
 	.ec-studio-composer__actions,
 	.ec-studio-social-platforms__item,
-	.ec-studio-image-list__item,
 	.ec-studio-comment-list__meta {
 		flex-direction: column;
 		align-items: stretch;

--- a/src/blocks/studio/tabs/socials/publish/index.ts
+++ b/src/blocks/studio/tabs/socials/publish/index.ts
@@ -359,30 +359,16 @@ const PlatformPublishPane = ( { slug, label, username, config }: PlatformPublish
 			h(
 				'div',
 				{ className: 'ec-studio-composer' },
-				h(
-					FieldGroupView,
-					{
-						label: __( 'Caption', 'extrachill-studio' ),
-						htmlFor: `ec-studio-${ slug }-caption`,
-						help: charLimit > 0
-							? sprintf( __( '%d / %d characters', 'extrachill-studio' ), caption.length, charLimit )
-							: null,
-					},
-					createElement( 'textarea', {
-						id: `ec-studio-${ slug }-caption`,
-						rows: 6,
-						value: caption,
-						onChange: ( event: ChangeEvent< HTMLTextAreaElement > ) => setCaption( event.target.value ),
-						placeholder: sprintf( __( 'Write your %s caption here…', 'extrachill-studio' ), platformLabel ),
-						maxLength: charLimit > 0 ? charLimit : undefined,
-					} )
-				),
+				// 1. Media picker — primary affordance for adding images.
 				supportsImages
 					? h( MediaPicker, {
 						onSelect: handleMediaSelect,
 						className: 'ec-studio-pane__media-picker',
 					} )
 					: null,
+				// 2. Selected images thumbnail row (renders nothing when queue is empty).
+				supportsImages ? renderImageThumbnails() : null,
+				// 3. External URL fallback — paste + Add button.
 				supportsImages
 					? h(
 						FieldGroupView,
@@ -417,9 +403,29 @@ const PlatformPublishPane = ( { slug, label, username, config }: PlatformPublish
 						)
 					)
 					: null,
-				supportsImages ? renderImageThumbnails() : null,
+				// 4. Caption textarea.
+				h(
+					FieldGroupView,
+					{
+						label: __( 'Caption', 'extrachill-studio' ),
+						htmlFor: `ec-studio-${ slug }-caption`,
+						help: charLimit > 0
+							? sprintf( __( '%d / %d characters', 'extrachill-studio' ), caption.length, charLimit )
+							: null,
+					},
+					createElement( 'textarea', {
+						id: `ec-studio-${ slug }-caption`,
+						rows: 6,
+						value: caption,
+						onChange: ( event: ChangeEvent< HTMLTextAreaElement > ) => setCaption( event.target.value ),
+						placeholder: sprintf( __( 'Write your %s caption here…', 'extrachill-studio' ), platformLabel ),
+						maxLength: charLimit > 0 ? charLimit : undefined,
+					} )
+				),
+				// 5. Status / error inline messages.
 				error ? h( InlineStatusView, { tone: 'error', className: 'ec-studio-message' }, error ) : null,
 				! error && status ? h( InlineStatusView, { tone: 'success', className: 'ec-studio-message' }, status ) : null,
+				// 6. Action row — Submit for Review / Publish Now.
 				h(
 					ActionRowView,
 					{ className: 'ec-studio-composer__actions' },

--- a/src/blocks/studio/tabs/socials/publish/index.ts
+++ b/src/blocks/studio/tabs/socials/publish/index.ts
@@ -231,9 +231,10 @@ const PlatformPublishPane = ( { slug, label, username, config }: PlatformPublish
 		try {
 			const response = await studioClient.socials.crossPost( {
 				platforms: [ slug ],
-				// SocialImageInput in @extrachill/api-client only declares `url`; DM-Socials accepts
-				// `alt` server-side for platforms that support it (Bluesky, Twitter, Threads).
-				// Cast to bypass the narrower client-side type until the api-client is updated.
+				// SocialImageInput in @extrachill/api-client only declares `url`; DM-Socials
+				// accepts `alt` server-side for platforms that support it (Bluesky, Twitter,
+				// Threads). Cast bypasses the narrower client-side type until
+				// Extra-Chill/extrachill-api-client#11 lands.
 				images: images.map( ( { url, alt } ) => ( { url, alt } ) ) as { url: string }[],
 				caption: caption.trim(),
 			} );

--- a/src/blocks/studio/tabs/socials/publish/index.ts
+++ b/src/blocks/studio/tabs/socials/publish/index.ts
@@ -25,6 +25,12 @@ interface WpPost {
 	id: number;
 }
 
+interface SelectedImage {
+	url: string;
+	alt?: string;
+	title?: string;
+}
+
 /**
  * Generic social platform publishing pane.
  *
@@ -35,7 +41,7 @@ interface WpPost {
 const PlatformPublishPane = ( { slug, label, username, config }: PlatformPublishPaneProps ): ReactElement => {
 	const [ caption, setCaption ] = useState( '' );
 	const [ imageUrlInput, setImageUrlInput ] = useState( '' );
-	const [ imageUrls, setImageUrls ] = useState< string[] >( [] );
+	const [ images, setImages ] = useState< SelectedImage[] >( [] );
 	const [ isPublishing, setIsPublishing ] = useState( false );
 	const [ status, setStatus ] = useState( '' );
 	const [ error, setError ] = useState( '' );
@@ -63,14 +69,21 @@ const PlatformPublishPane = ( { slug, label, username, config }: PlatformPublish
 			return;
 		}
 
-		setImageUrls( ( current ) => [ ...current, nextUrl ] );
+		setImages( ( current ) => [ ...current, { url: nextUrl } ] );
 		setImageUrlInput( '' );
 		setError( '' );
 		setStatus( __( 'External image URL added to publish queue.', 'extrachill-studio' ) );
 	};
 
 	const handleMediaSelect = ( url: string, item: NetworkMediaItem ): void => {
-		setImageUrls( ( current ) => [ ...current, url ] );
+		setImages( ( current ) => [
+			...current,
+			{
+				url,
+				alt: item.alt || undefined,
+				title: item.title || undefined,
+			},
+		] );
 		setError( '' );
 		setStatus(
 			sprintf(
@@ -81,8 +94,8 @@ const PlatformPublishPane = ( { slug, label, username, config }: PlatformPublish
 		);
 	};
 
-	const removeImageUrl = ( index: number ): void => {
-		setImageUrls( ( current ) => current.filter( ( _item, itemIndex ) => itemIndex !== index ) );
+	const removeImageAt = ( index: number ): void => {
+		setImages( ( current ) => current.filter( ( _item, itemIndex ) => itemIndex !== index ) );
 		setStatus( __( 'Image removed from publish queue.', 'extrachill-studio' ) );
 		setError( '' );
 	};
@@ -94,7 +107,7 @@ const PlatformPublishPane = ( { slug, label, username, config }: PlatformPublish
 			return;
 		}
 
-		if ( supportsImages && imageUrls.length === 0 ) {
+		if ( supportsImages && images.length === 0 ) {
 			setError( __( 'Add at least one image before publishing.', 'extrachill-studio' ) );
 			setStatus( '' );
 			return;
@@ -113,7 +126,10 @@ const PlatformPublishPane = ( { slug, label, username, config }: PlatformPublish
 		try {
 			const response = await studioClient.socials.crossPost( {
 				platforms: [ slug ],
-				images: imageUrls.map( ( url ) => ( { url } ) ),
+				// SocialImageInput in @extrachill/api-client only declares `url`; DM-Socials accepts
+				// `alt` server-side for platforms that support it (Bluesky, Twitter, Threads).
+				// Cast to bypass the narrower client-side type until the api-client is updated.
+				images: images.map( ( { url, alt } ) => ( { url, alt } ) ) as { url: string }[],
 				caption: caption.trim(),
 			} );
 
@@ -162,7 +178,7 @@ const PlatformPublishPane = ( { slug, label, username, config }: PlatformPublish
 			setJobResult( platformResult );
 			setStatus( sprintf( __( '%s publish completed.', 'extrachill-studio' ), platformLabel ) );
 			setCaption( '' );
-			setImageUrls( [] );
+			setImages( [] );
 		} catch ( publishError ) {
 			if ( abortController?.signal.aborted ) {
 				// Silently swallow — a new publish was started.
@@ -182,7 +198,7 @@ const PlatformPublishPane = ( { slug, label, username, config }: PlatformPublish
 			return;
 		}
 
-		if ( supportsImages && imageUrls.length === 0 ) {
+		if ( supportsImages && images.length === 0 ) {
 			setError( __( 'Add at least one image before submitting.', 'extrachill-studio' ) );
 			setStatus( '' );
 			return;
@@ -203,8 +219,8 @@ const PlatformPublishPane = ( { slug, label, username, config }: PlatformPublish
 					meta: {
 						_studio_social_platforms: [ slug ],
 						_studio_social_caption: caption.trim(),
-						_studio_social_images: imageUrls.map( ( url ) => ( { url } ) ),
-						_studio_social_media_kind: imageUrls.length > 1 ? 'carousel' : 'image',
+						_studio_social_images: images.map( ( { url, alt, title } ) => ( { url, alt, title } ) ),
+						_studio_social_media_kind: images.length > 1 ? 'carousel' : 'image',
 					},
 				},
 			} );
@@ -213,7 +229,7 @@ const PlatformPublishPane = ( { slug, label, username, config }: PlatformPublish
 				sprintf( __( 'Draft #%d submitted for review. An admin will approve it before it goes live.', 'extrachill-studio' ), post.id )
 			);
 			setCaption( '' );
-			setImageUrls( [] );
+			setImages( [] );
 		} catch ( submitError ) {
 			setStatus( '' );
 			setError( ( submitError as Error )?.message || __( 'Failed to submit draft.', 'extrachill-studio' ) );
@@ -325,18 +341,18 @@ const PlatformPublishPane = ( { slug, label, username, config }: PlatformPublish
 				)
 			)
 		),
-		supportsImages && imageUrls.length > 0
+		supportsImages && images.length > 0
 			? h(
 				PanelView,
 				{ className: 'ec-studio-panel', compact: true },
 				createElement(
 					'ul',
 					{ className: 'ec-studio-image-list' },
-					...imageUrls.map( ( url, index ) => createElement(
+					...images.map( ( image, index ) => createElement(
 						'li',
-						{ key: `${ url }-${ index }`, className: 'ec-studio-image-list__item' },
-						createElement( 'span', { className: 'ec-studio-image-list__url' }, url ),
-						createElement( 'button', { type: 'button', className: 'ec-studio-image-list__remove', onClick: () => removeImageUrl( index ) }, __( 'Remove', 'extrachill-studio' ) )
+						{ key: `${ image.url }-${ index }`, className: 'ec-studio-image-list__item' },
+						createElement( 'span', { className: 'ec-studio-image-list__url' }, image.url ),
+						createElement( 'button', { type: 'button', className: 'ec-studio-image-list__remove', onClick: () => removeImageAt( index ) }, __( 'Remove', 'extrachill-studio' ) )
 					) )
 				)
 			)

--- a/src/blocks/studio/tabs/socials/publish/index.ts
+++ b/src/blocks/studio/tabs/socials/publish/index.ts
@@ -100,6 +100,111 @@ const PlatformPublishPane = ( { slug, label, username, config }: PlatformPublish
 		setError( '' );
 	};
 
+	const moveImage = ( index: number, direction: -1 | 1 ): void => {
+		setImages( ( current ) => {
+			const target = index + direction;
+			if ( target < 0 || target >= current.length ) {
+				return current;
+			}
+			const next = [ ...current ];
+			const [ moved ] = next.splice( index, 1 );
+			next.splice( target, 0, moved );
+			return next;
+		} );
+	};
+
+	/**
+	 * Render the selected-images thumbnail row.
+	 *
+	 * Horizontal flex row of ~80px tiles. Each tile shows the image, a
+	 * remove (×) button overlay, and (for carousel-capable platforms) left/right
+	 * arrow buttons to reorder the image within the array. Returns null when
+	 * the queue is empty so the row collapses entirely.
+	 */
+	const renderImageThumbnails = (): ReactElement | null => {
+		if ( images.length === 0 ) {
+			return null;
+		}
+
+		const supportsReordering = !! config.supportsCarousel && images.length > 1;
+		const lastIndex = images.length - 1;
+
+		return createElement(
+			'ul',
+			{ className: 'ec-studio-image-thumbs', 'aria-label': __( 'Selected images', 'extrachill-studio' ) },
+			...images.map( ( image, index ) => {
+				const label = image.title || image.alt || image.url;
+				return createElement(
+					'li',
+					{
+						key: `${ image.url }-${ index }`,
+						className: 'ec-studio-image-thumbs__tile',
+					},
+					createElement( 'img', {
+						className: 'ec-studio-image-thumbs__image',
+						src: image.url,
+						alt: image.alt || '',
+						title: image.title || image.alt || image.url,
+						loading: 'lazy',
+					} ),
+					createElement(
+						'button',
+						{
+							type: 'button',
+							className: 'ec-studio-image-thumbs__remove',
+							onClick: () => removeImageAt( index ),
+							'aria-label': sprintf(
+								/* translators: %s: image title or filename */
+								__( 'Remove image: %s', 'extrachill-studio' ),
+								label
+							),
+							title: __( 'Remove image', 'extrachill-studio' ),
+						},
+						'×'
+					),
+					supportsReordering
+						? createElement(
+							'div',
+							{ className: 'ec-studio-image-thumbs__reorder' },
+							createElement(
+								'button',
+								{
+									type: 'button',
+									className: 'ec-studio-image-thumbs__move ec-studio-image-thumbs__move--left',
+									onClick: () => moveImage( index, -1 ),
+									disabled: index === 0,
+									'aria-label': sprintf(
+										/* translators: %s: image title or filename */
+										__( 'Move image left: %s', 'extrachill-studio' ),
+										label
+									),
+									title: __( 'Move left', 'extrachill-studio' ),
+								},
+								'‹'
+							),
+							createElement(
+								'button',
+								{
+									type: 'button',
+									className: 'ec-studio-image-thumbs__move ec-studio-image-thumbs__move--right',
+									onClick: () => moveImage( index, 1 ),
+									disabled: index === lastIndex,
+									'aria-label': sprintf(
+										/* translators: %s: image title or filename */
+										__( 'Move image right: %s', 'extrachill-studio' ),
+										label
+									),
+									title: __( 'Move right', 'extrachill-studio' ),
+								},
+								'›'
+							)
+						)
+						: null
+				);
+			} )
+		);
+	};
+
 	const publishPost = async (): Promise< void > => {
 		if ( ! caption.trim() ) {
 			setError( __( 'Add a caption before publishing.', 'extrachill-studio' ) );
@@ -312,6 +417,7 @@ const PlatformPublishPane = ( { slug, label, username, config }: PlatformPublish
 						)
 					)
 					: null,
+				supportsImages ? renderImageThumbnails() : null,
 				error ? h( InlineStatusView, { tone: 'error', className: 'ec-studio-message' }, error ) : null,
 				! error && status ? h( InlineStatusView, { tone: 'success', className: 'ec-studio-message' }, status ) : null,
 				h(
@@ -341,22 +447,6 @@ const PlatformPublishPane = ( { slug, label, username, config }: PlatformPublish
 				)
 			)
 		),
-		supportsImages && images.length > 0
-			? h(
-				PanelView,
-				{ className: 'ec-studio-panel', compact: true },
-				createElement(
-					'ul',
-					{ className: 'ec-studio-image-list' },
-					...images.map( ( image, index ) => createElement(
-						'li',
-						{ key: `${ image.url }-${ index }`, className: 'ec-studio-image-list__item' },
-						createElement( 'span', { className: 'ec-studio-image-list__url' }, image.url ),
-						createElement( 'button', { type: 'button', className: 'ec-studio-image-list__remove', onClick: () => removeImageAt( index ) }, __( 'Remove', 'extrachill-studio' ) )
-					) )
-				)
-			)
-			: null,
 		jobResult
 			? h(
 				PanelView,


### PR DESCRIPTION
## Summary

Two tightly-coupled UX changes to the per-platform socials publish pane that ship together because they touch the same JSX in `src/blocks/studio/tabs/socials/publish/index.ts`.

Closes #38 (layout reorder)
Closes #39 (thumbnail row + alt/title metadata)

## What changed

### 1. State shape: `string[]` → `Array<{ url, alt?, title? }>`

Selected images now carry `alt` and `title` from the underlying `NetworkMediaItem`. Platforms that support per-image alt text (Bluesky, Twitter, Threads) receive it through:

- `studioClient.socials.crossPost({ images: [{ url, alt }, ...] })` — direct publish path
- `_studio_social_images` post-meta on `submitForReview` drafts — admin-approval path

External URLs added through the paste-input only carry `{ url }` (no metadata available).

> The `@extrachill/api-client` `SocialImageInput` type only declares `{ url: string }`. We cast at the `crossPost` call site to bypass it; DM-Socials accepts `alt` server-side already. A follow-up to broaden the api-client type would close that gap cleanly.

### 2. Thumbnail row replaces URL list

The bottom URL list panel is gone. In its place: a horizontal flex row of ~80px image tiles, wrapping to multiple lines for many images. Each tile has:

- **Image** rendered with `object-fit: cover` at 80×80, `alt` and `title` from the image metadata
- **× remove button** absolutely positioned top-right, `aria-label="Remove image: {title|alt|url}"`
- **Left/right arrow buttons** absolutely positioned bottom (only on platforms where `config.supportsCarousel === true` AND `images.length > 1`). Arrows disable at array boundaries. Single-image platforms (Twitter) skip the arrows entirely.

CSS is namespaced `.ec-studio-image-thumbs` / `.ec-studio-image-thumbs__tile` etc. The dead `.ec-studio-image-list*` rules are removed.

### 3. Layout reorder — media picker on top

New order inside `.ec-studio-composer`:

1. Media picker (network media library + upload tile)
2. Selected images thumbnail row
3. External URL field + Add button
4. Caption textarea
5. Status / error inline messages
6. Action row (Submit for Review / Publish Now)

Previously the caption was at the top with the media picker buried between it and the action row — forced a scroll-and-jump dance to compose around queued images.

### 4. Result panel preserved

The "Latest publish result" PanelView (permalink + media id) still renders below the composer. It no longer includes the URL list since thumbnails handle that role now.

## Commits

- \`refactor: change selected-images state shape to carry alt/title metadata\`
- \`feat: thumbnail row replaces URL list for selected social images\`
- \`refactor: reorder socials publish pane so media picker is on top\`

Three logical commits so the diff is reviewable in pieces — state shape change in isolation, then the thumbnail row, then the pure JSX reorder.

## Verification

- \`npm run typecheck\` clean
- \`npm run build\` clean (no warnings, no console errors expected at runtime)
- Worked exclusively in worktree at \`/var/lib/datamachine/workspace/extrachill-studio@socials-publish-redesign\`
- No edits to \`CHANGELOG.md\` or version constants — homeboy owns those at release time
- No release run — release happens after merge

cc @chubes4