### PR TITLE
fix: route transcription drafts to main extrachill.com via universal cross-site primitive

### DIFF
--- a/inc/abilities/transcription-job-status.php
+++ b/inc/abilities/transcription-job-status.php
@@ -177,8 +177,21 @@ function ec_studio_execute_transcription_job_status( array $input ): array|\WP_E
 			return $job;
 		}
 
-		$post_id  = (int) $draft_result;
-		$edit_url = (string) get_edit_post_link( $post_id, 'raw' );
+		$post_id = (int) $draft_result;
+
+		// Resolve the edit URL on the main site (where the draft was created).
+		// switch_to_blog is the only OS-level cross-site call in this ability;
+		// computing get_edit_post_link from another site returns the wrong host.
+		$edit_url     = '';
+		$main_blog_id = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'main' ) : 0;
+		if ( $main_blog_id > 0 ) {
+			switch_to_blog( $main_blog_id );
+			try {
+				$edit_url = (string) get_edit_post_link( $post_id, 'raw' );
+			} finally {
+				restore_current_blog();
+			}
+		}
 
 		$job['draft_post_id']  = $post_id;
 		$job['draft_post_url'] = $edit_url;

--- a/inc/transcription/draft-post-creator.php
+++ b/inc/transcription/draft-post-creator.php
@@ -2,16 +2,20 @@
 /**
  * Draft Post Creator
  *
- * Creates a draft post on the current site (i.e. the site that submitted
- * the transcription job — typically studio.extrachill.com) under the
- * uploading user's authorship. The draft surfaces in the Blog tab's
- * drafts dropdown automatically because the Blog tab queries the same
- * `wp/v2/posts?status=draft` endpoint on the same site.
+ * Creates a draft post on the main extrachill.com site for a completed
+ * transcription. Studio runs at studio.extrachill.com (a subsite); the
+ * Blog tab and Transcribe tab both target main extrachill.com because
+ * that's where editorial content publishes.
  *
- * Side-effect integration: Transcribe and Blog tabs share zero code, but
- * both operate on the same `status=draft` posts on the same site, so a
- * transcription draft is just a regular draft from the Blog tab's
- * perspective.
+ * Cross-site dispatch goes through the universal extrachill-multisite
+ * primitive `ec_cross_site_rest_request()`, which (as of multisite
+ * v1.12.3) accepts fully-qualified REST paths including core WP routes
+ * like `/wp/v2/posts`. No manual switch_to_blog ceremony in studio code.
+ *
+ * Side-effect integration with the Blog tab: both tabs write through
+ * `/wp/v2/posts` on main extrachill.com, so a transcription draft surfaces
+ * in the Blog tab's drafts dropdown automatically. Tabs are decoupled in
+ * code; shared WordPress data does the integration.
  *
  * @package    ExtraChillStudio
  * @subpackage Transcription
@@ -21,9 +25,10 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Create a draft post on the current site with the transcription content.
+ * Create a draft post on the main extrachill.com site.
  *
  * @since 0.10.0
+ * @since 0.10.2 Refactored to use ec_cross_site_rest_request() universal primitive.
  *
  * @param array  $job                 Persisted job row.
  * @param string $transcript_content  Transcript body to use as post_content.
@@ -48,6 +53,14 @@ function ec_studio_transcription_create_draft( array $job, string $transcript_co
 		);
 	}
 
+	if ( ! function_exists( 'ec_cross_site_rest_request' ) ) {
+		return new \WP_Error(
+			'multisite_helper_missing',
+			__( 'extrachill-multisite is required for cross-site draft creation.', 'extrachill-studio' ),
+			array( 'status' => 500 )
+		);
+	}
+
 	$attachment_url = (string) ( $job['attachment_url'] ?? '' );
 	$attachment_id  = (int) ( $job['attachment_id'] ?? 0 );
 
@@ -57,34 +70,61 @@ function ec_studio_transcription_create_draft( array $job, string $transcript_co
 		wp_basename( $attachment_url )
 	);
 
-	$postarr = array(
-		'post_title'   => $title,
-		'post_status'  => 'draft',
-		'post_author'  => $user_id,
-		'post_content' => $transcript_content,
-		'post_type'    => 'post',
-		'meta_input'   => array(
-			'_studio_source_recording_url'   => $attachment_url,
-			'_studio_source_recording_id'    => $attachment_id,
-			'_studio_transcription_model'    => (string) ( $job['model'] ?? '' ),
-			'_studio_transcription_diarized' => ! empty( $job['diarize'] ) ? '1' : '0',
-			'_studio_transcription_job_id'   => (string) ( $job['job_id'] ?? '' ),
-		),
+	// POST /wp/v2/posts on main extrachill.com via the universal cross-site
+	// primitive. Path is fully-qualified (`/wp/v2/posts`); the helper passes
+	// it through verbatim (multisite v1.12.3+).
+	$response = ec_cross_site_rest_request(
+		'main',
+		'POST',
+		'/wp/v2/posts',
+		array(
+			'body'    => array(
+				'title'   => $title,
+				'status'  => 'draft',
+				'author'  => $user_id,
+				'content' => $transcript_content,
+			),
+			'user_id' => $user_id,
+		)
 	);
 
-	$result = wp_insert_post( $postarr, true );
-
-	if ( is_wp_error( $result ) ) {
-		return $result;
+	if ( is_wp_error( $response ) ) {
+		return $response;
 	}
 
-	$post_id = (int) $result;
+	$post_id = isset( $response['id'] ) ? (int) $response['id'] : 0;
 	if ( $post_id <= 0 ) {
 		return new \WP_Error(
-			'draft_create_failed',
-			__( 'wp_insert_post returned 0; draft was not created.', 'extrachill-studio' ),
+			'draft_create_no_id',
+			__( 'wp/v2/posts returned a response without a post id.', 'extrachill-studio' ),
 			array( 'status' => 500 )
 		);
+	}
+
+	// Attach Studio-specific meta on main extrachill.com. The /wp/v2/posts
+	// `meta` field only accepts keys registered with show_in_rest; rather
+	// than register all of them globally, we make a second cross-site call
+	// to update_post_meta via switch_to_blog inside the multisite helper.
+	//
+	// We do this via a tiny extrachill-studio REST route registered on main,
+	// OR we accept the round-trip cost of N cross-site calls. For v1, the
+	// simpler approach: a single cross-site update via the WP /wp/v2/posts/<id>
+	// endpoint with `meta`, which works if the keys are registered. Since
+	// they aren't, we set meta directly inside a switch_to_blog block in
+	// studio's own process — the only switch_to_blog in this file, justified
+	// because there's no /wp/v2/posts/<id>/meta route that accepts arbitrary keys.
+	$main_blog_id = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'main' ) : 0;
+	if ( $main_blog_id > 0 ) {
+		switch_to_blog( $main_blog_id );
+		try {
+			update_post_meta( $post_id, '_studio_source_recording_url', $attachment_url );
+			update_post_meta( $post_id, '_studio_source_recording_id', $attachment_id );
+			update_post_meta( $post_id, '_studio_transcription_model', (string) ( $job['model'] ?? '' ) );
+			update_post_meta( $post_id, '_studio_transcription_diarized', ! empty( $job['diarize'] ) ? '1' : '0' );
+			update_post_meta( $post_id, '_studio_transcription_job_id', (string) ( $job['job_id'] ?? '' ) );
+		} finally {
+			restore_current_blog();
+		}
 	}
 
 	return $post_id;


### PR DESCRIPTION
## Summary

Transcription drafts now land on **main extrachill.com** — same target the Blog tab writes to via `/wp/v2/posts`. Studio runs at studio.extrachill.com (a subsite); editorial content publishes from main extrachill.com, so that's where drafts belong.

## Side-effect integration with the Blog tab

Both tabs are decoupled in code (no shared imports, no event bus). They integrate via shared WordPress data: both write through `/wp/v2/posts` on main extrachill.com, so a transcription draft surfaces in the Blog tab's drafts dropdown automatically — same primitive surface, same destination.

## What changed

| File | Change |
|---|---|
| `inc/transcription/draft-post-creator.php` | Refactored to call `ec_cross_site_rest_request( 'main', 'POST', '/wp/v2/posts', [...] )` instead of local `wp_insert_post`. Studio-specific post meta still set via a single `switch_to_blog` block (the meta keys aren't registered with `show_in_rest`, so they can't ride along in the REST `meta` field). |
| `inc/abilities/transcription-job-status.php` | `get_edit_post_link` now wrapped in `switch_to_blog( ec_get_blog_id('main') )` so the URL resolves to the right host. |

## Why this works now

extrachill-multisite #17 made `ec_cross_site_rest_request()` accept fully-qualified paths (e.g. `/wp/v2/posts`) instead of forcing the `/extrachill/v1` prepend. This studio-side change uses that universal primitive cleanly.

**Requires:** `extrachill-multisite >= 1.12.3`.

## Behavior

| Before (v0.10.1) | After |
|---|---|
| Draft created on `studio.extrachill.com` | Draft created on `extrachill.com` (blog_id=1) |
| Authored by current user on studio subsite | Authored by current user on main (assumes user_id parity, true on this network via extrachill-users) |
| `draft_post_url` pointed at studio.extrachill.com/wp-admin/post.php | `draft_post_url` points at extrachill.com/wp-admin/post.php |
| Did NOT surface in Blog tab's drafts dropdown | DOES surface (Blog tab queries main site) |

## Test plan

After merge + deploy:

1. Submit a transcription job from `studio.extrachill.com` (via the existing abilities — UI doesn't exist yet, that's Phase B2).
2. Poll until status flips to `completed`.
3. Verify a draft post exists on `extrachill.com` (NOT studio.extrachill.com) with the transcript as `post_content`.
4. Verify `draft_post_url` in the response points at `extrachill.com/wp-admin/post.php?post=<id>&action=edit`.

## Out of scope

- React Transcribe tab UI — Phase B2.
- Backfilling drafts that landed on studio.extrachill.com under v0.10.1 — handful of test posts, can manually move or delete.