### PR TITLE
fix(transcribe): use theme's .ec-checkbox-row primitive for option checkboxes

### DIFF
--- a/src/blocks/studio/style.css
+++ b/src/blocks/studio/style.css
@@ -788,32 +788,18 @@ html.is-fullscreen-mode .ec-studio-compose-editor .interface-interface-skeleton_
 	width: 100%;
 }
 
+/*
+ * Vertical stack for the two transcription option checkboxes
+ * (`Identify speakers`, `Remove filler words`). The .ec-checkbox-row
+ * primitive from the EC theme owns each row's internal layout — see
+ * https://github.com/Extra-Chill/extrachill/pull/21 — so this rule
+ * only handles the spacing between rows.
+ */
 .ec-studio-transcribe__options {
 	display: flex;
 	flex-direction: column;
 	gap: var(--spacing-xs);
 	margin-top: var(--spacing-sm);
-}
-
-.ec-studio-transcribe__checkbox-label {
-	display: grid;
-	grid-template-columns: auto 1fr;
-	column-gap: var(--spacing-sm);
-	align-items: baseline;
-	cursor: pointer;
-	padding: var(--spacing-xs) 0;
-}
-
-.ec-studio-transcribe__checkbox-label input[type="checkbox"] {
-	margin: 0;
-	grid-row: 1 / span 2;
-	align-self: center;
-}
-
-.ec-studio-transcribe__checkbox-hint {
-	grid-column: 2;
-	font-size: var(--font-size-sm);
-	color: var(--muted-text);
 }
 
 .ec-studio-transcribe__active {

--- a/src/blocks/studio/tabs/transcribe/index.ts
+++ b/src/blocks/studio/tabs/transcribe/index.ts
@@ -529,7 +529,7 @@ const TranscribePane = ( _props: StudioPaneProps ): ReactElement => {
 
 	const diarizeCheckbox = createElement(
 		'label',
-		{ className: 'ec-studio-transcribe__checkbox-label', htmlFor: 'ec-studio-transcribe-diarize' },
+		{ className: 'ec-checkbox-row', htmlFor: 'ec-studio-transcribe-diarize' },
 		createElement( 'input', {
 			id: 'ec-studio-transcribe-diarize',
 			type: 'checkbox',
@@ -544,14 +544,14 @@ const TranscribePane = ( _props: StudioPaneProps ): ReactElement => {
 		),
 		createElement(
 			'span',
-			{ className: 'ec-studio-transcribe__checkbox-hint' },
+			{ className: 'ec-checkbox-row__hint' },
 			__( 'adds ~15 min · best for multi-speaker interviews', 'extrachill-studio' )
 		)
 	);
 
 	const fillersCheckbox = createElement(
 		'label',
-		{ className: 'ec-studio-transcribe__checkbox-label', htmlFor: 'ec-studio-transcribe-fillers' },
+		{ className: 'ec-checkbox-row', htmlFor: 'ec-studio-transcribe-fillers' },
 		createElement( 'input', {
 			id: 'ec-studio-transcribe-fillers',
 			type: 'checkbox',
@@ -566,7 +566,7 @@ const TranscribePane = ( _props: StudioPaneProps ): ReactElement => {
 		),
 		createElement(
 			'span',
-			{ className: 'ec-studio-transcribe__checkbox-hint' },
+			{ className: 'ec-checkbox-row__hint' },
 			__( 'um, uh, like, you know — recommended for editorial polish', 'extrachill-studio' )
 		)
 	);


### PR DESCRIPTION
Adopts the .ec-checkbox-row primitive from Extra-Chill/extrachill#21 (deployed v2.4.0) to fix the label-butted-against-checkbox bug in the Transcribe tab. Drops the local grid-based CSS that didn't survive the global `input[type="checkbox"]` `margin-right` collapse. Net -14 LOC.