### PR TITLE
feat: React Transcribe tab using direct headless sweatpants pipeline (Phase B2)

### DIFF
--- a/src/blocks/studio/app/tabs.ts
+++ b/src/blocks/studio/app/tabs.ts
@@ -15,6 +15,12 @@ export const getStudioTabs = (): StudioTab[] => [
 		preview: __( 'Publish and manage posts across social platforms.', 'extrachill-studio' ),
 	},
 	{
+		id: 'transcribe',
+		pane: 'transcribe',
+		label: __( 'Transcribe', 'extrachill-studio' ),
+		preview: __( 'Transcribe audio with Whisper.', 'extrachill-studio' ),
+	},
+	{
 		id: 'qr-codes',
 		pane: 'qr-codes',
 		label: __( 'QR Codes', 'extrachill-studio' ),

--- a/src/blocks/studio/style.css
+++ b/src/blocks/studio/style.css
@@ -724,6 +724,152 @@ html.is-fullscreen-mode .ec-studio-compose-editor .interface-interface-skeleton_
 	height: 100%;
 }
 
+/* ── Transcribe tab ── */
+.ec-studio-pane--transcribe {
+	gap: var(--spacing-md);
+}
+
+.ec-studio-transcribe__dropzone {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: var(--spacing-xs);
+	min-height: 140px;
+	padding: var(--spacing-lg);
+	border: 2px dashed var(--border-color);
+	border-radius: var(--border-radius-md);
+	background: var(--background-color);
+	color: var(--text-color);
+	cursor: pointer;
+	text-align: center;
+	transition: border-color var(--transition-fast, 150ms ease), background var(--transition-fast, 150ms ease);
+}
+
+.ec-studio-transcribe__dropzone:hover,
+.ec-studio-transcribe__dropzone:focus-visible {
+	border-color: var(--link-color);
+	background: var(--interactive-hover-bg, rgba(11, 83, 148, 0.04));
+	outline: none;
+}
+
+.ec-studio-transcribe__dropzone.is-dragging {
+	border-color: var(--link-color);
+	background: var(--interactive-active-bg, rgba(11, 83, 148, 0.08));
+}
+
+.ec-studio-transcribe__dropzone.has-file {
+	border-style: solid;
+}
+
+.ec-studio-transcribe__dropzone-headline {
+	font-weight: var(--font-weight-semibold, 600);
+}
+
+.ec-studio-transcribe__dropzone-meta {
+	font-size: var(--font-size-sm);
+	color: var(--muted-text);
+}
+
+.ec-studio-transcribe__file {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: var(--spacing-xs);
+	word-break: break-all;
+}
+
+.ec-studio-transcribe__file-meta {
+	font-size: var(--font-size-sm);
+	color: var(--muted-text);
+}
+
+.ec-studio-transcribe__preset {
+	width: 100%;
+}
+
+.ec-studio-transcribe__active {
+	border-left: 3px solid var(--link-color, #0b5394);
+}
+
+.ec-studio-transcribe__active-meta {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: var(--spacing-xs);
+	font-size: var(--font-size-sm);
+	color: var(--muted-text);
+}
+
+.ec-studio-transcribe__active-meta strong {
+	color: var(--text-color);
+	word-break: break-all;
+}
+
+.ec-studio-transcribe__status {
+	text-transform: capitalize;
+	font-weight: var(--font-weight-semibold, 600);
+}
+
+.ec-studio-transcribe__history {
+	list-style: none;
+	padding: 0;
+	margin: var(--spacing-sm) 0 0;
+	display: grid;
+	gap: var(--spacing-md);
+}
+
+.ec-studio-transcribe__history-item {
+	padding: var(--spacing-md);
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius-md);
+	background: var(--background-color);
+	display: grid;
+	gap: var(--spacing-sm);
+}
+
+.ec-studio-transcribe__history-item.is-failed {
+	border-color: var(--error-color, #dc3232);
+	background: rgba(220, 50, 50, 0.04);
+}
+
+.ec-studio-transcribe__history-header {
+	font-size: var(--font-size-base);
+	word-break: break-all;
+}
+
+.ec-studio-transcribe__history-meta {
+	color: var(--muted-text);
+	font-size: var(--font-size-sm);
+	text-transform: capitalize;
+}
+
+.ec-studio-transcribe__history-error {
+	font-size: var(--font-size-sm);
+	color: var(--error-color, #dc3232);
+}
+
+.ec-studio-transcribe__history-actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--spacing-xs);
+}
+
+.ec-studio-transcribe__transcript {
+	margin: var(--spacing-sm) 0 0;
+	padding: var(--spacing-md);
+	border-radius: var(--border-radius-md);
+	background: var(--card-background, var(--background-color));
+	border: 1px solid var(--border-color);
+	font-family: var(--font-family-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+	font-size: var(--font-size-sm);
+	line-height: 1.6;
+	white-space: pre-wrap;
+	word-break: break-word;
+	max-height: 480px;
+	overflow-y: auto;
+}
+
 /* ── Socials tab — sidebar + content layout ── */
 .ec-studio-socials-layout {
 	display: grid;

--- a/src/blocks/studio/tabs/transcribe/client.ts
+++ b/src/blocks/studio/tabs/transcribe/client.ts
@@ -1,0 +1,143 @@
+/**
+ * Sweatpants HTTP client for the Transcribe tab.
+ *
+ * All calls go directly browser → `https://sweatpants.chubes.net` using the
+ * HMAC-signed bearer token minted by `tokenManager`. WordPress is NOT in
+ * the data path — its only role is minting the token.
+ *
+ * If the sweatpants base URL ever needs to be configurable per environment
+ * (staging, dev), hoist `SWEATPANTS_BASE_URL` to a server-injected value
+ * via `render.php` data attributes or `wp_localize_script`.
+ *
+ * @package ExtraChillStudio
+ */
+
+import { getToken, invalidateToken } from './tokenManager';
+import type {
+	SweatpantsJob,
+	SweatpantsJobResults,
+	SweatpantsUpload,
+} from './types';
+
+/** Single sweatpants worker in production — see the docblock for env-config notes. */
+const SWEATPANTS_BASE_URL = 'https://sweatpants.chubes.net';
+
+/** Sweatpants caps uploads at 500 MB by default. Validate client-side. */
+export const MAX_UPLOAD_BYTES = 500 * 1024 * 1024;
+
+/** Module ID for the audio-transcription pipeline on sweatpants. */
+const TRANSCRIPTION_MODULE_ID = 'audio-transcription';
+
+interface RequestOptions {
+	method?: 'GET' | 'POST' | 'DELETE';
+	body?: BodyInit | null;
+	headers?: Record< string, string >;
+}
+
+/**
+ * Internal: perform an authorized fetch against sweatpants.
+ *
+ * On 401, drops the cached token and retries once with a fresh mint —
+ * covers the case where the cached token expired mid-flight or the
+ * sweatpants secret rotated server-side.
+ */
+const request = async < T >( path: string, options: RequestOptions = {}, retried = false ): Promise< T > => {
+	const token = await getToken();
+	const headers: Record< string, string > = {
+		Authorization: `Bearer ${ token.token }`,
+		...( options.headers || {} ),
+	};
+
+	const response = await globalThis.fetch( `${ SWEATPANTS_BASE_URL }${ path }`, {
+		method: options.method || 'GET',
+		headers,
+		body: options.body ?? null,
+	} );
+
+	if ( response.status === 401 && ! retried ) {
+		invalidateToken();
+		return request< T >( path, options, true );
+	}
+
+	if ( ! response.ok ) {
+		let detail = `${ response.status } ${ response.statusText }`;
+		try {
+			const errorBody = await response.json() as { error?: string; message?: string };
+			if ( errorBody?.error || errorBody?.message ) {
+				detail = `${ detail } — ${ errorBody.error || errorBody.message }`;
+			}
+		} catch {
+			// Body wasn't JSON; stick with status text.
+		}
+		throw new Error( `Sweatpants ${ path } failed: ${ detail }` );
+	}
+
+	return response.json() as Promise< T >;
+};
+
+/**
+ * Upload an audio file directly to sweatpants /uploads.
+ *
+ * @param file Browser File from a file input or drop event.
+ * @returns Sweatpants upload metadata, including the `path` we feed to
+ *   the audio-transcription module as `audio_path`.
+ */
+export const uploadAudio = async ( file: File ): Promise< SweatpantsUpload > => {
+	const formData = new FormData();
+	formData.append( 'file', file, file.name );
+
+	return request< SweatpantsUpload >( '/uploads', {
+		method: 'POST',
+		body: formData,
+		// Don't set Content-Type — the browser sets a multipart boundary.
+	} );
+};
+
+interface CreateJobInput {
+	uploadPath: string;
+	model: 'base' | 'medium' | 'large';
+	diarize: boolean;
+	removeFillers: boolean;
+	language?: string;
+}
+
+/**
+ * Create an audio-transcription job referencing a previously uploaded
+ * file path.
+ *
+ * The `output_dir` uses a UUID-ish unique-id so multiple concurrent jobs
+ * never collide on the sweatpants host.
+ */
+export const createJob = async ( input: CreateJobInput ): Promise< SweatpantsJob > => {
+	const uniqueId = ( typeof globalThis.crypto !== 'undefined' && 'randomUUID' in globalThis.crypto )
+		? globalThis.crypto.randomUUID()
+		: `job-${ Date.now() }-${ Math.random().toString( 36 ).slice( 2, 10 ) }`;
+
+	const payload = {
+		module_id: TRANSCRIPTION_MODULE_ID,
+		inputs: {
+			audio_path: input.uploadPath,
+			output_dir: `/var/lib/sweatpants/output/${ uniqueId }`,
+			model: input.model,
+			diarize: input.diarize,
+			remove_fillers: input.removeFillers,
+			language: input.language || 'en',
+		},
+	};
+
+	return request< SweatpantsJob >( '/jobs', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify( payload ),
+	} );
+};
+
+/** Fetch the latest state for a job. */
+export const getJob = async ( jobId: string ): Promise< SweatpantsJob > => {
+	return request< SweatpantsJob >( `/jobs/${ encodeURIComponent( jobId ) }` );
+};
+
+/** Fetch the results envelope for a completed job. */
+export const getResults = async ( jobId: string ): Promise< SweatpantsJobResults > => {
+	return request< SweatpantsJobResults >( `/jobs/${ encodeURIComponent( jobId ) }/results` );
+};

--- a/src/blocks/studio/tabs/transcribe/index.ts
+++ b/src/blocks/studio/tabs/transcribe/index.ts
@@ -1,0 +1,653 @@
+/**
+ * Transcribe Pane — Direct headless audio transcription via sweatpants.
+ *
+ * Flow (browser ↔ sweatpants directly, NO server-side polling):
+ *   1. Mint short-lived HMAC token via `extrachill/sweatpants-token` ability.
+ *   2. POST audio multipart → `https://sweatpants.chubes.net/uploads`.
+ *   3. POST job spec → `https://sweatpants.chubes.net/jobs` (audio-transcription).
+ *   4. Poll GET /jobs/{id} every 5s until terminal status.
+ *   5. GET /jobs/{id}/results and pull `data.content.transcription`
+ *      (or `combined_txt` / `combined_txt_clean` for diarized presets).
+ *
+ * Persistence: jobs live only in this component's React state — no local
+ * store. Past transcriptions disappear when the user navigates away.
+ *
+ * @package ExtraChillStudio
+ */
+
+import { __, sprintf } from '@wordpress/i18n';
+import { createElement, useCallback, useEffect, useRef, useState } from '@wordpress/element';
+import type { ChangeEvent, DragEvent, ReactElement } from 'react';
+import { ActionRow, FieldGroup, InlineStatus, Panel, PanelHeader } from '@extrachill/components';
+
+import type { StudioPaneProps } from '../../types/studio';
+import { createJob, getJob, getResults, MAX_UPLOAD_BYTES, uploadAudio } from './client';
+import type {
+	ActiveJob,
+	SweatpantsJobStatus,
+	TranscribePreset,
+} from './types';
+
+const h = createElement as typeof import( 'react' ).createElement;
+const PanelView = Panel as unknown as ( props: any ) => ReactElement;
+const ActionRowView = ActionRow as unknown as ( props: any ) => ReactElement;
+const FieldGroupView = FieldGroup as unknown as ( props: any ) => ReactElement;
+const InlineStatusView = InlineStatus as unknown as ( props: any ) => ReactElement;
+
+/** Polling interval while jobs are pending or running (ms). */
+const POLL_INTERVAL_MS = 5000;
+
+/** Time to flash "Copied" inline feedback after a successful clipboard write. */
+const COPY_FEEDBACK_MS = 2000;
+
+interface PresetConfig {
+	model: 'base' | 'medium' | 'large';
+	diarize: boolean;
+	removeFillers: boolean;
+	label: string;
+	description: string;
+}
+
+/**
+ * Map preset → sweatpants module inputs.
+ *
+ * The estimates are approximate and only used as user-visible hints.
+ */
+const PRESET_CONFIG: Record< TranscribePreset, PresetConfig > = {
+	quick: {
+		model: 'base',
+		diarize: false,
+		removeFillers: false,
+		label: __( 'Quick draft', 'extrachill-studio' ),
+		description: __( 'base model · ~10 min for 16-min audio · lower quality', 'extrachill-studio' ),
+	},
+	standard: {
+		model: 'medium',
+		diarize: false,
+		removeFillers: false,
+		label: __( 'Standard', 'extrachill-studio' ),
+		description: __( 'medium model · ~90 min · good quality', 'extrachill-studio' ),
+	},
+	publish: {
+		model: 'large',
+		diarize: true,
+		removeFillers: true,
+		label: __( 'Publish quality', 'extrachill-studio' ),
+		description: __( 'large model · ~3 hr · best quality, speaker labels, fillers removed', 'extrachill-studio' ),
+	},
+};
+
+const SUPPORTED_EXTENSIONS = [ '.mp3', '.m4a', '.wav', '.flac', '.ogg', '.mp4' ];
+
+const TERMINAL_STATUSES: ReadonlyArray< SweatpantsJobStatus > = [ 'completed', 'failed', 'stopped' ];
+
+const isTerminal = ( status: SweatpantsJobStatus ): boolean => TERMINAL_STATUSES.includes( status );
+
+/**
+ * Pick the best transcript field from the results `content` map.
+ *
+ * Priority (most-processed first):
+ *   1. combined_txt_clean (diarized + filler-stripped)
+ *   2. combined_txt (diarized)
+ *   3. transcription (plain)
+ */
+const pickTranscript = ( content: Record< string, string > ): string => {
+	if ( typeof content.combined_txt_clean === 'string' && content.combined_txt_clean.length > 0 ) {
+		return content.combined_txt_clean;
+	}
+	if ( typeof content.combined_txt === 'string' && content.combined_txt.length > 0 ) {
+		return content.combined_txt;
+	}
+	if ( typeof content.transcription === 'string' && content.transcription.length > 0 ) {
+		return content.transcription;
+	}
+	return '';
+};
+
+/** Format byte count as MB with one decimal. */
+const formatMB = ( bytes: number ): string => `${ ( bytes / 1024 / 1024 ).toFixed( 1 ) } MB`;
+
+/** Format elapsed seconds as "M:SS". */
+const formatElapsed = ( startedAt: number, completedAt?: number ): string => {
+	const end = completedAt || Date.now();
+	const seconds = Math.max( 0, Math.floor( ( end - startedAt ) / 1000 ) );
+	const m = Math.floor( seconds / 60 );
+	const s = seconds % 60;
+	return `${ m }:${ s.toString().padStart( 2, '0' ) }`;
+};
+
+/** Strip extension off a filename for the .transcript.txt download name. */
+const stripExtension = ( filename: string ): string => filename.replace( /\.\w+$/, '' );
+
+/**
+ * Trigger a browser blob download for a plain-text transcript.
+ */
+const downloadTranscriptBlob = ( transcript: string, originalFilename: string ): void => {
+	const blob = new Blob( [ transcript ], { type: 'text/plain' } );
+	const url = URL.createObjectURL( blob );
+	const a = document.createElement( 'a' );
+	a.href = url;
+	a.download = `${ stripExtension( originalFilename ) }.transcript.txt`;
+	document.body.appendChild( a );
+	a.click();
+	document.body.removeChild( a );
+	URL.revokeObjectURL( url );
+};
+
+const TranscribePane = ( _props: StudioPaneProps ): ReactElement => {
+	const fileInputRef = useRef< HTMLInputElement >( null );
+
+	const [ selectedFile, setSelectedFile ] = useState< File | null >( null );
+	const [ preset, setPreset ] = useState< TranscribePreset >( 'standard' );
+	const [ isDragging, setIsDragging ] = useState( false );
+
+	/** Currently-running job, if any. Only one concurrent job in v1. */
+	const [ activeJob, setActiveJob ] = useState< ActiveJob | null >( null );
+	/** Completed/failed jobs from this session, newest first. */
+	const [ history, setHistory ] = useState< ActiveJob[] >( [] );
+
+	const [ stageMessage, setStageMessage ] = useState( '' );
+	const [ error, setError ] = useState( '' );
+	const [ copiedJobId, setCopiedJobId ] = useState< string | null >( null );
+	const [ expandedJobId, setExpandedJobId ] = useState< string | null >( null );
+
+	const pollTimerRef = useRef< ReturnType< typeof setInterval > | null >( null );
+	const activeJobRef = useRef< ActiveJob | null >( null );
+	activeJobRef.current = activeJob;
+
+	const isBusy = !! activeJob && ! isTerminal( activeJob.status );
+
+	// ── File selection ────────────────────────────────────────────────
+
+	const validateAndSetFile = useCallback( ( file: File | null ): void => {
+		setError( '' );
+		setStageMessage( '' );
+
+		if ( ! file ) {
+			setSelectedFile( null );
+			return;
+		}
+
+		if ( file.size > MAX_UPLOAD_BYTES ) {
+			setSelectedFile( null );
+			setError( sprintf(
+				/* translators: %s: human-readable file size, e.g. "612.4 MB" */
+				__( 'File is %s — sweatpants caps uploads at 500 MB.', 'extrachill-studio' ),
+				formatMB( file.size )
+			) );
+			return;
+		}
+
+		setSelectedFile( file );
+	}, [] );
+
+	const onFilePickerChange = ( event: ChangeEvent< HTMLInputElement > ): void => {
+		const file = event.target.files && event.target.files[ 0 ] ? event.target.files[ 0 ] : null;
+		validateAndSetFile( file );
+	};
+
+	const onPickButtonClick = (): void => {
+		fileInputRef.current?.click();
+	};
+
+	const onDragOver = ( event: DragEvent< HTMLDivElement > ): void => {
+		event.preventDefault();
+		event.stopPropagation();
+		if ( ! isDragging ) {
+			setIsDragging( true );
+		}
+	};
+
+	const onDragLeave = ( event: DragEvent< HTMLDivElement > ): void => {
+		event.preventDefault();
+		event.stopPropagation();
+		setIsDragging( false );
+	};
+
+	const onDrop = ( event: DragEvent< HTMLDivElement > ): void => {
+		event.preventDefault();
+		event.stopPropagation();
+		setIsDragging( false );
+		const file = event.dataTransfer.files && event.dataTransfer.files[ 0 ] ? event.dataTransfer.files[ 0 ] : null;
+		validateAndSetFile( file );
+	};
+
+	// ── Polling lifecycle ─────────────────────────────────────────────
+
+	const stopPolling = useCallback( (): void => {
+		if ( pollTimerRef.current ) {
+			clearInterval( pollTimerRef.current );
+			pollTimerRef.current = null;
+		}
+	}, [] );
+
+	/**
+	 * Promote the active job into history once it reaches a terminal state.
+	 * Pulls results for completed jobs; pulls error detail for failed jobs.
+	 */
+	const finalizeJob = useCallback( async ( job: ActiveJob ): Promise< void > => {
+		stopPolling();
+
+		if ( job.status === 'completed' ) {
+			setStageMessage( __( 'Fetching transcript…', 'extrachill-studio' ) );
+			try {
+				const results = await getResults( job.jobId );
+				const first = results.results && results.results[ 0 ];
+				const transcript = first ? pickTranscript( first.data.content ) : '';
+				const finalized: ActiveJob = {
+					...job,
+					completedAt: Date.now(),
+					transcript: transcript || __( '(empty transcript)', 'extrachill-studio' ),
+				};
+				setActiveJob( null );
+				setHistory( ( prev ) => [ finalized, ...prev ] );
+				setExpandedJobId( finalized.jobId );
+				setStageMessage( '' );
+			} catch ( resultsErr ) {
+				const failed: ActiveJob = {
+					...job,
+					status: 'failed',
+					completedAt: Date.now(),
+					error: ( resultsErr as Error )?.message || __( 'Failed to fetch results.', 'extrachill-studio' ),
+				};
+				setActiveJob( null );
+				setHistory( ( prev ) => [ failed, ...prev ] );
+				setStageMessage( '' );
+				setError( failed.error || '' );
+			}
+			return;
+		}
+
+		// failed | stopped
+		const failed: ActiveJob = {
+			...job,
+			completedAt: Date.now(),
+			error: job.error || __( 'Job did not complete successfully.', 'extrachill-studio' ),
+		};
+		setActiveJob( null );
+		setHistory( ( prev ) => [ failed, ...prev ] );
+		setStageMessage( '' );
+		setError( failed.error || '' );
+	}, [ stopPolling ] );
+
+	const pollOnce = useCallback( async (): Promise< void > => {
+		const current = activeJobRef.current;
+		if ( ! current || isTerminal( current.status ) ) {
+			return;
+		}
+
+		// Pause polling while the browser tab is hidden — resume on focus.
+		if ( typeof document !== 'undefined' && document.visibilityState === 'hidden' ) {
+			return;
+		}
+
+		try {
+			const fresh = await getJob( current.jobId );
+			const updated: ActiveJob = { ...current, status: fresh.status, error: fresh.error || undefined };
+			setActiveJob( updated );
+			activeJobRef.current = updated;
+
+			if ( isTerminal( fresh.status ) ) {
+				await finalizeJob( updated );
+			}
+		} catch ( pollErr ) {
+			// Network blip — keep polling, but surface the latest error.
+			setError( ( pollErr as Error )?.message || __( 'Polling failed.', 'extrachill-studio' ) );
+		}
+	}, [ finalizeJob ] );
+
+	const startPolling = useCallback( (): void => {
+		stopPolling();
+		pollTimerRef.current = setInterval( () => {
+			pollOnce();
+		}, POLL_INTERVAL_MS );
+	}, [ pollOnce, stopPolling ] );
+
+	// Resume polling when the tab regains focus.
+	useEffect( () => {
+		const onVisibilityChange = (): void => {
+			if ( document.visibilityState === 'visible' && activeJobRef.current && ! isTerminal( activeJobRef.current.status ) ) {
+				pollOnce();
+			}
+		};
+		document.addEventListener( 'visibilitychange', onVisibilityChange );
+		return () => {
+			document.removeEventListener( 'visibilitychange', onVisibilityChange );
+		};
+	}, [ pollOnce ] );
+
+	// Clean up the timer on unmount.
+	useEffect( () => {
+		return () => {
+			stopPolling();
+		};
+	}, [ stopPolling ] );
+
+	// ── Pipeline ──────────────────────────────────────────────────────
+
+	const startTranscription = async (): Promise< void > => {
+		if ( ! selectedFile || isBusy ) {
+			return;
+		}
+
+		setError( '' );
+		const config = PRESET_CONFIG[ preset ];
+		const startedAt = Date.now();
+
+		try {
+			setStageMessage( __( 'Authorizing…', 'extrachill-studio' ) );
+
+			setStageMessage( __( 'Uploading audio…', 'extrachill-studio' ) );
+			const upload = await uploadAudio( selectedFile );
+
+			setStageMessage( __( 'Submitting transcription job…', 'extrachill-studio' ) );
+			const job = await createJob( {
+				uploadPath: upload.path,
+				model: config.model,
+				diarize: config.diarize,
+				removeFillers: config.removeFillers,
+			} );
+
+			const tracked: ActiveJob = {
+				jobId: job.id,
+				filename: selectedFile.name,
+				preset,
+				status: job.status,
+				startedAt,
+			};
+			setActiveJob( tracked );
+			activeJobRef.current = tracked;
+			setSelectedFile( null );
+			if ( fileInputRef.current ) {
+				fileInputRef.current.value = '';
+			}
+
+			setStageMessage( __( 'Job running…', 'extrachill-studio' ) );
+			startPolling();
+
+			// Kick an immediate poll so short jobs flip to "completed" without a 5s wait.
+			pollOnce();
+		} catch ( pipelineErr ) {
+			setStageMessage( '' );
+			setError( ( pipelineErr as Error )?.message || __( 'Transcription failed to start.', 'extrachill-studio' ) );
+		}
+	};
+
+	const retryFromHistory = ( job: ActiveJob ): void => {
+		// Drop the failed entry from history so the UI reads clean; user must re-pick the file.
+		setHistory( ( prev ) => prev.filter( ( h ) => h.jobId !== job.jobId ) );
+		setError( __( 'Re-select the audio file to retry.', 'extrachill-studio' ) );
+	};
+
+	// ── Clipboard / download / view ──────────────────────────────────
+
+	const copyTranscript = async ( job: ActiveJob ): Promise< void > => {
+		if ( ! job.transcript ) {
+			return;
+		}
+		try {
+			await navigator.clipboard.writeText( job.transcript );
+			setCopiedJobId( job.jobId );
+			setTimeout( () => {
+				setCopiedJobId( ( current ) => ( current === job.jobId ? null : current ) );
+			}, COPY_FEEDBACK_MS );
+		} catch {
+			setError( __( 'Clipboard copy failed — your browser may have blocked it.', 'extrachill-studio' ) );
+		}
+	};
+
+	const downloadTranscript = ( job: ActiveJob ): void => {
+		if ( ! job.transcript ) {
+			return;
+		}
+		downloadTranscriptBlob( job.transcript, job.filename );
+	};
+
+	const toggleExpanded = ( jobId: string ): void => {
+		setExpandedJobId( ( current ) => ( current === jobId ? null : jobId ) );
+	};
+
+	// ── Render ────────────────────────────────────────────────────────
+
+	const dropZoneClass = `ec-studio-transcribe__dropzone${ isDragging ? ' is-dragging' : '' }${ selectedFile ? ' has-file' : '' }`;
+
+	const dropZone = h(
+		'div',
+		{
+			className: dropZoneClass,
+			onDragOver,
+			onDragLeave,
+			onDrop,
+			onClick: onPickButtonClick,
+			role: 'button',
+			tabIndex: 0,
+		},
+		createElement( 'input', {
+			ref: fileInputRef,
+			type: 'file',
+			accept: 'audio/*,video/mp4',
+			onChange: onFilePickerChange,
+			style: { display: 'none' },
+		} ),
+		selectedFile
+			? h(
+				'div',
+				{ className: 'ec-studio-transcribe__file' },
+				createElement( 'strong', null, selectedFile.name ),
+				createElement( 'span', { className: 'ec-studio-transcribe__file-meta' }, formatMB( selectedFile.size ) )
+			)
+			: h(
+				'div',
+				{ className: 'ec-studio-transcribe__dropzone-prompt' },
+				createElement( 'div', { className: 'ec-studio-transcribe__dropzone-headline' },
+					__( 'Drag audio here or click to upload', 'extrachill-studio' )
+				),
+				createElement( 'div', { className: 'ec-studio-transcribe__dropzone-meta' },
+					sprintf(
+						/* translators: %s: list of supported file extensions */
+						__( 'Supported: %s · Max 500 MB', 'extrachill-studio' ),
+						SUPPORTED_EXTENSIONS.join( ', ' )
+					)
+				)
+			)
+	);
+
+	const presetSelect = createElement(
+		'select',
+		{
+			id: 'ec-studio-transcribe-preset',
+			className: 'ec-studio-transcribe__preset',
+			value: preset,
+			onChange: ( event: ChangeEvent< HTMLSelectElement > ) => setPreset( event.target.value as TranscribePreset ),
+			disabled: isBusy,
+		},
+		( Object.keys( PRESET_CONFIG ) as TranscribePreset[] ).map( ( key ) =>
+			createElement(
+				'option',
+				{ key, value: key },
+				`${ PRESET_CONFIG[ key ].label } — ${ PRESET_CONFIG[ key ].description }`
+			)
+		)
+	);
+
+	const transcribeButton = createElement(
+		'button',
+		{
+			type: 'button',
+			className: 'button-1 button-medium',
+			onClick: startTranscription,
+			disabled: ! selectedFile || isBusy,
+		},
+		isBusy ? __( 'Working…', 'extrachill-studio' ) : __( 'Transcribe', 'extrachill-studio' )
+	);
+
+	const renderActiveJob = (): ReactElement | null => {
+		if ( ! activeJob ) {
+			return null;
+		}
+		const elapsed = formatElapsed( activeJob.startedAt );
+		return h(
+			PanelView,
+			{ className: 'ec-studio-panel ec-studio-transcribe__active', compact: true },
+			h( PanelHeader, { description: __( 'Active job', 'extrachill-studio' ) } ),
+			createElement(
+				'div',
+				{ className: 'ec-studio-transcribe__active-meta' },
+				createElement( 'strong', null, activeJob.filename ),
+				createElement( 'span', null, ' · ' ),
+				createElement( 'span', { className: 'ec-studio-transcribe__status' }, activeJob.status ),
+				createElement( 'span', null, ' · ' ),
+				createElement( 'span', null, sprintf(
+					/* translators: %s: elapsed M:SS */
+					__( '%s elapsed', 'extrachill-studio' ),
+					elapsed
+				) )
+			),
+			stageMessage
+				? h( InlineStatusView, { tone: 'info', className: 'ec-studio-message' }, stageMessage )
+				: null
+		);
+	};
+
+	const renderHistoryItem = ( job: ActiveJob ): ReactElement => {
+		const isExpanded = expandedJobId === job.jobId;
+		const elapsed = formatElapsed( job.startedAt, job.completedAt );
+		const presetLabel = PRESET_CONFIG[ job.preset ].label;
+
+		const headerLine = createElement(
+			'div',
+			{ className: 'ec-studio-transcribe__history-header' },
+			createElement( 'strong', null, job.filename ),
+			createElement( 'span', { className: 'ec-studio-transcribe__history-meta' },
+				` · ${ job.status } · ${ presetLabel } · ${ elapsed }`
+			)
+		);
+
+		if ( job.status === 'failed' || job.status === 'stopped' ) {
+			return createElement(
+				'li',
+				{ key: job.jobId, className: 'ec-studio-transcribe__history-item is-failed' },
+				headerLine,
+				job.error
+					? createElement( 'div', { className: 'ec-studio-transcribe__history-error' },
+						sprintf(
+							/* translators: %s: server-reported error */
+							__( 'Error: %s', 'extrachill-studio' ),
+							job.error
+						)
+					)
+					: null,
+				createElement(
+					'div',
+					{ className: 'ec-studio-transcribe__history-actions' },
+					createElement(
+						'button',
+						{
+							type: 'button',
+							className: 'button-1 button-small',
+							onClick: () => retryFromHistory( job ),
+						},
+						__( 'Retry', 'extrachill-studio' )
+					)
+				)
+			);
+		}
+
+		// completed
+		return createElement(
+			'li',
+			{ key: job.jobId, className: 'ec-studio-transcribe__history-item' },
+			headerLine,
+			createElement(
+				'div',
+				{ className: 'ec-studio-transcribe__history-actions' },
+				createElement(
+					'button',
+					{
+						type: 'button',
+						className: 'button-1 button-small',
+						onClick: () => copyTranscript( job ),
+						disabled: ! job.transcript,
+					},
+					copiedJobId === job.jobId
+						? __( 'Copied', 'extrachill-studio' )
+						: __( 'Copy', 'extrachill-studio' )
+				),
+				createElement(
+					'button',
+					{
+						type: 'button',
+						className: 'button-1 button-small button-secondary',
+						onClick: () => downloadTranscript( job ),
+						disabled: ! job.transcript,
+					},
+					__( 'Download .txt', 'extrachill-studio' )
+				),
+				createElement(
+					'button',
+					{
+						type: 'button',
+						className: 'button-1 button-small button-secondary',
+						onClick: () => toggleExpanded( job.jobId ),
+						disabled: ! job.transcript,
+					},
+					isExpanded
+						? __( 'Hide transcript', 'extrachill-studio' )
+						: __( 'View transcript', 'extrachill-studio' )
+				)
+			),
+			isExpanded && job.transcript
+				? createElement(
+					'pre',
+					{ className: 'ec-studio-transcribe__transcript' },
+					job.transcript
+				)
+				: null
+		);
+	};
+
+	return h(
+		'div',
+		{ className: 'ec-studio-pane ec-studio-pane--transcribe' },
+		h(
+			PanelView,
+			{ className: 'ec-studio-panel', compact: true },
+			h( PanelHeader, {
+				description: __( 'Transcribe audio with Whisper. Upload a file, pick a quality preset, and get a plain-text transcript.', 'extrachill-studio' ),
+			} ),
+			h(
+				'div',
+				{ className: 'ec-studio-composer' },
+				dropZone,
+				h(
+					FieldGroupView,
+					{ label: __( 'Quality', 'extrachill-studio' ), htmlFor: 'ec-studio-transcribe-preset' },
+					presetSelect
+				),
+				h(
+					ActionRowView,
+					{ className: 'ec-studio-composer__actions' },
+					transcribeButton
+				)
+			),
+			error ? h( InlineStatusView, { tone: 'error', className: 'ec-studio-message' }, error ) : null
+		),
+		renderActiveJob(),
+		history.length > 0
+			? h(
+				PanelView,
+				{ className: 'ec-studio-panel', compact: true },
+				h( PanelHeader, {
+					description: __( 'Recent transcriptions (this session)', 'extrachill-studio' ),
+				} ),
+				createElement(
+					'ul',
+					{ className: 'ec-studio-transcribe__history' },
+					...history.map( renderHistoryItem )
+				)
+			)
+			: null
+	);
+};
+
+export default TranscribePane;

--- a/src/blocks/studio/tabs/transcribe/tokenManager.ts
+++ b/src/blocks/studio/tabs/transcribe/tokenManager.ts
@@ -1,0 +1,100 @@
+/**
+ * Token manager for the sweatpants compute worker.
+ *
+ * Mints a short-lived HMAC-signed bearer token via the WordPress ability
+ * `extrachill/sweatpants-token` and caches it in module scope for the
+ * lifetime of the page. Re-mints automatically when the cached token is
+ * within `EXPIRY_BUFFER_SECONDS` of expiry (clock skew protection).
+ *
+ * The token does NOT cross between tabs — it's minted lazily on the first
+ * sweatpants call from the Transcribe tab.
+ *
+ * @package ExtraChillStudio
+ */
+
+import apiFetch from '@wordpress/api-fetch';
+import type { SweatpantsToken } from './types';
+
+const TOKEN_ABILITY_PATH = '/wp/v2/abilities/extrachill/sweatpants-token/execute';
+const DEFAULT_SCOPE = 'uploads:write jobs:write jobs:read';
+const DEFAULT_TTL_SECONDS = 900;
+const EXPIRY_BUFFER_SECONDS = 60;
+
+let cachedToken: SweatpantsToken | null = null;
+let inflight: Promise< SweatpantsToken > | null = null;
+
+/**
+ * Returns the current unix time in seconds.
+ */
+const nowSeconds = (): number => Math.floor( Date.now() / 1000 );
+
+/**
+ * Returns true if the cached token exists and has at least
+ * `EXPIRY_BUFFER_SECONDS` of life remaining.
+ */
+const tokenIsFresh = ( token: SweatpantsToken | null ): token is SweatpantsToken => {
+	if ( ! token ) {
+		return false;
+	}
+	return token.expires_at - EXPIRY_BUFFER_SECONDS > nowSeconds();
+};
+
+/**
+ * Mint a new token via the WordPress ability.
+ *
+ * @throws Error if the ability call fails or returns a malformed payload.
+ */
+const mintToken = async (): Promise< SweatpantsToken > => {
+	const response = await apiFetch< SweatpantsToken >( {
+		path: TOKEN_ABILITY_PATH,
+		method: 'POST',
+		data: {
+			scope: DEFAULT_SCOPE,
+			ttl: DEFAULT_TTL_SECONDS,
+		},
+	} );
+
+	if ( ! response || typeof response.token !== 'string' || typeof response.expires_at !== 'number' ) {
+		throw new Error( 'Token ability returned an unexpected payload.' );
+	}
+
+	return response;
+};
+
+/**
+ * Get a valid sweatpants bearer token, minting + caching if needed.
+ *
+ * Concurrent callers share a single in-flight mint promise so we don't
+ * thrash the ability with parallel requests during a burst (e.g. file
+ * upload + job-create kick off back-to-back).
+ */
+export const getToken = async (): Promise< SweatpantsToken > => {
+	if ( tokenIsFresh( cachedToken ) ) {
+		return cachedToken;
+	}
+
+	if ( inflight ) {
+		return inflight;
+	}
+
+	inflight = ( async (): Promise< SweatpantsToken > => {
+		try {
+			const fresh = await mintToken();
+			cachedToken = fresh;
+			return fresh;
+		} finally {
+			inflight = null;
+		}
+	} )();
+
+	return inflight;
+};
+
+/**
+ * Forcibly drop the cached token. Useful when the server returns 401 and
+ * we want the next call to re-mint instead of trying the expired token
+ * again.
+ */
+export const invalidateToken = (): void => {
+	cachedToken = null;
+};

--- a/src/blocks/studio/tabs/transcribe/types.ts
+++ b/src/blocks/studio/tabs/transcribe/types.ts
@@ -1,0 +1,105 @@
+/**
+ * Type definitions for the Transcribe tab.
+ *
+ * Shapes mirror the sweatpants worker REST contract (https://sweatpants.chubes.net)
+ * and the extrachill/sweatpants-token WordPress ability response.
+ *
+ * @package ExtraChillStudio
+ */
+
+/**
+ * Bearer token minted by the WordPress ability `extrachill/sweatpants-token`.
+ *
+ * The token is HMAC-SHA256 signed (JWT-shaped, but NOT a JWT — pass as a
+ * literal Bearer). It carries the requested scope claims and an expiry.
+ */
+export interface SweatpantsToken {
+	token: string;
+	expires_at: number;
+	scope: string;
+}
+
+/** Result of POST /uploads on sweatpants. */
+export interface SweatpantsUpload {
+	upload_id: string;
+	path: string;
+	filename: string;
+	size_bytes: number;
+	mime_type: string;
+	created_at: number;
+}
+
+/** Lifecycle states reported by sweatpants for a job. */
+export type SweatpantsJobStatus = 'pending' | 'running' | 'completed' | 'failed' | 'stopped';
+
+/** Result of GET /jobs/{id} on sweatpants. */
+export interface SweatpantsJob {
+	id: string;
+	module_id: string;
+	status: SweatpantsJobStatus;
+	created_at: string;
+	started_at: string | null;
+	completed_at: string | null;
+	error: string | null;
+}
+
+/**
+ * Result of GET /jobs/{id}/results on sweatpants.
+ *
+ * For audio-transcription, `data.content.transcription` is the plain
+ * transcript. When `diarize=true`, `data.content.combined_txt` carries
+ * speaker labels; when also `remove_fillers=true`,
+ * `data.content.combined_txt_clean` is the clean speaker-labelled version.
+ */
+export interface SweatpantsJobResult {
+	id: number;
+	data: {
+		status: 'complete';
+		files: Record< string, string >;
+		content: Record< string, string >;
+		stats: {
+			segments: number;
+			speakers: number | null;
+			duration: number;
+		};
+	};
+	created_at: string;
+}
+
+export interface SweatpantsJobResults {
+	results: SweatpantsJobResult[];
+	total: number;
+}
+
+/**
+ * Quality/feature preset surfaced in the UI.
+ *
+ * Maps to (model, diarize, remove_fillers) tuples — see PRESET_CONFIG in
+ * the pane component. A single dropdown is friendlier than three independent
+ * controls and the team only needs three sensible combinations.
+ */
+export type TranscribePreset = 'quick' | 'standard' | 'publish';
+
+/** Stages the pane walks through for a single transcription request. */
+export type TranscribeStage =
+	| 'idle'
+	| 'fileSelected'
+	| 'mintingToken'
+	| 'uploading'
+	| 'submittingJob'
+	| 'polling'
+	| 'fetchingResults'
+	| 'done'
+	| 'error';
+
+/** A transcription job tracked in the React component's local state. */
+export interface ActiveJob {
+	jobId: string;
+	filename: string;
+	preset: TranscribePreset;
+	status: SweatpantsJobStatus;
+	startedAt: number;
+	completedAt?: number;
+	transcript?: string;
+	error?: string;
+}

--- a/src/blocks/studio/view.ts
+++ b/src/blocks/studio/view.ts
@@ -9,6 +9,7 @@ import type { StudioContext, StudioPaneProps } from './types/studio';
 import ComposePane from './tabs/compose';
 import QrCodesPane from './tabs/qr-codes';
 import SocialsPane from './tabs/socials';
+import TranscribePane from './tabs/transcribe';
 
 const ROOT_SELECTOR = '[data-ec-studio-root]';
 
@@ -16,6 +17,7 @@ const STUDIO_PANES: Record< string, ComponentType< StudioPaneProps > > = {
 	compose: ComposePane,
 	'qr-codes': QrCodesPane,
 	socials: SocialsPane,
+	transcribe: TranscribePane,
 };
 
 const StudioApp = ( { context }: { context: StudioContext } ): ReactElement => {


### PR DESCRIPTION
## Summary

Adds a Transcribe tab to the Studio block that orchestrates the entire audio-to-transcript flow **browser ↔ sweatpants directly**. WordPress is in the path only to mint a short-lived HMAC bearer via the `extrachill/sweatpants-token` ability — no PHP in upload, job-create, polling, or results retrieval.

## User flow

1. User picks audio (file dialog or drag-drop) — client-side validates ≤500 MB.
2. User picks a quality preset (Quick / Standard / Publish) and clicks **Transcribe**.
3. Browser mints a 15-min bearer token via `POST /wp/v2/abilities/extrachill/sweatpants-token/execute` (scope `uploads:write jobs:write jobs:read`).
4. Browser uploads the file directly to `https://sweatpants.chubes.net/uploads`.
5. Browser submits a job to `https://sweatpants.chubes.net/jobs` against the `audio-transcription` module with `(model, diarize, remove_fillers)` derived from the preset.
6. Browser polls `GET /jobs/{id}` every 5s. Polling pauses while the browser tab is hidden and resumes on focus.
7. On `completed`, browser fetches `GET /jobs/{id}/results` and surfaces the transcript with **Copy**, **Download .txt**, **View transcript** actions.

## Files added / modified

**New:**
- `src/blocks/studio/tabs/transcribe/types.ts` — sweatpants response shapes + local state types
- `src/blocks/studio/tabs/transcribe/tokenManager.ts` — module-scope token cache, 60s expiry buffer, in-flight mint dedup, 401 invalidation
- `src/blocks/studio/tabs/transcribe/client.ts` — `uploadAudio`, `createJob`, `getJob`, `getResults` over `globalThis.fetch`
- `src/blocks/studio/tabs/transcribe/index.ts` — `TranscribePane` React component (drop zone, preset dropdown, active-job card, history list)

**Modified:**
- `src/blocks/studio/app/tabs.ts` — `transcribe` tab registered between `socials` and `qr-codes`
- `src/blocks/studio/view.ts` — `TranscribePane` wired into `STUDIO_PANES`
- `src/blocks/studio/style.css` — scoped `.ec-studio-transcribe__*` styles for drop zone, active-job card, history list, transcript viewer

## TypeScript types overview

```ts
SweatpantsToken         // { token, expires_at, scope } from the WP ability
SweatpantsUpload        // POST /uploads response
SweatpantsJob           // GET /jobs/{id} response
SweatpantsJobStatus     // 'pending' | 'running' | 'completed' | 'failed' | 'stopped'
SweatpantsJobResults    // GET /jobs/{id}/results envelope
TranscribePreset        // 'quick' | 'standard' | 'publish'
ActiveJob               // local React state for an in-flight or completed job
```

`PRESET_CONFIG` maps the three presets to `(model, diarize, removeFillers)`:
- **Quick draft** → `base, false, false`
- **Standard** → `medium, false, false` (default)
- **Publish quality** → `large, true, true`

Transcript field selection prefers `combined_txt_clean` (diarized + filler-stripped) → `combined_txt` (diarized) → `transcription` (plain), so the same UI handles all three preset outputs.

## Test plan (post-merge + deploy)

1. Visit a page with the Studio block as a logged-in team member or admin.
2. Click the new **Transcribe** tab — it sits between Socials and QR Codes.
3. Drag a small `.mp3` (a few minutes) into the drop zone, leave preset on **Standard**, click **Transcribe**.
4. Verify the network tab shows: 1× ability call to `…/abilities/extrachill/sweatpants-token/execute`, 1× `POST sweatpants.chubes.net/uploads`, 1× `POST sweatpants.chubes.net/jobs`, then `GET /jobs/{id}` polls every 5s.
5. When the job completes, the active-job card flips into the **Recent Transcriptions** list. **Copy** writes the transcript to clipboard with "Copied" feedback for 2s, **Download .txt** saves a `<filename>.transcript.txt` blob, **View transcript** expands the body in a scrollable monospace pane.
6. Run a `Quick draft` job to sanity-check the smaller model path.
7. Run a `Publish quality` job to confirm `combined_txt_clean` is what gets surfaced when diarize+fillers are on.
8. Try uploading a >500 MB file — client-side rejection fires before any sweatpants call.
9. Switch tabs mid-poll, switch back — polling pauses on `visibilitychange=hidden` and resumes on visible.

## Known gotchas

- **CORS:** sweatpants does not currently advertise CORS headers in spec docs. If the browser blocks the cross-origin upload/job/poll calls, file a sweatpants-core CORS issue. Multipart browser POST should work in practice; we did not hit CORS during local development of the request shape, but production verification is the first deploy step.
- **File size limit:** hardcoded 500 MB to match sweatpants' default cap. If sweatpants raises the cap, bump `MAX_UPLOAD_BYTES` in `client.ts`.
- **Token lifecycle:** tokens are cached in module scope for the lifetime of the page. Switching between tabs does not re-mint; navigating away and back to a fresh page does. The 60s expiry buffer guards against clock skew. On `401`, the client drops the cache and retries once before bubbling the error.
- **Sweatpants base URL is hardcoded** (`https://sweatpants.chubes.net`). For multi-environment support (staging/dev), hoist to a server-injected value via `render.php` data attribute or `wp_localize_script`. Documented inline in `client.ts`.
- **No cross-session persistence:** the Recent Transcriptions list lives in React state only. Refresh = clean slate. Future iteration could list `GET /jobs` filtered by user sub claim once that's wired up.
- **One concurrent job:** v1 supports a single in-flight transcription at a time. The button disables while a job is non-terminal.

## Out of scope (per brief)

- Save-as-draft to `/wp/v2/posts` from the transcript (follow-up PR)
- Cross-session history (needs server-side or sweatpants-side index)
- WebSocket live progress (v1 shows status + elapsed time)
- Multiple concurrent uploads
- Mobile-first UX
- CHANGELOG / version bump (homeboy owns both at release time)

## Verification done locally

- `npm run typecheck` — clean
- `npm run build` — succeeds, output webpack-compiled
- Bundle grep'd: zero references to deleted `transcribe-recording` / `transcription-job-status` abilities; `sweatpants-token` and `sweatpants.chubes.net` are present as expected

cc <@532385681268408341>