### PR TITLE
fix: token-mint ability call uses correct Abilities API REST path

### DIFF
--- a/src/blocks/studio/tabs/transcribe/tokenManager.ts
+++ b/src/blocks/studio/tabs/transcribe/tokenManager.ts
@@ -15,7 +15,10 @@
 import apiFetch from '@wordpress/api-fetch';
 import type { SweatpantsToken } from './types';
 
-const TOKEN_ABILITY_PATH = '/wp/v2/abilities/extrachill/sweatpants-token/execute';
+// The Abilities API exposes its REST surface under /wp-abilities/v1, NOT
+// /wp/v2/abilities, and the action verb is /run, not /execute. Verified
+// against the live `/wp-json/` discovery on studio.extrachill.com.
+const TOKEN_ABILITY_PATH = '/wp-abilities/v1/abilities/extrachill/sweatpants-token/run';
 const DEFAULT_SCOPE = 'uploads:write jobs:write jobs:read';
 const DEFAULT_TTL_SECONDS = 900;
 const EXPIRY_BUFFER_SECONDS = 60;


### PR DESCRIPTION
Fixes #54.

## Summary

One-line fix: change the Abilities API REST path in `tokenManager.ts` from `/wp/v2/abilities/extrachill/sweatpants-token/execute` (which 404s — that namespace doesn't exist) to `/wp-abilities/v1/abilities/extrachill/sweatpants-token/run` (the canonical Abilities API surface, verified against `/wp-json/` discovery on production).

## Why this broke

I wrote the Phase B2 minion brief with the wrong REST path and didn't sanity-check it against what the Abilities API actually exposes. Two mistakes baked into the brief:

| | Wrong (in brief + minion code) | Right (this PR) |
|---|---|---|
| Namespace | `wp/v2/abilities` | `wp-abilities/v1/abilities` |
| Action verb | `/execute` | `/run` |

## Test plan

After merge + deploy:

1. Studio team member opens the Transcribe tab on `studio.extrachill.com`
2. Selects a small audio file
3. Clicks **Transcribe**
4. Token mints successfully (no "no route was found" / 404), upload to sweatpants begins, transcription runs to completion

## Out of scope

- Widening accepted file types — tracked separately as #55
- ffmpeg conversion docs — tracked separately as Extra-Chill/sweatpants-modules#3