### PR TITLE
fix: declare nullable fields in transcription-job-status output schema

### DIFF
--- a/inc/abilities/transcription-job-status.php
+++ b/inc/abilities/transcription-job-status.php
@@ -53,9 +53,12 @@ function ec_studio_register_transcription_job_status_ability(): void {
 					'properties' => array(
 						'job_id'         => array( 'type' => 'string' ),
 						'status'         => array( 'type' => 'string' ),
-						'draft_post_id'  => array( 'type' => 'integer' ),
-						'draft_post_url' => array( 'type' => 'string' ),
-						'error'          => array( 'type' => 'string' ),
+						// Nullable until the job reaches 'completed' and the
+						// draft post is created on main extrachill.com.
+						'draft_post_id'  => array( 'type' => array( 'integer', 'null' ) ),
+						'draft_post_url' => array( 'type' => array( 'string', 'null' ) ),
+						// Nullable in non-failure states; populated only when status='failed'.
+						'error'          => array( 'type' => array( 'string', 'null' ) ),
 					),
 				),
 				'execute_callback'    => 'ec_studio_execute_transcription_job_status',


### PR DESCRIPTION
## Summary

The `transcription-job-status` ability rejected every poll with:

\`\`\`
Ability "extrachill/transcription-job-status" has invalid output.
Reason: output[draft_post_id] is not of type integer.
\`\`\`

The ability returns the full job row, which contains `draft_post_id`, `draft_post_url`, and `error` fields. These are populated as `null` while a job is in flight (`status=pending|running`) and only get real values when the job reaches `completed` (draft_post_id/url) or `failed` (error). The previous output schema declared them as non-nullable single types, so the Abilities API rejected every response.

## What changed

`inc/abilities/transcription-job-status.php`:

| Field | Before | After |
|---|---|---|
| `draft_post_id` | `'type' => 'integer'` | `'type' => [ 'integer', 'null' ]` |
| `draft_post_url` | `'type' => 'string'` | `'type' => [ 'string', 'null' ]` |
| `error` | `'type' => 'string'` | `'type' => [ 'string', 'null' ]` |

Net **+5 / −3** lines, single file.

## How this was caught

Smoke-testing v0.10.2 by submitting a real transcription job via `wp_get_ability()->execute()` and polling. The deploy itself didn't surface this because schema validation only runs at execute time, not registration time.

## Test plan

After merge + deploy:

1. Submit a job via the ability.
2. Poll until completed.
3. Each poll response should validate cleanly — no schema errors.
4. Verify the draft lands on main extrachill.com (the underlying behavior PR #49 is shipping).