### PR TITLE
fix: send completion email from main-site context so SMTP works

### DIFF
--- a/inc/transcription/callback.php
+++ b/inc/transcription/callback.php
@@ -292,7 +292,19 @@ function ec_studio_transcription_callback_create_draft(
  * Resolves the edit URL on main extrachill.com (the post lives there) so the
  * link drops the user directly into the WP editor for their new draft.
  *
+ * The entire body composition AND the wp_mail() call run inside
+ * `switch_to_blog( ec_get_blog_id('main') )`. This is required because
+ * Easy WP SMTP stores its config + encrypted credentials per-site —
+ * configuring it on main extrachill.com doesn't make the studio subsite
+ * see those credentials, so a wp_mail() call from studio's context
+ * either falls back to PHP mail() (no sendmail binary, fails) or hits
+ * SMTP with garbage decrypted credentials (auth failure). Sending from
+ * main's context is also semantically right: the email is FROM the
+ * editorial site where the draft lives, so the "From" address matches
+ * the link the recipient clicks.
+ *
  * @since 0.13.0
+ * @since 0.14.1 Wrap the wp_mail call in switch_to_blog so SMTP is configured.
  *
  * @param \WP_User $user        Recipient.
  * @param int      $post_id     Draft post id on main.
@@ -309,14 +321,9 @@ function ec_studio_transcription_callback_send_email(
 	array $stats
 ): bool {
 	$main_blog_id = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'main' ) : 0;
-	$edit_url     = '';
-	if ( $main_blog_id > 0 ) {
-		switch_to_blog( $main_blog_id );
-		try {
-			$edit_url = (string) get_edit_post_link( $post_id, 'raw' );
-		} finally {
-			restore_current_blog();
-		}
+
+	if ( $main_blog_id <= 0 ) {
+		return false;
 	}
 
 	$duration_sec = isset( $stats['duration'] ) ? (float) $stats['duration'] : 0;
@@ -339,21 +346,30 @@ function ec_studio_transcription_callback_send_email(
 		$filename
 	);
 
-	$body = ec_studio_transcription_render_completion_email(
-		array(
-			'recipient_name' => $user->display_name ?: $user->user_login,
-			'filename'       => $filename,
-			'duration_sec'   => $duration_sec,
-			'segments'       => $segments,
-			'has_speakers'   => $has_speakers,
-			'preview'        => $preview,
-			'edit_url'       => $edit_url,
-		)
-	);
+	switch_to_blog( $main_blog_id );
+	try {
+		$edit_url = (string) get_edit_post_link( $post_id, 'raw' );
 
-	$headers = array(
-		'Content-Type: text/html; charset=UTF-8',
-	);
+		$body = ec_studio_transcription_render_completion_email(
+			array(
+				'recipient_name' => $user->display_name ?: $user->user_login,
+				'filename'       => $filename,
+				'duration_sec'   => $duration_sec,
+				'segments'       => $segments,
+				'has_speakers'   => $has_speakers,
+				'preview'        => $preview,
+				'edit_url'       => $edit_url,
+			)
+		);
 
-	return (bool) wp_mail( $user->user_email, $subject, $body, $headers );
+		$headers = array(
+			'Content-Type: text/html; charset=UTF-8',
+		);
+
+		$sent = (bool) wp_mail( $user->user_email, $subject, $body, $headers );
+	} finally {
+		restore_current_blog();
+	}
+
+	return $sent;
 }


### PR DESCRIPTION
Fixes #64.

## Summary

The completion email sent by the transcription callback was returning `wp_mail() → false`. Root cause: Easy WP SMTP stores its config + encrypted credentials per-site, but the callback handler runs in `studio.extrachill.com` context where SMTP isn't configured.

## Fix

Extend the existing `switch_to_blog( ec_get_blog_id('main') )` block in `ec_studio_transcription_callback_send_email()` to wrap the `wp_mail()` call too, not just the `get_edit_post_link()` resolution. The whole body composition + send happens in main's context now.

```diff
-	switch_to_blog( $main_blog_id );
-	try {
-		$edit_url = (string) get_edit_post_link( $post_id, 'raw' );
-	} finally {
-		restore_current_blog();
-	}
-	// …compose + send wp_mail outside the switch…
+	switch_to_blog( $main_blog_id );
+	try {
+		$edit_url = (string) get_edit_post_link( $post_id, 'raw' );
+		$body = ec_studio_transcription_render_completion_email( [...] );
+		$sent = (bool) wp_mail( $user->user_email, $subject, $body, $headers );
+	} finally {
+		restore_current_blog();
+	}
```

Net **+30 / −16** lines, single function.

## Why this is the right fix

- **SMTP config is on main**, so `wp_mail` from main's context picks up the correct AWS SES credentials.
- **Semantically correct**: the email is FROM the editorial site where the draft lives, matches the link the recipient clicks (also `extrachill.com/wp-admin/...`).
- **Survives future studio-only oversights**: even if someone configures SMTP independently on studio in the future, this code keeps sending from main, which is what we want.

## Verification

Empirically reproduced:

```
wp --url=studio.extrachill.com eval 'wp_mail(...)'                    → false (Could not authenticate)
wp --url=studio.extrachill.com eval 'switch_to_blog(1); wp_mail(...)' → true
```

After this PR + deploy, the smoke test against `/wp-json/extrachill/v1/transcribe/callback` should return `email_sent: true` and a real email should land in the recipient's inbox.

## Test plan

After merge + deploy:

1. POST a smoke-test callback to `/wp-json/extrachill/v1/transcribe/callback` with a valid HMAC token
2. Response should now show `"email_sent": true`
3. Recipient inbox should receive "Your transcription is ready: <filename>"
4. Email should render the green "Open draft in editor" button → click → lands on extrachill.com main editor

## Related

- #62 (callback receiver) — this is a follow-up bugfix that closes the loop on the email path
- #61 (React tab callback handoff) — together with #62 + this fix, completes the "close the tab, get an email" UX