### PR TITLE
feat: React Transcribe tab passes callback handoff + close-the-tab UX (+ widen file types)

### DIFF
--- a/inc/abilities/sweatpants-token.php
+++ b/inc/abilities/sweatpants-token.php
@@ -125,9 +125,28 @@ function ec_studio_register_sweatpants_token_ability(): void {
 				'output_schema'       => array(
 					'type'       => 'object',
 					'properties' => array(
-						'token'      => array( 'type' => 'string' ),
-						'expires_at' => array( 'type' => 'integer' ),
-						'scope'      => array( 'type' => 'string' ),
+						'token'           => array( 'type' => 'string' ),
+						'expires_at'      => array( 'type' => 'integer' ),
+						'scope'           => array( 'type' => 'string' ),
+						// Callback handoff fields — populated only when the
+						// requested scope includes `callback:write`. The React
+						// tab passes these straight through to sweatpants in
+						// the job inputs so the worker can sign + POST a
+						// completion callback to our REST endpoint.
+						//
+						// `callback_secret` is the same value as the network
+						// option `sweatpants_signed_token_secret`. Returning
+						// it to the browser is acceptable because (a) the
+						// requester is already gated to team members, (b) the
+						// secret is only used to sign callbacks the receiver
+						// (this site) verifies — no privilege escalation path
+						// for a stolen browser-side copy beyond what the team
+						// member could already do, (c) it's per-deployment
+						// rotatable.
+						'callback_url'    => array( 'type' => array( 'string', 'null' ) ),
+						'callback_secret' => array( 'type' => array( 'string', 'null' ) ),
+						'callback_issuer' => array( 'type' => array( 'string', 'null' ) ),
+						'callback_user_id' => array( 'type' => array( 'integer', 'null' ) ),
 					),
 				),
 				'execute_callback'    => 'ec_studio_execute_sweatpants_token',
@@ -235,9 +254,30 @@ function ec_studio_execute_sweatpants_token( array $input ): array|\WP_Error {
 		);
 	}
 
-	return array(
+	$response = array(
 		'token'      => $token,
 		'expires_at' => $expires_at,
 		'scope'      => $payload['scope'],
 	);
+
+	// When the caller asked for `callback:write`, surface the handoff fields
+	// so the React tab can wire sweatpants to POST a completion callback
+	// back to /wp-json/extrachill/v1/transcribe/callback when the job
+	// finishes. See inc/transcription/callback.php for the receiver.
+	if ( in_array( 'callback:write', $requested_scopes, true ) ) {
+		$callback_url = function_exists( 'rest_url' )
+			? rest_url( 'extrachill/v1/transcribe/callback' )
+			: '';
+		$response['callback_url']     = $callback_url ?: null;
+		$response['callback_secret']  = $secret;
+		$response['callback_issuer']  = EC_STUDIO_SWEATPANTS_TOKEN_ISSUER;
+		$response['callback_user_id'] = $user_id;
+	} else {
+		$response['callback_url']     = null;
+		$response['callback_secret']  = null;
+		$response['callback_issuer']  = null;
+		$response['callback_user_id'] = null;
+	}
+
+	return $response;
 }

--- a/src/blocks/studio/tabs/transcribe/client.ts
+++ b/src/blocks/studio/tabs/transcribe/client.ts
@@ -107,22 +107,52 @@ interface CreateJobInput {
  *
  * The `output_dir` uses a UUID-ish unique-id so multiple concurrent jobs
  * never collide on the sweatpants host.
+ *
+ * If the cached token carries the `callback:write` scope (it does by
+ * default — see tokenManager.DEFAULT_SCOPE), the callback handoff fields
+ * from the token-mint response are passed through to sweatpants. The
+ * worker will then sign + POST a completion callback to our REST endpoint
+ * when the job finishes, which creates a draft on main extrachill.com and
+ * emails the uploader. This is what enables "close the tab, get an email"
+ * — the React polling loop is a fallback for users who stay on the page.
  */
 export const createJob = async ( input: CreateJobInput ): Promise< SweatpantsJob > => {
 	const uniqueId = ( typeof globalThis.crypto !== 'undefined' && 'randomUUID' in globalThis.crypto )
 		? globalThis.crypto.randomUUID()
 		: `job-${ Date.now() }-${ Math.random().toString( 36 ).slice( 2, 10 ) }`;
 
+	const token = await getToken();
+
+	const inputs: Record< string, unknown > = {
+		audio_path: input.uploadPath,
+		output_dir: `/var/lib/sweatpants/output/${ uniqueId }`,
+		model: input.model,
+		diarize: input.diarize,
+		remove_fillers: input.removeFillers,
+		language: input.language || 'en',
+	};
+
+	// Wire the completion callback when the token carries the necessary
+	// material. All four fields must be present together — sweatpants
+	// requires `callback_url`, and the receiver verification requires
+	// `callback_secret` + `callback_user_id`.
+	if (
+		token.callback_url &&
+		token.callback_secret &&
+		token.callback_user_id !== null
+	) {
+		inputs.callback_url = token.callback_url;
+		inputs.callback_secret = token.callback_secret;
+		inputs.callback_issuer = token.callback_issuer || 'extrachill-studio';
+		inputs.callback_user_id = token.callback_user_id;
+		// `callback_cleanup_on_success` defaults to true on the module side;
+		// leaving it unset preserves the headless-pipeline default of
+		// "receiver acks → worker deletes audio + outputs".
+	}
+
 	const payload = {
 		module_id: TRANSCRIPTION_MODULE_ID,
-		inputs: {
-			audio_path: input.uploadPath,
-			output_dir: `/var/lib/sweatpants/output/${ uniqueId }`,
-			model: input.model,
-			diarize: input.diarize,
-			remove_fillers: input.removeFillers,
-			language: input.language || 'en',
-		},
+		inputs,
 	};
 
 	return request< SweatpantsJob >( '/jobs', {

--- a/src/blocks/studio/tabs/transcribe/index.ts
+++ b/src/blocks/studio/tabs/transcribe/index.ts
@@ -37,6 +37,16 @@ const InlineStatusView = InlineStatus as unknown as ( props: any ) => ReactEleme
 /** Polling interval while jobs are pending or running (ms). */
 const POLL_INTERVAL_MS = 5000;
 
+/**
+ * After this many ms of being on the page with an in-flight job, stop the
+ * polling loop. The user is told up-front that they can close the tab and
+ * we'll email them — at that point the polling adds no value (it just
+ * burns network on a job that may take hours). Short jobs (`base` model
+ * on ~30s audio) finish well before this threshold so polling still
+ * delivers instant feedback for users who DO stay on the page.
+ */
+const POLLING_HANDOFF_MS = 90 * 1000;
+
 /** Time to flash "Copied" inline feedback after a successful clipboard write. */
 const COPY_FEEDBACK_MS = 2000;
 
@@ -76,8 +86,6 @@ const PRESET_CONFIG: Record< TranscribePreset, PresetConfig > = {
 		description: __( 'large model · ~3 hr · best quality, speaker labels, fillers removed', 'extrachill-studio' ),
 	},
 };
-
-const SUPPORTED_EXTENSIONS = [ '.mp3', '.m4a', '.wav', '.flac', '.ogg', '.mp4' ];
 
 const TERMINAL_STATUSES: ReadonlyArray< SweatpantsJobStatus > = [ 'completed', 'failed', 'stopped' ];
 
@@ -281,6 +289,20 @@ const TranscribePane = ( _props: StudioPaneProps ): ReactElement => {
 			return;
 		}
 
+		// After the handoff window, stop polling. The completion email is the
+		// canonical notification path; in-tab polling forever is wasted work.
+		const elapsedMs = Date.now() - current.startedAt;
+		if ( elapsedMs > POLLING_HANDOFF_MS ) {
+			stopPolling();
+			setStageMessage(
+				__(
+					'Job is still running on the worker. We\'ll email you when it\'s done — you can close this tab.',
+					'extrachill-studio'
+				)
+			);
+			return;
+		}
+
 		try {
 			const fresh = await getJob( current.jobId );
 			const updated: ActiveJob = { ...current, status: fresh.status, error: fresh.error || undefined };
@@ -294,7 +316,7 @@ const TranscribePane = ( _props: StudioPaneProps ): ReactElement => {
 			// Network blip — keep polling, but surface the latest error.
 			setError( ( pollErr as Error )?.message || __( 'Polling failed.', 'extrachill-studio' ) );
 		}
-	}, [ finalizeJob ] );
+	}, [ finalizeJob, stopPolling ] );
 
 	const startPolling = useCallback( (): void => {
 		stopPolling();
@@ -362,7 +384,12 @@ const TranscribePane = ( _props: StudioPaneProps ): ReactElement => {
 				fileInputRef.current.value = '';
 			}
 
-			setStageMessage( __( 'Job running…', 'extrachill-studio' ) );
+			setStageMessage(
+				__(
+					'Submitted. We\'ll email you when it\'s done — usually 5–60 minutes depending on length. You can close this tab.',
+					'extrachill-studio'
+				)
+			);
 			startPolling();
 
 			// Kick an immediate poll so short jobs flip to "completed" without a 5s wait.
@@ -424,8 +451,14 @@ const TranscribePane = ( _props: StudioPaneProps ): ReactElement => {
 		},
 		createElement( 'input', {
 			ref: fileInputRef,
+			// audio/* + video/* covers everything ffmpeg can decode on the
+			// worker side — phone recordings (m4a, aac, opus, amr), browser
+			// MediaRecorder output (webm), screen-recorded video (mp4, mov,
+			// mkv), etc. The audio-transcription module on sweatpants
+			// auto-converts to wav via ffmpeg before passing to Whisper, so
+			// the frontend only needs to accept what ffmpeg accepts.
 			type: 'file',
-			accept: 'audio/*,video/mp4',
+			accept: 'audio/*,video/*',
 			onChange: onFilePickerChange,
 			style: { display: 'none' },
 		} ),
@@ -443,10 +476,9 @@ const TranscribePane = ( _props: StudioPaneProps ): ReactElement => {
 					__( 'Drag audio here or click to upload', 'extrachill-studio' )
 				),
 				createElement( 'div', { className: 'ec-studio-transcribe__dropzone-meta' },
-					sprintf(
-						/* translators: %s: list of supported file extensions */
-						__( 'Supported: %s · Max 500 MB', 'extrachill-studio' ),
-						SUPPORTED_EXTENSIONS.join( ', ' )
+					__(
+						'Any audio or video file · Max 500 MB · auto-converted via ffmpeg',
+						'extrachill-studio'
 					)
 				)
 			)

--- a/src/blocks/studio/tabs/transcribe/tokenManager.ts
+++ b/src/blocks/studio/tabs/transcribe/tokenManager.ts
@@ -19,7 +19,10 @@ import type { SweatpantsToken } from './types';
 // /wp/v2/abilities, and the action verb is /run, not /execute. Verified
 // against the live `/wp-json/` discovery on studio.extrachill.com.
 const TOKEN_ABILITY_PATH = '/wp-abilities/v1/abilities/extrachill/sweatpants-token/run';
-const DEFAULT_SCOPE = 'uploads:write jobs:write jobs:read';
+// `callback:write` lets sweatpants sign and POST a completion callback
+// back to our REST endpoint when the job finishes — this is how the user
+// gets an email + draft post without keeping the browser tab open.
+const DEFAULT_SCOPE = 'uploads:write jobs:write jobs:read callback:write';
 const DEFAULT_TTL_SECONDS = 900;
 const EXPIRY_BUFFER_SECONDS = 60;
 

--- a/src/blocks/studio/tabs/transcribe/types.ts
+++ b/src/blocks/studio/tabs/transcribe/types.ts
@@ -17,6 +17,22 @@ export interface SweatpantsToken {
 	token: string;
 	expires_at: number;
 	scope: string;
+	/**
+	 * Callback handoff fields — populated by the WP token-mint ability when
+	 * the requested scope includes `callback:write`. The Transcribe tab
+	 * passes these through to sweatpants in the job inputs so the worker
+	 * can sign + POST a completion callback to our REST endpoint when the
+	 * job finishes. See `inc/transcription/callback.php` for the receiver.
+	 *
+	 * Returning `callback_secret` to the browser is acceptable because the
+	 * requester is already gated to team members; the secret only signs
+	 * callbacks the receiver verifies, so a stolen browser-side copy
+	 * doesn't escalate beyond what the team member can already do.
+	 */
+	callback_url: string | null;
+	callback_secret: string | null;
+	callback_issuer: string | null;
+	callback_user_id: number | null;
 }
 
 /** Result of POST /uploads on sweatpants. */


### PR DESCRIPTION
Fixes #61. Also fixes #55.

## Summary

Wires the React Transcribe tab into the completion-callback pipeline that sweatpants-modules#5 (deployed) and extrachill-studio#62 (deployed) built. Once this lands, the full "close the tab, get an email" UX works end-to-end.

Bundles the file-type widening (#55) since it's a one-line change in the same file and the same audience hit both bugs.

## What changed

| File | Change |
|---|---|
| `inc/abilities/sweatpants-token.php` | When the requested scope includes `callback:write`, the response now also returns `callback_url` (resolved via `rest_url`), `callback_secret` (the `sweatpants_signed_token_secret` network option), `callback_issuer`, and `callback_user_id` (current user). Output schema declares the four fields as nullable for non-callback scopes. |
| `tabs/transcribe/types.ts` | `SweatpantsToken` interface gains the four nullable callback fields. |
| `tabs/transcribe/tokenManager.ts` | `DEFAULT_SCOPE` adds `callback:write`. |
| `tabs/transcribe/client.ts` | `createJob()` passes the four callback fields into the sweatpants job inputs when the token carries them. |
| `tabs/transcribe/index.ts` | Polling stops after 90s (the email becomes the canonical notification). Post-submit message updated to set the user's expectation: *"Submitted. We'll email you when it's done — usually 5–60 minutes depending on length. You can close this tab."* When polling hands off, the stage message updates to *"Job is still running on the worker. We'll email you when it's done — you can close this tab."* |
| `tabs/transcribe/index.ts` | File picker `accept` widens from `audio/*,video/mp4` to `audio/*,video/*`. Drops the unused `SUPPORTED_EXTENSIONS` constant. Dropzone copy updates to *"Any audio or video file · Max 500 MB · auto-converted via ffmpeg"*. |

Net **+143 / −22** across 5 files.

## End-to-end flow this completes

```
browser → mint token via /wp-abilities/v1/abilities/extrachill/sweatpants-token/run
        ← { token, callback_url, callback_secret, callback_user_id, ... }
       
browser → POST audio to sweatpants /uploads
       
browser → POST job to sweatpants /jobs with callback_url + callback_secret + callback_user_id
        ← { job_id }

browser shows: "Submitted. We'll email you when it's done. You can close this tab."
browser polls for 90s, then stops

   --- user closes tab; backend continues ---

sweatpants → ffmpeg → Whisper → POST callback to studio.extrachill.com
                                with HMAC-signed Bearer token

extrachill-studio receiver
  → verifies HMAC via wp_native_auth_verify_external_token
  → confirms scope = callback:write
  → resolves user from sub claim
  → ec_cross_site_rest_request('main', POST /wp/v2/posts, ...)
  → wp_mail(user_email, "Your transcription is ready: <filename>", html_body)
  → returns 200 → sweatpants deletes upload + output dirs
```

## Why returning `callback_secret` to the browser is acceptable

- The requester is already gated to team members (`ec_is_team_member()` check on the token-mint ability).
- The secret only signs callbacks that the receiver (this site) verifies. A stolen browser-side copy can't be used to call extrachill.com endpoints — the verification matches on `(secret, payload)` and there's no privilege escalation path beyond what the team member could already do.
- It's per-deployment rotatable. If we ever need per-job ephemeral secrets, we can layer that in without breaking the contract shape.

## Test plan

After merge + deploy:

1. Open Studio in a browser, go to Transcribe tab
2. Drop an audio file (try `.opus` or `.aac` to verify file-type widening works)
3. Pick a preset, click Transcribe
4. **Confirm the success message**: "Submitted. We'll email you when it's done — usually 5–60 minutes depending on length. You can close this tab."
5. Close the tab entirely
6. Wait for the job to complete on sweatpants (~3–10 min for `quick`, ~30 min for `standard` on a typical interview)
7. Confirm an email arrives at the team member's WP email address
8. Click "Open draft in editor" → lands on the right edit URL on extrachill.com main
9. Confirm sweatpants cleaned up the upload + output dirs (`ls /var/lib/sweatpants/uploads/` and `ls /var/lib/sweatpants/output/`)

## Known follow-up

- `email_sent: false` from the smoke test on PR #62 — `wp_mail()` works in isolation but returned false from inside the callback handler. Needs a small debug session. Likely a context issue (no logged-in user during the callback request) confusing Easy WP SMTP. Tracked separately.

## Out of scope

- Persistent job history across browser sessions (current history is in-memory only)
- Per-user notification preferences (always email for v1)
- WebSocket log streaming as a fancier in-tab progress display (the email replaces the need for it)