### PR TITLE
fix: clear all pre-existing lint errors blocking releases (#66)

### DIFF
--- a/extrachill-studio.php
+++ b/extrachill-studio.php
@@ -6,13 +6,13 @@
  * Version: 0.15.1
  * Author: Chris Huber
  * Author URI: https://chubes.net
- * Requires Plugins: extrachill-users
+ * Requires Plugins: extrachill-users, data-machine
  * License: GPL v2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: extrachill-studio
  * Requires at least: 6.9
  * Tested up to: 6.9
- * Requires PHP: 7.4
+ * Requires PHP: 8.2
  * Network: false
  *
  * @package ExtraChillStudio

--- a/inc/abilities/run-giveaway.php
+++ b/inc/abilities/run-giveaway.php
@@ -247,7 +247,10 @@ function ec_studio_execute_run_giveaway( array $input ): array|\WP_Error {
 		return new \WP_Error(
 			'no_valid_entries',
 			sprintf( 'No valid entries after filtering. %d comments, %d filtered out.', $stats['total_comments'], $stats['filtered_out'] ),
-			array( 'status' => 404, 'stats' => $stats )
+			array(
+				'status' => 404,
+				'stats'  => $stats,
+			)
 		);
 	}
 

--- a/inc/abilities/sweatpants-token.php
+++ b/inc/abilities/sweatpants-token.php
@@ -268,7 +268,7 @@ function ec_studio_execute_sweatpants_token( array $input ): array|\WP_Error {
 		$callback_url = function_exists( 'rest_url' )
 			? rest_url( 'extrachill/v1/transcribe/callback' )
 			: '';
-		$response['callback_url']     = $callback_url ?: null;
+		$response['callback_url']     = '' !== $callback_url ? $callback_url : null;
 		$response['callback_secret']  = $secret;
 		$response['callback_issuer']  = EC_STUDIO_SWEATPANTS_TOKEN_ISSUER;
 		$response['callback_user_id'] = $user_id;

--- a/inc/compose-editor.php
+++ b/inc/compose-editor.php
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return array
  */
 function register_compose_context( array $contexts ): array {
-	$contexts['studio'] = [
+	$contexts['studio'] = array(
 		'type'         => 'studio',
 		'textarea'     => '#ec-studio-compose-content',
 		'container'    => '.ec-studio-compose-editor',
@@ -46,7 +46,7 @@ function register_compose_context( array $contexts ): array {
 		'editor_setup' => function ( $engine ) {
 			// Add .gutenberg-support body class so BE's scoped toolbar/component
 			// dark mode styles in style-index.min.css apply.
-			add_filter( 'body_class', [ $engine, 'body_class' ] );
+			add_filter( 'body_class', array( $engine, 'body_class' ) );
 
 			// The IBE renders inline (shouldIframe=false), not in an iframe.
 			// Theme root.css variables are available on the host page, but
@@ -54,7 +54,7 @@ function register_compose_context( array $contexts ): array {
 			// proper sizing.
 			add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_editor_inline_styles', 50 );
 		},
-	];
+	);
 
 	return $contexts;
 }

--- a/inc/social-drafts.php
+++ b/inc/social-drafts.php
@@ -198,11 +198,16 @@ function on_publish_crosspost( string $new_status, string $old_status, \WP_Post 
 		return;
 	}
 
-	$images       = get_post_meta( $post->ID, META_IMAGES, true ) ?: array();
-	$aspect_ratio = get_post_meta( $post->ID, META_ASPECT_RATIO, true ) ?: '4:5';
-	$media_kind   = get_post_meta( $post->ID, META_MEDIA_KIND, true ) ?: 'image';
-	$video_url    = get_post_meta( $post->ID, META_VIDEO_URL, true ) ?: '';
-	$cover_url    = get_post_meta( $post->ID, META_COVER_URL, true ) ?: '';
+	$images       = get_post_meta( $post->ID, META_IMAGES, true );
+	$images       = ! empty( $images ) ? $images : array();
+	$aspect_ratio = get_post_meta( $post->ID, META_ASPECT_RATIO, true );
+	$aspect_ratio = ! empty( $aspect_ratio ) ? $aspect_ratio : '4:5';
+	$media_kind   = get_post_meta( $post->ID, META_MEDIA_KIND, true );
+	$media_kind   = ! empty( $media_kind ) ? $media_kind : 'image';
+	$video_url    = get_post_meta( $post->ID, META_VIDEO_URL, true );
+	$video_url    = ! empty( $video_url ) ? $video_url : '';
+	$cover_url    = get_post_meta( $post->ID, META_COVER_URL, true );
+	$cover_url    = ! empty( $cover_url ) ? $cover_url : '';
 
 	// Schedule async cross-post via DM Task System.
 	$job_id = \DataMachine\Engine\Tasks\TaskScheduler::schedule(
@@ -246,7 +251,8 @@ add_action( 'transition_post_status', __NAMESPACE__ . '\\on_publish_crosspost', 
  * @param array $results Array of result entries.
  */
 function log_publish_result( int $post_id, array $results ) {
-	$existing = get_post_meta( $post_id, META_PUBLISH_LOG, true ) ?: array();
+	$existing = get_post_meta( $post_id, META_PUBLISH_LOG, true );
+	$existing = ! empty( $existing ) ? $existing : array();
 	$merged   = array_merge( $existing, $results );
 	update_post_meta( $post_id, META_PUBLISH_LOG, $merged );
 }
@@ -287,8 +293,12 @@ function render_admin_columns( string $column, int $post_id ) {
 				return ! empty( $entry['success'] );
 			} ) );
 			$total   = count( $log );
-			/* translators: 1: success count 2: total count */
-			printf( esc_html__( '%1$d / %2$d posted', 'extrachill-studio' ), $success, $total );
+			printf(
+				/* translators: 1: success count 2: total count */
+				esc_html__( '%1$d / %2$d posted', 'extrachill-studio' ),
+				(int) $success,
+				(int) $total
+			);
 		} else {
 			$platforms = get_post_meta( $post_id, META_PLATFORMS, true );
 			if ( ! empty( $platforms ) ) {

--- a/inc/transcription/callback.php
+++ b/inc/transcription/callback.php
@@ -352,7 +352,7 @@ function ec_studio_transcription_callback_send_email(
 
 		$body = ec_studio_transcription_render_completion_email(
 			array(
-				'recipient_name' => $user->display_name ?: $user->user_login,
+				'recipient_name' => '' !== $user->display_name ? $user->display_name : $user->user_login,
 				'filename'       => $filename,
 				'duration_sec'   => $duration_sec,
 				'segments'       => $segments,

--- a/inc/transcription/email-template.php
+++ b/inc/transcription/email-template.php
@@ -33,7 +33,12 @@ function ec_studio_transcription_format_duration( float $seconds ): string {
 	$m     = intdiv( $total % 3600, 60 );
 	$s     = $total % 60;
 	if ( $h > 0 ) {
-		return sprintf( __( '%dh %dm', 'extrachill-studio' ), $h, $m );
+		return sprintf(
+			/* translators: 1: hours, 2: minutes */
+			__( '%1$dh %2$dm', 'extrachill-studio' ),
+			$h,
+			$m
+		);
 	}
 	return sprintf( '%d:%02d', $m, $s );
 }
@@ -67,7 +72,11 @@ function ec_studio_transcription_render_completion_email( array $args ): string 
 	$args = wp_parse_args( $args, $defaults );
 
 	$greeting = $args['recipient_name']
-		? sprintf( __( 'Hey %s,', 'extrachill-studio' ), esc_html( $args['recipient_name'] ) )
+		? sprintf(
+			/* translators: %s: recipient display name */
+			__( 'Hey %s,', 'extrachill-studio' ),
+			esc_html( $args['recipient_name'] )
+		)
 		: __( 'Hey,', 'extrachill-studio' );
 
 	$duration_label = ec_studio_transcription_format_duration( (float) $args['duration_sec'] );


### PR DESCRIPTION
## Summary

Closes #66.

Clears all 32 pre-existing PHPStan + PHPCS errors so future `homeboy release extrachill-studio` runs pass without `--skip-checks`. After this PR, `homeboy lint` reports **0 errors** (31 non-blocking phpcs alignment warnings remain — those don't fail releases).

## Root causes

Two stale plugin-header declarations were responsible for **16 of the 32 errors** (50%):

### 1. `Requires PHP: 7.4` → `8.2`

Studio runs on extrachill.com (PHP 8.4) and uses 8.0+ features (`str_ends_with`, native union return types). PHPStan correctly reported these as unsupported under the declared 7.4 floor — the network is well past 7.4. Bumping to 8.2 reflects reality and clears:

- 1× `phpstan.function.notFound` for `str_ends_with`
- 3× `phpstan.return.unionTypeNotSupported`

### 2. `Requires Plugins:` adds `data-machine`

`inc/tasks/giveaway-task.php` extends `DataMachine\Engine\AI\System\Tasks\SystemTask`, but Studio's plugin header only declared `extrachill-users`. Homeboy's PHPStan harness reads `Requires Plugins:` to resolve dependency autoloaders, so the DM symbols were invisible to static analysis. Adding `data-machine` clears:

- 1× `phpstan.class.notFound`
- 3× `phpstan.method.notFound`

It also incidentally cleared 8 other `phpstan.argument.type` / `function.alreadyNarrowedType` / theme-function findings because better stub resolution disambiguated the union types they were complaining about.

## Code-quality fixes (16 phpcs errors)

| File | Code | Fix |
|---|---|---|
| `inc/abilities/run-giveaway.php` | `ArrayDeclarationSpacing` | Break multi-key array onto separate lines |
| `inc/abilities/sweatpants-token.php` | `DisallowShortTernary` | Explicit `'' !== $x ? $x : null` |
| `inc/compose-editor.php` ×2 | `DisallowShortArraySyntax` | `[...]` → `array(...)` |
| `inc/social-drafts.php` ×6 | `DisallowShortTernary` | Explicit `! empty()` comparisons |
| `inc/social-drafts.php` ×2 | `EscapeOutput` | Cast `(int) $success`, `(int) $total` |
| `inc/transcription/callback.php` | `DisallowShortTernary` | Explicit `display_name` fallback |
| `inc/transcription/email-template.php` ×2 | `MissingTranslatorsComment` | Add `/* translators: */` |
| `inc/transcription/email-template.php` | `UnorderedPlaceholdersText` | `%d %d` → `%1$d %2$d` |

## Verification

```
$ homeboy lint  →  0 errors, 31 warnings
$ homeboy review →  audit + lint + test umbrella, lint-clean
```

The 31 remaining warnings are all `WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned` and `Generic.Formatting.MultipleStatementAlignment` — cosmetic alignment hints, non-blocking, not in scope for this PR.

## Notes

- No functional behavior changes. Pure lint cleanup.
- The two header changes (PHP 8.2 floor, DM dependency declaration) are also semantically correct fixes — Studio truly does require both.
- Pre-existing dev practice was to skip these checks on release. After this lands, the next release will run clean end-to-end.