### PR TITLE
fix: wrap token-mint POST body under 'input' key

### DIFF
--- a/src/blocks/studio/tabs/transcribe/tokenManager.ts
+++ b/src/blocks/studio/tabs/transcribe/tokenManager.ts
@@ -48,12 +48,20 @@ const tokenIsFresh = ( token: SweatpantsToken | null ): token is SweatpantsToken
  * @throws Error if the ability call fails or returns a malformed payload.
  */
 const mintToken = async (): Promise< SweatpantsToken > => {
+	// The Abilities API /run controller expects the ability inputs nested
+	// under an `input` key in the POST body — see
+	// class-wp-rest-abilities-v1-run-controller.php::get_input_from_request().
+	// Sending the inputs at the top level makes `$json_params['input']`
+	// return null and the ability framework rejects with "input is not of
+	// type object."
 	const response = await apiFetch< SweatpantsToken >( {
 		path: TOKEN_ABILITY_PATH,
 		method: 'POST',
 		data: {
-			scope: DEFAULT_SCOPE,
-			ttl: DEFAULT_TTL_SECONDS,
+			input: {
+				scope: DEFAULT_SCOPE,
+				ttl: DEFAULT_TTL_SECONDS,
+			},
 		},
 	} );
 


### PR DESCRIPTION
Fixes #57.

## Summary

The Abilities API `/run` REST controller reads the request body via `$request->get_json_params()['input']` (see `class-wp-rest-abilities-v1-run-controller.php:200-202`). The Transcribe tab was sending ability inputs at the top level, which made the controller resolve input as `null` and the ability framework reject with:

> Ability "extrachill/sweatpants-token" has invalid input. Reason: input is not of type object.

## Fix

One-line change in `tokenManager.ts`: nest `{ scope, ttl }` under a top-level `input` key.

```diff
 data: {
-    scope: DEFAULT_SCOPE,
-    ttl: DEFAULT_TTL_SECONDS,
+    input: {
+        scope: DEFAULT_SCOPE,
+        ttl: DEFAULT_TTL_SECONDS,
+    },
 },
```

## Test plan

After merge + deploy:

1. Reload Studio, open Transcribe tab
2. Click Transcribe
3. Token mints (no "input is not of type object" error)
4. Upload + transcription proceeds

If anything else breaks, file a follow-up — there may be more contract assumptions in `client.ts` (sweatpants direct calls) that haven't been exercised yet.

## Related

- #54 / PR #56 — fixed the REST namespace + verb (`/wp-abilities/v1/.../run`)
- #57 — this PR
- Both bugs traced to the same source: my B2 brief had multiple errors in the Abilities API REST contract section.