### PR TITLE
feat: Transcribe tab backend foundation (Phase B1)

### DIFF
--- a/extrachill-studio.php
+++ b/extrachill-studio.php
@@ -35,6 +35,13 @@ require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/social-drafts.php';
 require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/compose-editor.php';
 require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/abilities/resolve-instagram-media.php';
 require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/abilities/run-giveaway.php';
+require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/transcription/sweatpants-client.php';
+require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/transcription/job-store.php';
+require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/transcription/draft-post-creator.php';
+require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/transcription/rest.php';
+require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/transcription/gc.php';
+require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/abilities/transcribe-recording.php';
+require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/abilities/transcription-job-status.php';
 
 /*
  * Defer loading of GiveawayTask until after Data Machine has registered its
@@ -115,6 +122,7 @@ function extrachill_studio_activate() {
  * @return void
  */
 function extrachill_studio_deactivate() {
+	wp_clear_scheduled_hook( 'ec_studio_transcription_daily_gc' );
 	flush_rewrite_rules();
 }
 

--- a/inc/abilities/transcribe-recording.php
+++ b/inc/abilities/transcribe-recording.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Transcribe Recording Ability
+ *
+ * Submits a WP audio attachment to the sweatpants worker on chubes.net for
+ * transcription, persists a local job row, and returns the sweatpants job id
+ * + initial status. Polling + draft creation happens in
+ * extrachill/transcription-job-status.
+ *
+ * @package    ExtraChillStudio
+ * @subpackage Abilities
+ * @since      0.10.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+use ExtraChillStudio\Transcription\SweatpantsClient;
+
+/**
+ * Register the transcribe-recording ability.
+ *
+ * @since 0.10.0
+ *
+ * @return void
+ */
+function ec_studio_register_transcribe_recording_ability(): void {
+	if ( ! class_exists( 'WP_Ability' ) ) {
+		return;
+	}
+
+	$register = function () {
+		wp_register_ability(
+			'extrachill/transcribe-recording',
+			array(
+				'label'               => __( 'Transcribe Recording', 'extrachill-studio' ),
+				'description'         => __( 'Submit a WP audio attachment to the sweatpants worker for transcription.', 'extrachill-studio' ),
+				'category'            => 'extrachill',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'attachment_id'  => array(
+							'type'        => 'integer',
+							'description' => __( 'WP attachment ID for the audio file.', 'extrachill-studio' ),
+						),
+						'model'          => array(
+							'type'        => 'string',
+							'enum'        => array( 'base', 'medium', 'large' ),
+							'default'     => 'medium',
+							'description' => __( 'Whisper model size.', 'extrachill-studio' ),
+						),
+						'diarize'        => array(
+							'type'        => 'boolean',
+							'default'     => false,
+							'description' => __( 'Run PyAnnote speaker diarization.', 'extrachill-studio' ),
+						),
+						'remove_fillers' => array(
+							'type'        => 'boolean',
+							'default'     => false,
+							'description' => __( 'Strip filler words from the transcript.', 'extrachill-studio' ),
+						),
+					),
+					'required'   => array( 'attachment_id' ),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'job_id' => array( 'type' => 'string' ),
+						'status' => array( 'type' => 'string' ),
+					),
+				),
+				'execute_callback'    => 'ec_studio_execute_transcribe_recording',
+				'permission_callback' => function () {
+					return current_user_can( 'manage_options' ) || ( function_exists( 'ec_is_team_member' ) && \ec_is_team_member() );
+				},
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+	};
+
+	if ( doing_action( 'wp_abilities_api_init' ) ) {
+		$register();
+	} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+		add_action( 'wp_abilities_api_init', $register );
+	}
+}
+ec_studio_register_transcribe_recording_ability();
+
+/**
+ * Execute callback for transcribe-recording.
+ *
+ * @since 0.10.0
+ *
+ * @param array $input Validated input.
+ * @return array|\WP_Error
+ */
+function ec_studio_execute_transcribe_recording( array $input ): array|\WP_Error {
+	$attachment_id  = (int) ( $input['attachment_id'] ?? 0 );
+	$model          = isset( $input['model'] ) ? (string) $input['model'] : 'medium';
+	$diarize        = ! empty( $input['diarize'] );
+	$remove_fillers = ! empty( $input['remove_fillers'] );
+
+	if ( $attachment_id <= 0 ) {
+		return new \WP_Error( 'invalid_attachment', __( 'attachment_id is required and must be a positive integer.', 'extrachill-studio' ), array( 'status' => 400 ) );
+	}
+
+	$attachment = get_post( $attachment_id );
+	if ( ! $attachment || 'attachment' !== $attachment->post_type ) {
+		return new \WP_Error( 'attachment_not_found', __( 'Attachment not found.', 'extrachill-studio' ), array( 'status' => 404 ) );
+	}
+
+	if ( ! wp_attachment_is( 'audio', $attachment ) ) {
+		return new \WP_Error( 'not_audio', __( 'Attachment is not an audio file.', 'extrachill-studio' ), array( 'status' => 400 ) );
+	}
+
+	$user_id = get_current_user_id();
+	if ( $user_id <= 0 ) {
+		return new \WP_Error( 'not_logged_in', __( 'You must be logged in to transcribe recordings.', 'extrachill-studio' ), array( 'status' => 401 ) );
+	}
+
+	if ( ! function_exists( 'ec_has_main_site_account' ) || ! \ec_has_main_site_account( $user_id ) ) {
+		return new \WP_Error(
+			'no_main_site_account',
+			__( 'You must have an account on the main extrachill.com site to author transcription drafts.', 'extrachill-studio' ),
+			array( 'status' => 403 )
+		);
+	}
+
+	$attachment_url = wp_get_attachment_url( $attachment_id );
+	if ( ! $attachment_url ) {
+		return new \WP_Error( 'attachment_url_missing', __( 'Could not resolve a URL for the attachment.', 'extrachill-studio' ), array( 'status' => 500 ) );
+	}
+
+	$inputs = array(
+		'audio_url'      => $attachment_url,
+		'output_dir'     => '/var/lib/sweatpants/output/' . wp_generate_uuid4(),
+		'model'          => $model,
+		'diarize'        => $diarize,
+		'remove_fillers' => $remove_fillers,
+		'language'       => 'en',
+	);
+
+	$client   = new SweatpantsClient();
+	$response = $client->submit_job( 'audio-transcription', $inputs );
+
+	if ( is_wp_error( $response ) ) {
+		return $response;
+	}
+
+	$job_id = isset( $response['id'] ) ? (string) $response['id'] : '';
+	if ( '' === $job_id ) {
+		return new \WP_Error( 'sweatpants_bad_response', __( 'Sweatpants response is missing the job id.', 'extrachill-studio' ), array( 'status' => 502 ) );
+	}
+
+	$status = isset( $response['status'] ) ? (string) $response['status'] : 'pending';
+
+	ec_studio_transcription_save_job(
+		$job_id,
+		array(
+			'job_id'         => $job_id,
+			'attachment_id'  => $attachment_id,
+			'attachment_url' => $attachment_url,
+			'user_id'        => $user_id,
+			'model'          => $model,
+			'diarize'        => $diarize,
+			'remove_fillers' => $remove_fillers,
+			'target_blog_id' => 1,
+			'status'         => $status,
+			'created_at'     => current_time( 'c', true ),
+			'completed_at'   => null,
+			'draft_post_id'  => null,
+			'draft_post_url' => null,
+			'error'          => null,
+		)
+	);
+
+	return array(
+		'job_id' => $job_id,
+		'status' => $status,
+	);
+}

--- a/inc/abilities/transcription-job-status.php
+++ b/inc/abilities/transcription-job-status.php
@@ -1,0 +1,203 @@
+<?php
+/**
+ * Transcription Job Status Ability
+ *
+ * Polls the sweatpants worker for a job's current state and, on the first
+ * poll where sweatpants reports `completed`, fetches the results, picks the
+ * appropriate transcript flavour based on the job's diarize/remove_fillers
+ * flags, and creates a draft post on the target blog.
+ *
+ * Cached terminal states (completed/failed) short-circuit the remote call so
+ * UI polling stays cheap once the job has resolved.
+ *
+ * @package    ExtraChillStudio
+ * @subpackage Abilities
+ * @since      0.10.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+use ExtraChillStudio\Transcription\SweatpantsClient;
+
+/**
+ * Register the transcription-job-status ability.
+ *
+ * @since 0.10.0
+ *
+ * @return void
+ */
+function ec_studio_register_transcription_job_status_ability(): void {
+	if ( ! class_exists( 'WP_Ability' ) ) {
+		return;
+	}
+
+	$register = function () {
+		wp_register_ability(
+			'extrachill/transcription-job-status',
+			array(
+				'label'               => __( 'Transcription Job Status', 'extrachill-studio' ),
+				'description'         => __( 'Poll a transcription job and create a draft post once it completes.', 'extrachill-studio' ),
+				'category'            => 'extrachill',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'job_id' => array(
+							'type'        => 'string',
+							'description' => __( 'Sweatpants job UUID.', 'extrachill-studio' ),
+						),
+					),
+					'required'   => array( 'job_id' ),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'job_id'         => array( 'type' => 'string' ),
+						'status'         => array( 'type' => 'string' ),
+						'draft_post_id'  => array( 'type' => 'integer' ),
+						'draft_post_url' => array( 'type' => 'string' ),
+						'error'          => array( 'type' => 'string' ),
+					),
+				),
+				'execute_callback'    => 'ec_studio_execute_transcription_job_status',
+				'permission_callback' => function () {
+					return current_user_can( 'manage_options' ) || ( function_exists( 'ec_is_team_member' ) && \ec_is_team_member() );
+				},
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+	};
+
+	if ( doing_action( 'wp_abilities_api_init' ) ) {
+		$register();
+	} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+		add_action( 'wp_abilities_api_init', $register );
+	}
+}
+ec_studio_register_transcription_job_status_ability();
+
+/**
+ * Pick the appropriate transcript content flavour from a results envelope.
+ *
+ * @since 0.10.0
+ *
+ * @param array $data            results[0].data payload from sweatpants.
+ * @param bool  $diarize         Whether the job was diarized.
+ * @param bool  $remove_fillers  Whether filler-removal was requested.
+ * @return string Transcript content (may be empty if all fallbacks miss).
+ */
+function ec_studio_transcription_pick_transcript_content( array $data, bool $diarize, bool $remove_fillers ): string {
+	$content = isset( $data['content'] ) && is_array( $data['content'] ) ? $data['content'] : array();
+
+	$pick = static function ( array $bag, array $keys ): string {
+		foreach ( $keys as $key ) {
+			if ( isset( $bag[ $key ] ) && is_string( $bag[ $key ] ) && '' !== trim( $bag[ $key ] ) ) {
+				return (string) $bag[ $key ];
+			}
+		}
+		return '';
+	};
+
+	if ( $diarize && $remove_fillers ) {
+		return $pick( $content, array( 'combined_txt_clean', 'combined_txt', 'transcription' ) );
+	}
+	if ( $diarize ) {
+		return $pick( $content, array( 'combined_txt', 'transcription' ) );
+	}
+	return $pick( $content, array( 'transcription' ) );
+}
+
+/**
+ * Execute callback for transcription-job-status.
+ *
+ * @since 0.10.0
+ *
+ * @param array $input Validated input.
+ * @return array|\WP_Error
+ */
+function ec_studio_execute_transcription_job_status( array $input ): array|\WP_Error {
+	$job_id = isset( $input['job_id'] ) ? (string) $input['job_id'] : '';
+	if ( '' === $job_id ) {
+		return new \WP_Error( 'invalid_job_id', __( 'job_id is required.', 'extrachill-studio' ), array( 'status' => 400 ) );
+	}
+
+	$job = ec_studio_transcription_get_job( $job_id );
+	if ( null === $job ) {
+		return new \WP_Error( 'job_not_found', __( 'Transcription job not found.', 'extrachill-studio' ), array( 'status' => 404 ) );
+	}
+
+	$current_user = get_current_user_id();
+	if ( (int) ( $job['user_id'] ?? 0 ) !== $current_user && ! current_user_can( 'manage_options' ) ) {
+		return new \WP_Error( 'forbidden', __( 'You do not have permission to view this job.', 'extrachill-studio' ), array( 'status' => 403 ) );
+	}
+
+	$cached_status = (string) ( $job['status'] ?? '' );
+	if ( 'completed' === $cached_status || 'failed' === $cached_status ) {
+		return $job;
+	}
+
+	$client   = new SweatpantsClient();
+	$response = $client->get_job( $job_id );
+	if ( is_wp_error( $response ) ) {
+		return $response;
+	}
+
+	$remote_status = isset( $response['status'] ) ? (string) $response['status'] : $cached_status;
+	$job['status'] = $remote_status;
+
+	if ( 'completed' === $remote_status && empty( $job['draft_post_id'] ) ) {
+		$results = $client->get_job_results( $job_id );
+		if ( is_wp_error( $results ) ) {
+			return $results;
+		}
+
+		$rows = isset( $results['results'] ) && is_array( $results['results'] ) ? $results['results'] : array();
+		$data = array();
+		if ( isset( $rows[0]['data'] ) && is_array( $rows[0]['data'] ) ) {
+			$data = $rows[0]['data'];
+		}
+
+		$transcript = ec_studio_transcription_pick_transcript_content(
+			$data,
+			! empty( $job['diarize'] ),
+			! empty( $job['remove_fillers'] )
+		);
+
+		if ( '' === $transcript ) {
+			$job['status'] = 'failed';
+			$job['error']  = 'Transcript content missing from sweatpants response';
+			ec_studio_transcription_save_job( $job_id, $job );
+			return $job;
+		}
+
+		$draft_result = ec_studio_transcription_create_draft( $job, $transcript );
+		if ( is_wp_error( $draft_result ) ) {
+			$job['status'] = 'failed';
+			$job['error']  = $draft_result->get_error_message();
+			ec_studio_transcription_save_job( $job_id, $job );
+			return $job;
+		}
+
+		$post_id        = (int) $draft_result;
+		$target_blog_id = (int) ( $job['target_blog_id'] ?? 1 );
+
+		switch_to_blog( $target_blog_id );
+		$edit_url = (string) get_edit_post_link( $post_id, 'raw' );
+		restore_current_blog();
+
+		$job['draft_post_id']  = $post_id;
+		$job['draft_post_url'] = $edit_url;
+		$job['completed_at']   = current_time( 'c', true );
+		$job['error']          = null;
+	} elseif ( 'failed' === $remote_status ) {
+		$remote_error = '';
+		if ( isset( $response['error'] ) && is_string( $response['error'] ) ) {
+			$remote_error = $response['error'];
+		} elseif ( isset( $response['error']['message'] ) && is_string( $response['error']['message'] ) ) {
+			$remote_error = $response['error']['message'];
+		}
+		$job['error'] = $remote_error !== '' ? $remote_error : 'Sweatpants reported failure with no error detail.';
+	}
+
+	ec_studio_transcription_save_job( $job_id, $job );
+	return $job;
+}

--- a/inc/transcription/draft-post-creator.php
+++ b/inc/transcription/draft-post-creator.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Draft Post Creator
+ *
+ * Cross-blog draft post creation for completed transcriptions. Creates a draft
+ * on the target blog (default blog_id=1, the main extrachill.com site) under
+ * the uploading user's authorship. extrachill-users guarantees user_id parity
+ * across the network so post_author is the same id everywhere.
+ *
+ * @package    ExtraChillStudio
+ * @subpackage Transcription
+ * @since      0.10.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Create a draft post on the target blog with the transcription content.
+ *
+ * @since 0.10.0
+ *
+ * @param array  $job                 Persisted job row.
+ * @param string $transcript_content  Transcript body to use as post_content.
+ * @return int|\WP_Error Draft post ID on success, WP_Error on failure.
+ */
+function ec_studio_transcription_create_draft( array $job, string $transcript_content ): int|\WP_Error {
+	$user_id        = (int) ( $job['user_id'] ?? 0 );
+	$target_blog_id = (int) ( $job['target_blog_id'] ?? 1 );
+
+	if ( $user_id <= 0 ) {
+		return new \WP_Error(
+			'invalid_user',
+			__( 'Job is missing a valid user_id.', 'extrachill-studio' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	if ( ! function_exists( 'ec_has_main_site_account' ) || ! \ec_has_main_site_account( $user_id ) ) {
+		return new \WP_Error(
+			'no_main_site_account',
+			__( 'User does not have an account on the main site and cannot author drafts there.', 'extrachill-studio' ),
+			array( 'status' => 403 )
+		);
+	}
+
+	if ( '' === trim( $transcript_content ) ) {
+		return new \WP_Error(
+			'empty_transcript',
+			__( 'Transcript content is empty.', 'extrachill-studio' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	$attachment_url   = (string) ( $job['attachment_url'] ?? '' );
+	$attachment_id    = (int) ( $job['attachment_id'] ?? 0 );
+	$created_at       = (string) ( $job['created_at'] ?? '' );
+	$created_ts       = $created_at ? strtotime( $created_at ) : false;
+	$created_ts       = $created_ts ?: time();
+
+	$title = sprintf(
+		/* translators: 1: source recording filename, 2: human-readable date */
+		__( 'Transcription: %1$s — %2$s', 'extrachill-studio' ),
+		wp_basename( $attachment_url ),
+		wp_date( 'M j, Y', $created_ts )
+	);
+
+	$postarr = array(
+		'post_title'   => $title,
+		'post_status'  => 'draft',
+		'post_author'  => $user_id,
+		'post_content' => $transcript_content,
+		'post_type'    => 'post',
+		'meta_input'   => array(
+			'_studio_source_recording_url'   => $attachment_url,
+			'_studio_source_recording_id'    => $attachment_id,
+			'_studio_transcription_model'    => (string) ( $job['model'] ?? '' ),
+			'_studio_transcription_diarized' => ! empty( $job['diarize'] ) ? '1' : '0',
+			'_studio_transcription_job_id'   => (string) ( $job['job_id'] ?? '' ),
+		),
+	);
+
+	switch_to_blog( $target_blog_id );
+
+	try {
+		$result = wp_insert_post( $postarr, true );
+	} finally {
+		restore_current_blog();
+	}
+
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	$post_id = (int) $result;
+	if ( $post_id <= 0 ) {
+		return new \WP_Error(
+			'draft_create_failed',
+			__( 'wp_insert_post returned 0; draft was not created.', 'extrachill-studio' ),
+			array( 'status' => 500 )
+		);
+	}
+
+	return $post_id;
+}

--- a/inc/transcription/gc.php
+++ b/inc/transcription/gc.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Transcription GC Cron
+ *
+ * Daily WP cron event that purges transcription job rows older than 30 days.
+ * The hook itself is unscheduled in extrachill_studio_deactivate().
+ *
+ * @package    ExtraChillStudio
+ * @subpackage Transcription
+ * @since      0.10.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+const EC_STUDIO_TRANSCRIPTION_GC_HOOK = 'ec_studio_transcription_daily_gc';
+
+/**
+ * Schedule the daily GC event if it isn't already scheduled.
+ *
+ * @since 0.10.0
+ *
+ * @return void
+ */
+function ec_studio_transcription_schedule_gc(): void {
+	if ( ! wp_next_scheduled( EC_STUDIO_TRANSCRIPTION_GC_HOOK ) ) {
+		wp_schedule_event( time() + HOUR_IN_SECONDS, 'daily', EC_STUDIO_TRANSCRIPTION_GC_HOOK );
+	}
+}
+add_action( 'init', 'ec_studio_transcription_schedule_gc' );
+
+/**
+ * Cron handler — purges jobs older than 30 days.
+ *
+ * @since 0.10.0
+ *
+ * @return void
+ */
+function ec_studio_transcription_run_gc(): void {
+	$purged = ec_studio_transcription_gc_old_jobs( 30 );
+	if ( $purged > 0 ) {
+		error_log( sprintf( '[ExtraChillStudio][Transcription] GC purged %d jobs older than 30 days', $purged ) );
+	}
+}
+add_action( EC_STUDIO_TRANSCRIPTION_GC_HOOK, 'ec_studio_transcription_run_gc' );

--- a/inc/transcription/job-store.php
+++ b/inc/transcription/job-store.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Transcription Job Store
+ *
+ * Per-site option-backed persistence for transcription job rows. Index lives in
+ * `ec_studio_transcription_jobs`, keyed by sweatpants job UUID.
+ *
+ * Concurrency note: option writes can race under high concurrency. Acceptable
+ * for v1 (max ~5 users, ~1-2 jobs/month). If volume grows substantially, swap
+ * to a custom table. The public function signatures are stable so the swap is
+ * a backend-only refactor.
+ *
+ * Job row schema:
+ *   job_id, attachment_id, attachment_url, user_id, model, diarize,
+ *   remove_fillers, target_blog_id, status, created_at, completed_at,
+ *   draft_post_id, draft_post_url, error
+ *
+ * @package    ExtraChillStudio
+ * @subpackage Transcription
+ * @since      0.10.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+const EC_STUDIO_TRANSCRIPTION_JOBS_OPTION = 'ec_studio_transcription_jobs';
+
+/**
+ * Read the full jobs index from the option.
+ *
+ * @since 0.10.0
+ *
+ * @return array Map of job_id => row.
+ */
+function ec_studio_transcription_get_all_jobs(): array {
+	$jobs = get_option( EC_STUDIO_TRANSCRIPTION_JOBS_OPTION, array() );
+	return is_array( $jobs ) ? $jobs : array();
+}
+
+/**
+ * Upsert a job row. Existing rows are merged with new data.
+ *
+ * @since 0.10.0
+ *
+ * @param string $job_id Sweatpants job UUID.
+ * @param array  $data   Partial or full row data.
+ * @return void
+ */
+function ec_studio_transcription_save_job( string $job_id, array $data ): void {
+	if ( '' === $job_id ) {
+		return;
+	}
+
+	$jobs            = ec_studio_transcription_get_all_jobs();
+	$existing        = isset( $jobs[ $job_id ] ) && is_array( $jobs[ $job_id ] ) ? $jobs[ $job_id ] : array();
+	$merged          = array_merge( $existing, $data );
+	$merged['job_id'] = $job_id;
+
+	$jobs[ $job_id ] = $merged;
+
+	update_option( EC_STUDIO_TRANSCRIPTION_JOBS_OPTION, $jobs, false );
+}
+
+/**
+ * Fetch a single job row by job_id.
+ *
+ * @since 0.10.0
+ *
+ * @param string $job_id Sweatpants job UUID.
+ * @return array|null Job row or null if missing.
+ */
+function ec_studio_transcription_get_job( string $job_id ): ?array {
+	$jobs = ec_studio_transcription_get_all_jobs();
+	if ( isset( $jobs[ $job_id ] ) && is_array( $jobs[ $job_id ] ) ) {
+		return $jobs[ $job_id ];
+	}
+	return null;
+}
+
+/**
+ * List a user's jobs, newest first.
+ *
+ * @since 0.10.0
+ *
+ * @param int $user_id User ID.
+ * @param int $limit   Max rows to return (hard-capped at 100).
+ * @return array List of job rows.
+ */
+function ec_studio_transcription_list_user_jobs( int $user_id, int $limit = 20 ): array {
+	$limit = max( 1, min( 100, $limit ) );
+	$jobs  = ec_studio_transcription_get_all_jobs();
+	$mine  = array();
+
+	foreach ( $jobs as $row ) {
+		if ( ! is_array( $row ) ) {
+			continue;
+		}
+		if ( (int) ( $row['user_id'] ?? 0 ) === $user_id ) {
+			$mine[] = $row;
+		}
+	}
+
+	usort(
+		$mine,
+		static function ( $a, $b ) {
+			$at = strtotime( $a['created_at'] ?? '' ) ?: 0;
+			$bt = strtotime( $b['created_at'] ?? '' ) ?: 0;
+			return $bt <=> $at;
+		}
+	);
+
+	return array_slice( $mine, 0, $limit );
+}
+
+/**
+ * Delete a job row.
+ *
+ * @since 0.10.0
+ *
+ * @param string $job_id Sweatpants job UUID.
+ * @return bool True if a row was removed.
+ */
+function ec_studio_transcription_delete_job( string $job_id ): bool {
+	$jobs = ec_studio_transcription_get_all_jobs();
+	if ( ! isset( $jobs[ $job_id ] ) ) {
+		return false;
+	}
+
+	unset( $jobs[ $job_id ] );
+	update_option( EC_STUDIO_TRANSCRIPTION_JOBS_OPTION, $jobs, false );
+	return true;
+}
+
+/**
+ * Garbage-collect job rows older than $age_days.
+ *
+ * @since 0.10.0
+ *
+ * @param int $age_days Maximum age in days.
+ * @return int Count of rows purged.
+ */
+function ec_studio_transcription_gc_old_jobs( int $age_days = 30 ): int {
+	$age_days = max( 1, $age_days );
+	$cutoff   = time() - ( $age_days * DAY_IN_SECONDS );
+	$jobs     = ec_studio_transcription_get_all_jobs();
+	$purged   = 0;
+
+	foreach ( $jobs as $job_id => $row ) {
+		if ( ! is_array( $row ) ) {
+			unset( $jobs[ $job_id ] );
+			$purged++;
+			continue;
+		}
+		$created = strtotime( $row['created_at'] ?? '' );
+		if ( false === $created || $created < $cutoff ) {
+			unset( $jobs[ $job_id ] );
+			$purged++;
+		}
+	}
+
+	if ( $purged > 0 ) {
+		update_option( EC_STUDIO_TRANSCRIPTION_JOBS_OPTION, $jobs, false );
+	}
+
+	return $purged;
+}

--- a/inc/transcription/rest.php
+++ b/inc/transcription/rest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Transcription REST Routes
+ *
+ * Two thin REST handlers that delegate entirely to abilities. Per the platform
+ * contract, the REST layer owns no business logic — it only resolves the
+ * ability and calls execute().
+ *
+ * Routes live under `extrachill/v1/transcribe*`, which the route-affinity
+ * middleware in extrachill-api forwards to the owning subsite automatically
+ * for cross-site requests. No special wiring needed.
+ *
+ * @package    ExtraChillStudio
+ * @subpackage Transcription
+ * @since      0.10.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Register the transcribe REST routes.
+ *
+ * @since 0.10.0
+ *
+ * @return void
+ */
+function ec_studio_transcription_register_rest_routes(): void {
+	register_rest_route(
+		'extrachill/v1',
+		'/transcribe',
+		array(
+			'methods'             => 'POST',
+			'callback'            => static function ( \WP_REST_Request $request ) {
+				if ( ! function_exists( 'wp_get_ability' ) ) {
+					return new \WP_Error( 'ability_unavailable', __( 'Abilities API is not available.', 'extrachill-studio' ), array( 'status' => 500 ) );
+				}
+				$ability = wp_get_ability( 'extrachill/transcribe-recording' );
+				if ( ! $ability ) {
+					return new \WP_Error( 'ability_unavailable', __( 'extrachill/transcribe-recording ability is not registered.', 'extrachill-studio' ), array( 'status' => 500 ) );
+				}
+				$params = $request->get_json_params();
+				return $ability->execute( is_array( $params ) ? $params : array() );
+			},
+			'permission_callback' => static function () {
+				return current_user_can( 'manage_options' ) || ( function_exists( 'ec_is_team_member' ) && \ec_is_team_member() );
+			},
+		)
+	);
+
+	register_rest_route(
+		'extrachill/v1',
+		'/transcribe/(?P<job_id>[a-f0-9-]+)',
+		array(
+			'methods'             => 'GET',
+			'callback'            => static function ( \WP_REST_Request $request ) {
+				if ( ! function_exists( 'wp_get_ability' ) ) {
+					return new \WP_Error( 'ability_unavailable', __( 'Abilities API is not available.', 'extrachill-studio' ), array( 'status' => 500 ) );
+				}
+				$ability = wp_get_ability( 'extrachill/transcription-job-status' );
+				if ( ! $ability ) {
+					return new \WP_Error( 'ability_unavailable', __( 'extrachill/transcription-job-status ability is not registered.', 'extrachill-studio' ), array( 'status' => 500 ) );
+				}
+				return $ability->execute( array( 'job_id' => (string) $request['job_id'] ) );
+			},
+			'permission_callback' => static function () {
+				return current_user_can( 'manage_options' ) || ( function_exists( 'ec_is_team_member' ) && \ec_is_team_member() );
+			},
+		)
+	);
+}
+add_action( 'rest_api_init', 'ec_studio_transcription_register_rest_routes' );

--- a/inc/transcription/sweatpants-client.php
+++ b/inc/transcription/sweatpants-client.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Sweatpants HTTP Client
+ *
+ * Thin wrapper around wp_remote_* for the sweatpants worker API on chubes.net.
+ * Reads base URL + bearer token from network options (sweatpants_base_url,
+ * sweatpants_api_token). All methods return parsed array on 2xx, WP_Error
+ * otherwise with a stable error code for callers to branch on.
+ *
+ * @package    ExtraChillStudio
+ * @subpackage Transcription
+ * @since      0.10.0
+ */
+
+namespace ExtraChillStudio\Transcription;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * SweatpantsClient
+ *
+ * @since 0.10.0
+ */
+class SweatpantsClient {
+
+	/**
+	 * Base URL of the sweatpants API (no trailing slash).
+	 *
+	 * @var string
+	 */
+	private string $base_url;
+
+	/**
+	 * Bearer token for the sweatpants API.
+	 *
+	 * @var string
+	 */
+	private string $token;
+
+	/**
+	 * Constructor. Resolves base URL + token from network options.
+	 *
+	 * @since 0.10.0
+	 */
+	public function __construct() {
+		$this->base_url = untrailingslashit( (string) get_site_option( 'sweatpants_base_url', '' ) );
+		$this->token    = (string) get_site_option( 'sweatpants_api_token', '' );
+	}
+
+	/**
+	 * Submit a new job to sweatpants.
+	 *
+	 * @since 0.10.0
+	 *
+	 * @param string $module_id Sweatpants module slug (e.g. 'audio-transcription').
+	 * @param array  $inputs    Module-specific inputs (e.g. audio_url, output_dir).
+	 * @param array  $settings  Optional module-specific settings.
+	 * @return array|\WP_Error Parsed response on 2xx, WP_Error otherwise.
+	 */
+	public function submit_job( string $module_id, array $inputs, array $settings = array() ): array|\WP_Error {
+		$body = array(
+			'module_id' => $module_id,
+			'inputs'    => $inputs,
+		);
+		if ( ! empty( $settings ) ) {
+			$body['settings'] = $settings;
+		}
+
+		return $this->request( 'POST', '/jobs', $body, 60 );
+	}
+
+	/**
+	 * Fetch a job's current state.
+	 *
+	 * @since 0.10.0
+	 *
+	 * @param string $job_id Sweatpants job UUID.
+	 * @return array|\WP_Error Parsed response on 2xx, WP_Error otherwise.
+	 */
+	public function get_job( string $job_id ): array|\WP_Error {
+		return $this->request( 'GET', '/jobs/' . rawurlencode( $job_id ), null, 10 );
+	}
+
+	/**
+	 * Fetch a completed job's results envelope.
+	 *
+	 * @since 0.10.0
+	 *
+	 * @param string $job_id Sweatpants job UUID.
+	 * @return array|\WP_Error Parsed response on 2xx, WP_Error otherwise.
+	 */
+	public function get_job_results( string $job_id ): array|\WP_Error {
+		return $this->request( 'GET', '/jobs/' . rawurlencode( $job_id ) . '/results', null, 10 );
+	}
+
+	/**
+	 * Internal request dispatcher.
+	 *
+	 * @since 0.10.0
+	 *
+	 * @param string     $method   HTTP method.
+	 * @param string     $path     Path beginning with '/'.
+	 * @param array|null $body     Optional JSON body.
+	 * @param int        $timeout  Request timeout in seconds.
+	 * @return array|\WP_Error
+	 */
+	private function request( string $method, string $path, ?array $body, int $timeout ): array|\WP_Error {
+		if ( '' === $this->base_url || '' === $this->token ) {
+			return new \WP_Error(
+				'sweatpants_unauthorized',
+				__( 'Sweatpants base URL or API token is not configured.', 'extrachill-studio' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		$url  = $this->base_url . $path;
+		$args = array(
+			'method'  => $method,
+			'timeout' => $timeout,
+			'headers' => array(
+				'Authorization' => 'Bearer ' . $this->token,
+				'Accept'        => 'application/json',
+			),
+		);
+
+		if ( null !== $body ) {
+			$args['headers']['Content-Type'] = 'application/json';
+			$args['body']                    = wp_json_encode( $body );
+		}
+
+		$response = wp_remote_request( $url, $args );
+
+		if ( is_wp_error( $response ) ) {
+			$msg = $response->get_error_message();
+			error_log( '[ExtraChillStudio][Transcription] sweatpants unreachable ' . $method . ' ' . $path . ' — ' . $msg );
+			return new \WP_Error( 'sweatpants_unreachable', $msg, array( 'status' => 502 ) );
+		}
+
+		$code     = (int) wp_remote_retrieve_response_code( $response );
+		$raw_body = (string) wp_remote_retrieve_body( $response );
+
+		if ( $code >= 200 && $code < 300 ) {
+			$data = json_decode( $raw_body, true );
+			if ( ! is_array( $data ) ) {
+				error_log( '[ExtraChillStudio][Transcription] sweatpants non-JSON ' . $method . ' ' . $path . ' status=' . $code . ' body=' . substr( $raw_body, 0, 500 ) );
+				return new \WP_Error( 'sweatpants_bad_response', __( 'Sweatpants returned a non-JSON response.', 'extrachill-studio' ), array( 'status' => 502 ) );
+			}
+			return $data;
+		}
+
+		$truncated = substr( $raw_body, 0, 500 );
+		error_log( '[ExtraChillStudio][Transcription] sweatpants error ' . $method . ' ' . $path . ' status=' . $code . ' body=' . $truncated );
+
+		if ( 401 === $code || 403 === $code ) {
+			return new \WP_Error( 'sweatpants_unauthorized', __( 'Sweatpants rejected the bearer token.', 'extrachill-studio' ), array( 'status' => 502 ) );
+		}
+		if ( 404 === $code ) {
+			return new \WP_Error( 'sweatpants_job_not_found', __( 'Sweatpants job not found.', 'extrachill-studio' ), array( 'status' => 404 ) );
+		}
+		if ( $code >= 500 ) {
+			return new \WP_Error( 'sweatpants_server_error', sprintf( __( 'Sweatpants server error (HTTP %d).', 'extrachill-studio' ), $code ), array( 'status' => 502 ) );
+		}
+
+		return new \WP_Error( 'sweatpants_bad_response', sprintf( __( 'Sweatpants returned HTTP %d.', 'extrachill-studio' ), $code ), array( 'status' => 502 ) );
+	}
+}


### PR DESCRIPTION
## Summary

Backend foundation for the Transcribe tab (extrachill-studio#3). Builds the WordPress side of a cross-host transcription pipeline that hands audio to a sweatpants worker on `chubes.net` and writes the resulting transcript as a draft post on the main `extrachill.com` site.

**No UI in this PR.** A React tab pane (Phase B2) ships separately so this can be reviewed and exercised via curl first.

## What changed

7 new files + 1 edit to the main plugin file:

- `inc/transcription/sweatpants-client.php` — HTTP client for the sweatpants API (3 methods: submit_job, get_job, get_job_results) with stable error codes (`sweatpants_unauthorized`, `sweatpants_job_not_found`, `sweatpants_unreachable`, `sweatpants_bad_response`, `sweatpants_server_error`)
- `inc/transcription/job-store.php` — Per-site option-backed store for transcription jobs (5 functions: save/get/list_user/delete/gc). Includes a comment acknowledging the option-write race window — acceptable at expected volume
- `inc/transcription/draft-post-creator.php` — Cross-blog draft post creator. `switch_to_blog` → `wp_insert_post` wrapped in `try/finally` so `restore_current_blog()` always runs
- `inc/transcription/rest.php` — Two REST routes, thin wrappers over abilities
- `inc/transcription/gc.php` — Daily WP cron purging jobs >30d old
- `inc/abilities/transcribe-recording.php` — Ability that submits an attachment to sweatpants. Validates audio mime type, requires a main-site account (defensive `ec_has_main_site_account` check at submission time)
- `inc/abilities/transcription-job-status.php` — Ability that polls + creates draft on completion. Cached terminal states (completed/failed) short-circuit the remote call. Picks the right transcript flavour based on `diarize` + `remove_fillers` (`combined_txt_clean` → `combined_txt` → `transcription` fallback chain)

## Test plan

After merge + deploy:

```bash
# Submit a job manually via curl using a real WP attachment ID:
curl -X POST https://studio.extrachill.com/wp-json/extrachill/v1/transcribe \
  -H "Cookie: <admin session>" \
  -H "Content-Type: application/json" \
  -d '{"attachment_id": 12345, "model": "medium"}'

# Poll until done:
curl https://studio.extrachill.com/wp-json/extrachill/v1/transcribe/<job_id> -H "Cookie: ..."

# Verify draft post appears on extrachill.com under the user's authorship.
```

## Architecture notes

- Sweatpants base URL + bearer token already stored in network options (`sweatpants_base_url`, `sweatpants_api_token`); no new credential UI in this PR.
- Job state lives in a per-site option `ec_studio_transcription_jobs` (NOT a new DB table) keyed by sweatpants UUID. At expected volume (1–2/month × ~5 team members) the option-based store is fine; if it grows, swapping to a table is a backend-only change since the public function signatures are stable.
- Draft posts land on `blog_id=1` (main extrachill.com) via `switch_to_blog`, with `post_author = current_user_id` (extrachill-users guarantees user_id parity across the network).
- Defensive `ec_has_main_site_account()` checks at both submission time (in the ability) and creation time (in the draft creator) — if a Studio user somehow isn't on the main site, fail fast with a clear error.
- Routes live under `extrachill/v1/transcribe*`. The route-affinity middleware in extrachill-api forwards cross-site requests automatically — no special wiring needed.

## Backward compat

Pure additive — new files, new option, new abilities, new REST routes, new daily cron. No existing surfaces touched. Deactivation hook now also clears the GC cron event.

## Out of scope

- React/Gutenberg block changes (Phase B2)
- Translation strings beyond `__()` wrappers (Phase B4)
- Tests (Phase B4 once the plugin has a harness)
- CHANGELOG / version bump (homeboy at release time)

cc <@532385681268408341>