### PR TITLE
refactor: drop SocialImageInput cast, bump api-client to 0.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
 				"@extrachill/tokens": "^0.4.2"
 			},
 			"devDependencies": {
-				"@extrachill/api-client": "^0.6.0",
+				"@extrachill/api-client": "^0.7.0",
 				"@types/react": "^18.3.0",
 				"@types/wordpress__block-editor": "^15.0.5",
 				"@types/wordpress__blocks": "^15.10.2",
@@ -2666,9 +2666,9 @@
 			}
 		},
 		"node_modules/@extrachill/api-client": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/@extrachill/api-client/-/api-client-0.6.0.tgz",
-			"integrity": "sha512-H3HQr0nCENuo+JaC7fpJbhv2T8JkURFr1laCZK5tXfyC7Eay9khcgUOez7Mbdtj3bdWduewYpmurqo2kuK8WPA==",
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/@extrachill/api-client/-/api-client-0.7.0.tgz",
+			"integrity": "sha512-KjNQOj7JWzvSGvRXpFFph4Htz5TfwGTgcuer4IzcJ36f7hxN7H+nnUNoEMW5w2ZfC6gi9xxpTTj0LDSBPi9nVg==",
 			"dev": true,
 			"license": "GPL-2.0+"
 		},

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"@extrachill/tokens": "^0.4.2"
 	},
 	"devDependencies": {
-		"@extrachill/api-client": "^0.6.0",
+		"@extrachill/api-client": "^0.7.0",
 		"@types/react": "^18.3.0",
 		"@types/wordpress__block-editor": "^15.0.5",
 		"@types/wordpress__blocks": "^15.10.2",

--- a/src/blocks/studio/tabs/socials/publish/index.ts
+++ b/src/blocks/studio/tabs/socials/publish/index.ts
@@ -231,11 +231,7 @@ const PlatformPublishPane = ( { slug, label, username, config }: PlatformPublish
 		try {
 			const response = await studioClient.socials.crossPost( {
 				platforms: [ slug ],
-				// SocialImageInput in @extrachill/api-client only declares `url`; DM-Socials
-				// accepts `alt` server-side for platforms that support it (Bluesky, Twitter,
-				// Threads). Cast bypasses the narrower client-side type until
-				// Extra-Chill/extrachill-api-client#11 lands.
-				images: images.map( ( { url, alt } ) => ( { url, alt } ) ) as { url: string }[],
+				images: images.map( ( { url, alt, title } ) => ( { url, alt, title } ) ),
 				caption: caption.trim(),
 			} );
 


### PR DESCRIPTION
## Summary

Cleanup follow-up to PR #45. The `@extrachill/api-client` 0.7.0 release ships [Extra-Chill/extrachill-api-client#12](https://github.com/Extra-Chill/extrachill-api-client/pull/12), which broadens `SocialImageInput` to natively declare optional `alt` and `title`:

\`\`\`ts
interface SocialImageInput {
  url: string;
  alt?: string;
  title?: string;
}
\`\`\`

That matches what DM-Socials already accepts server-side for platforms that surface per-image metadata (Bluesky, Twitter, Threads). The type now expresses what was always true at runtime.

## What changed

**`package.json` + `package-lock.json`** — bump `@extrachill/api-client` from `^0.6.0` to `^0.7.0`.

**`src/blocks/studio/tabs/socials/publish/index.ts`** — drop the cast workaround at the `crossPost` call site:

Before:
\`\`\`ts
const response = await studioClient.socials.crossPost( {
    platforms: [ slug ],
    // SocialImageInput in @extrachill/api-client only declares \`url\`; DM-Socials
    // accepts \`alt\` server-side for platforms that support it (Bluesky, Twitter,
    // Threads). Cast bypasses the narrower client-side type until
    // Extra-Chill/extrachill-api-client#11 lands.
    images: images.map( ( { url, alt } ) => ( { url, alt } ) ) as { url: string }[],
    caption: caption.trim(),
} );
\`\`\`

After:
\`\`\`ts
const response = await studioClient.socials.crossPost( {
    platforms: [ slug ],
    images: images.map( ( { url, alt, title } ) => ( { url, alt, title } ) ),
    caption: caption.trim(),
} );
\`\`\`

Also forwards \`title\` alongside \`alt\` since both are tracked in \`SelectedImage\` state and both are now part of the public contract.

## Verification

- \`npx tsc --noEmit\` clean
- \`npm run build\` clean
- 3 files changed, +6 / −10

## Background

Originally tracked in PR #45's review thread — the cast was added when api-client lagged the server contract. That gap is now closed.

cc @chubes4