### PR TITLE
fix: create transcription drafts on current site, not main extrachill.com

### DIFF
--- a/inc/abilities/transcribe-recording.php
+++ b/inc/abilities/transcribe-recording.php
@@ -117,14 +117,6 @@ function ec_studio_execute_transcribe_recording( array $input ): array|\WP_Error
 		return new \WP_Error( 'not_logged_in', __( 'You must be logged in to transcribe recordings.', 'extrachill-studio' ), array( 'status' => 401 ) );
 	}
 
-	if ( ! function_exists( 'ec_has_main_site_account' ) || ! \ec_has_main_site_account( $user_id ) ) {
-		return new \WP_Error(
-			'no_main_site_account',
-			__( 'You must have an account on the main extrachill.com site to author transcription drafts.', 'extrachill-studio' ),
-			array( 'status' => 403 )
-		);
-	}
-
 	$attachment_url = wp_get_attachment_url( $attachment_id );
 	if ( ! $attachment_url ) {
 		return new \WP_Error( 'attachment_url_missing', __( 'Could not resolve a URL for the attachment.', 'extrachill-studio' ), array( 'status' => 500 ) );
@@ -163,7 +155,7 @@ function ec_studio_execute_transcribe_recording( array $input ): array|\WP_Error
 			'model'          => $model,
 			'diarize'        => $diarize,
 			'remove_fillers' => $remove_fillers,
-			'target_blog_id' => 1,
+			'target_blog_id' => get_current_blog_id(),
 			'status'         => $status,
 			'created_at'     => current_time( 'c', true ),
 			'completed_at'   => null,

--- a/inc/abilities/transcription-job-status.php
+++ b/inc/abilities/transcription-job-status.php
@@ -177,12 +177,8 @@ function ec_studio_execute_transcription_job_status( array $input ): array|\WP_E
 			return $job;
 		}
 
-		$post_id        = (int) $draft_result;
-		$target_blog_id = (int) ( $job['target_blog_id'] ?? 1 );
-
-		switch_to_blog( $target_blog_id );
+		$post_id  = (int) $draft_result;
 		$edit_url = (string) get_edit_post_link( $post_id, 'raw' );
-		restore_current_blog();
 
 		$job['draft_post_id']  = $post_id;
 		$job['draft_post_url'] = $edit_url;

--- a/inc/transcription/draft-post-creator.php
+++ b/inc/transcription/draft-post-creator.php
@@ -2,10 +2,16 @@
 /**
  * Draft Post Creator
  *
- * Cross-blog draft post creation for completed transcriptions. Creates a draft
- * on the target blog (default blog_id=1, the main extrachill.com site) under
- * the uploading user's authorship. extrachill-users guarantees user_id parity
- * across the network so post_author is the same id everywhere.
+ * Creates a draft post on the current site (i.e. the site that submitted
+ * the transcription job — typically studio.extrachill.com) under the
+ * uploading user's authorship. The draft surfaces in the Blog tab's
+ * drafts dropdown automatically because the Blog tab queries the same
+ * `wp/v2/posts?status=draft` endpoint on the same site.
+ *
+ * Side-effect integration: Transcribe and Blog tabs share zero code, but
+ * both operate on the same `status=draft` posts on the same site, so a
+ * transcription draft is just a regular draft from the Blog tab's
+ * perspective.
  *
  * @package    ExtraChillStudio
  * @subpackage Transcription
@@ -15,7 +21,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Create a draft post on the target blog with the transcription content.
+ * Create a draft post on the current site with the transcription content.
  *
  * @since 0.10.0
  *
@@ -24,22 +30,13 @@ defined( 'ABSPATH' ) || exit;
  * @return int|\WP_Error Draft post ID on success, WP_Error on failure.
  */
 function ec_studio_transcription_create_draft( array $job, string $transcript_content ): int|\WP_Error {
-	$user_id        = (int) ( $job['user_id'] ?? 0 );
-	$target_blog_id = (int) ( $job['target_blog_id'] ?? 1 );
+	$user_id = (int) ( $job['user_id'] ?? 0 );
 
 	if ( $user_id <= 0 ) {
 		return new \WP_Error(
 			'invalid_user',
 			__( 'Job is missing a valid user_id.', 'extrachill-studio' ),
 			array( 'status' => 400 )
-		);
-	}
-
-	if ( ! function_exists( 'ec_has_main_site_account' ) || ! \ec_has_main_site_account( $user_id ) ) {
-		return new \WP_Error(
-			'no_main_site_account',
-			__( 'User does not have an account on the main site and cannot author drafts there.', 'extrachill-studio' ),
-			array( 'status' => 403 )
 		);
 	}
 
@@ -51,17 +48,13 @@ function ec_studio_transcription_create_draft( array $job, string $transcript_co
 		);
 	}
 
-	$attachment_url   = (string) ( $job['attachment_url'] ?? '' );
-	$attachment_id    = (int) ( $job['attachment_id'] ?? 0 );
-	$created_at       = (string) ( $job['created_at'] ?? '' );
-	$created_ts       = $created_at ? strtotime( $created_at ) : false;
-	$created_ts       = $created_ts ?: time();
+	$attachment_url = (string) ( $job['attachment_url'] ?? '' );
+	$attachment_id  = (int) ( $job['attachment_id'] ?? 0 );
 
 	$title = sprintf(
-		/* translators: 1: source recording filename, 2: human-readable date */
-		__( 'Transcription: %1$s — %2$s', 'extrachill-studio' ),
-		wp_basename( $attachment_url ),
-		wp_date( 'M j, Y', $created_ts )
+		/* translators: %s: source recording filename */
+		__( 'Transcription: %s', 'extrachill-studio' ),
+		wp_basename( $attachment_url )
 	);
 
 	$postarr = array(
@@ -79,13 +72,7 @@ function ec_studio_transcription_create_draft( array $job, string $transcript_co
 		),
 	);
 
-	switch_to_blog( $target_blog_id );
-
-	try {
-		$result = wp_insert_post( $postarr, true );
-	} finally {
-		restore_current_blog();
-	}
+	$result = wp_insert_post( $postarr, true );
 
 	if ( is_wp_error( $result ) ) {
 		return $result;


### PR DESCRIPTION
## Summary

Aligns transcription drafts with how the Blog tab actually works. Drafts now land on the current site (typically `studio.extrachill.com`), where the Blog tab's drafts dropdown picks them up automatically — same `wp/v2/posts?status=draft` query it already runs.

## Why

The original B1 backend (#46) auto-created drafts on `blog_id=1` via `switch_to_blog`, requiring the Studio user to also have an account on the main site. That fought the Blog tab's pattern, which saves and lists drafts on the studio subsite via `wp/v2/posts`. Transcribe and Blog tabs are decoupled in code, but the design intent is they integrate **as a side-effect of operating on the same shared WordPress data**: both tabs see the same `status=draft` posts.

## What changed

| File | Change |
|---|---|
| `inc/transcription/draft-post-creator.php` | Drop `switch_to_blog`/`restore_current_blog` ceremony. Drop `ec_has_main_site_account` guard. Title simplified from `"Transcription: <file> — <date>"` to `"Transcription: <file>"`. |
| `inc/abilities/transcribe-recording.php` | Drop the defensive `ec_has_main_site_account` check at submission. `ec_is_team_member()` in the permission callback is the only gate now. `target_blog_id` defaults to `get_current_blog_id()` (kept as metadata for debugging). |
| `inc/abilities/transcription-job-status.php` | Drop the `switch_to_blog` wrapper around `get_edit_post_link`, since the post lives on the current site. |

Net **+20 / −45** lines (code reduction; ceremony removed).

## Behavior change

| Before | After |
|---|---|
| Draft post created on `extrachill.com` (blog_id=1) | Draft post created on `studio.extrachill.com` (the site that submitted the job) |
| Required user to have main-site account | Only requires `ec_is_team_member()` |
| Title: `Transcription: jfk.flac — May 10, 2026` | Title: `Transcription: jfk.flac` |
| Did NOT surface in Blog tab's drafts dropdown | DOES surface in Blog tab's drafts dropdown |

## Backward compat

Pure simplification. The job-store schema (`target_blog_id` field) is unchanged; existing in-flight job rows won't break — completed jobs with `target_blog_id=1` already have their `draft_post_id`/`draft_post_url` resolved. New jobs will record the current site's blog_id.

## Test plan

After merge + deploy:

1. Upload audio attachment via studio.extrachill.com media library.
2. Invoke `extrachill/transcribe-recording` ability with the attachment_id.
3. Poll `extrachill/transcription-job-status` until completed.
4. Verify the draft post exists on `studio.extrachill.com` (NOT extrachill.com) under the user's authorship.
5. Open Blog tab in Studio — the new draft should appear in the drafts dropdown.

## Out of scope

- React Transcribe tab UI — separate PR (Phase B2).
- `.txt` download endpoint — separate PR (Phase B2).