### PR TITLE
refactor(socials): nuke standalone 'paste external URL' input from publish pane

### DIFF
--- a/src/blocks/studio/tabs/socials/publish/index.ts
+++ b/src/blocks/studio/tabs/socials/publish/index.ts
@@ -40,7 +40,6 @@ interface SelectedImage {
  */
 const PlatformPublishPane = ( { slug, label, username, config }: PlatformPublishPaneProps ): ReactElement => {
 	const [ caption, setCaption ] = useState( '' );
-	const [ imageUrlInput, setImageUrlInput ] = useState( '' );
 	const [ images, setImages ] = useState< SelectedImage[] >( [] );
 	const [ isPublishing, setIsPublishing ] = useState( false );
 	const [ status, setStatus ] = useState( '' );
@@ -53,27 +52,6 @@ const PlatformPublishPane = ( { slug, label, username, config }: PlatformPublish
 	const platformLabel = label || slug;
 	const charLimit = config.charLimit || 0;
 	const supportsImages = ( config.maxImages || 0 ) > 0 || config.supportsCarousel;
-
-	const addImageUrl = (): void => {
-		const nextUrl = imageUrlInput.trim();
-
-		if ( ! nextUrl ) {
-			setError( __( 'Enter an image URL first.', 'extrachill-studio' ) );
-			return;
-		}
-
-		try {
-			new URL( nextUrl );
-		} catch {
-			setError( __( 'Please enter a valid image URL.', 'extrachill-studio' ) );
-			return;
-		}
-
-		setImages( ( current ) => [ ...current, { url: nextUrl } ] );
-		setImageUrlInput( '' );
-		setError( '' );
-		setStatus( __( 'External image URL added to publish queue.', 'extrachill-studio' ) );
-	};
 
 	const handleMediaSelect = ( url: string, item: NetworkMediaItem ): void => {
 		setImages( ( current ) => [
@@ -365,42 +343,7 @@ const PlatformPublishPane = ( { slug, label, username, config }: PlatformPublish
 					: null,
 				// 2. Selected images thumbnail row (renders nothing when queue is empty).
 				supportsImages ? renderImageThumbnails() : null,
-				// 3. External URL fallback — paste + Add button.
-				supportsImages
-					? h(
-						FieldGroupView,
-						{
-							label: __( 'Or paste an external URL', 'extrachill-studio' ),
-							htmlFor: `ec-studio-${ slug }-image-url`,
-							help: __( 'Public image URLs (e.g. Dropbox, Drive) — for files not yet in the media library, prefer the Upload tile above.', 'extrachill-studio' ),
-						},
-						createElement( 'input', {
-							id: `ec-studio-${ slug }-image-url`,
-							type: 'url',
-							value: imageUrlInput,
-							onChange: ( event: ChangeEvent< HTMLInputElement > ) => setImageUrlInput( event.target.value ),
-							placeholder: 'https://example.com/image.jpg',
-							autoComplete: 'url',
-						} )
-					)
-					: null,
-				supportsImages
-					? h(
-						ActionRowView,
-						{ className: 'ec-studio-composer__actions' },
-						createElement(
-							'button',
-							{
-								type: 'button',
-								className: 'button-1 button-medium',
-								onClick: addImageUrl,
-								disabled: ! imageUrlInput.trim(),
-							},
-							__( 'Add External URL', 'extrachill-studio' )
-						)
-					)
-					: null,
-				// 4. Caption textarea.
+				// 3. Caption textarea.
 				h(
 					FieldGroupView,
 					{
@@ -419,10 +362,10 @@ const PlatformPublishPane = ( { slug, label, username, config }: PlatformPublish
 						maxLength: charLimit > 0 ? charLimit : undefined,
 					} )
 				),
-				// 5. Status / error inline messages.
+				// 4. Status / error inline messages.
 				error ? h( InlineStatusView, { tone: 'error', className: 'ec-studio-message' }, error ) : null,
 				! error && status ? h( InlineStatusView, { tone: 'success', className: 'ec-studio-message' }, status ) : null,
-				// 6. Action row — Submit for Review / Publish Now.
+				// 5. Action row — Submit for Review / Publish Now.
 				h(
 					ActionRowView,
 					{ className: 'ec-studio-composer__actions' },


### PR DESCRIPTION
## Summary

Removes the standalone **Or paste an external URL** field and its **Add External URL** button from the socials publish pane. It was redundant slop on top of the media picker — the network media library + upload tile is the canonical path for adding images.

## What changed

`src/blocks/studio/tabs/socials/publish/index.ts`:

- Removed the `imageUrlInput` / `setImageUrlInput` state.
- Removed the `addImageUrl` handler (URL validation, queue push, status messaging).
- Removed the `FieldGroup` rendering the URL input.
- Removed the `ActionRow` rendering the **Add External URL** button.
- Renumbered the inline section comments so they read 1 → 5 again.

Net diff: **+3 / -60** in one file.

## Why

The external URL paste box was a fallback added on top of the proper media picker. In practice it duplicated work the media picker already covers (the upload tile inside the picker handles new files; the library handles existing assets), and it muddied the publish UX. Killing it leaves a single clear path: pick from the network media library (or upload via the tile inside it), then publish.

## Verification

- `npm run build` — webpack compiled successfully.
- Grep for `imageUrlInput`, `addImageUrl`, `setImageUrlInput`, `External URL`, `paste an external` — zero hits in source.
- `ChangeEvent` import retained (still used by the caption textarea).
- `useState` import retained (still used by remaining state hooks).

## Out of scope

- No PHP / REST changes — `_studio_social_images` schema is unchanged; images already in queue still publish identically.
- No version bump or changelog edit (homeboy owns those).