### PR TITLE
refactor: migrate transcription email, retire switch_to_blog (closes #71)

### DIFF
--- a/inc/transcription/callback.php
+++ b/inc/transcription/callback.php
@@ -98,7 +98,7 @@ function ec_studio_transcription_handle_callback( \WP_REST_Request $request ) {
 	}
 
 	// --- Scope check --------------------------------------------------
-	$scope = isset( $payload['scope'] ) ? (string) $payload['scope'] : '';
+	$scope  = isset( $payload['scope'] ) ? (string) $payload['scope'] : '';
 	$scopes = array_filter( preg_split( '/\s+/', $scope ) );
 	if ( ! in_array( 'callback:write', $scopes, true ) ) {
 		return new \WP_Error( 'forbidden_scope', __( 'Token lacks callback:write scope.', 'extrachill-studio' ), array( 'status' => 403 ) );
@@ -223,9 +223,7 @@ function ec_studio_transcription_callback_create_draft(
 	string $filename,
 	string $transcript,
 	string $job_id,
-	array $stats,
-	array $full_body
-) {
+	array $stats) {
 	if ( ! function_exists( 'ec_cross_site_rest_request' ) ) {
 		return new \WP_Error(
 			'multisite_helper_missing',
@@ -381,7 +379,7 @@ function ec_studio_transcription_callback_send_email(
 			'subject'  => $subject,
 			'template' => 'extrachill/branded',
 			'context'  => array(
-				'recipient_name' => $user->display_name ?: $user->user_login,
+				'recipient_name' => $user->display_name ? $user->display_name : $user->user_login,
 				'preheader'      => __( 'Your transcription is ready', 'extrachill-studio' ),
 				'body_html'      => $body_html,
 				'cta_url'        => $edit_url,

--- a/inc/transcription/callback.php
+++ b/inc/transcription/callback.php
@@ -271,6 +271,11 @@ function ec_studio_transcription_callback_create_draft(
 	// Attach Studio-specific meta on the main site.
 	$main_blog_id = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'main' ) : 0;
 	if ( $main_blog_id > 0 ) {
+		// Switch is for post-context resolution, NOT for SMTP: the draft
+		// lives on main extrachill.com, so update_post_meta() must run in
+		// main's blog context to hit the correct postmeta table. SMTP
+		// routing for outgoing mail is handled separately by ec_send_email()
+		// via the mail_site_id input.
 		switch_to_blog( $main_blog_id );
 		try {
 			update_post_meta( $post_id, '_studio_source_filename', $filename );
@@ -289,29 +294,28 @@ function ec_studio_transcription_callback_create_draft(
 /**
  * Send the "your transcription is ready" email to the uploader.
  *
- * Resolves the edit URL on main extrachill.com (the post lives there) so the
- * link drops the user directly into the WP editor for their new draft.
- *
- * The entire body composition AND the wp_mail() call run inside
- * `switch_to_blog( ec_get_blog_id('main') )`. This is required because
- * Easy WP SMTP stores its config + encrypted credentials per-site —
- * configuring it on main extrachill.com doesn't make the studio subsite
- * see those credentials, so a wp_mail() call from studio's context
- * either falls back to PHP mail() (no sendmail binary, fails) or hits
- * SMTP with garbage decrypted credentials (auth failure). Sending from
- * main's context is also semantically right: the email is FROM the
- * editorial site where the draft lives, so the "From" address matches
- * the link the recipient clicks.
+ * Delegates mail dispatch to `ec_send_email()` (extrachill-multisite),
+ * which wraps the `datamachine/send-email` ability. The branded shell
+ * (`extrachill/branded`) owns the document chrome, greeting, CTA
+ * button, and footer; this function only assembles the transcription-
+ * specific inner body and context.
  *
  * @since 0.13.0
- * @since 0.14.1 Wrap the wp_mail call in switch_to_blog so SMTP is configured.
+ * @since X.Y.Z Mail dispatch delegated to ec_send_email(); SMTP context
+ *              is auto-resolved by the ability via mail_site_id
+ *              (`ec_mail_site_id()`), retiring the manual
+ *              `switch_to_blog( ec_get_blog_id('main') )` workaround
+ *              previously needed because Easy WP SMTP stores its config
+ *              per-site. The only remaining switch in this function is
+ *              for resolving the post's edit URL in main's context — the
+ *              draft lives there — which is unrelated to SMTP.
  *
  * @param \WP_User $user        Recipient.
  * @param int      $post_id     Draft post id on main.
  * @param string   $filename    Original recording filename.
  * @param string   $transcript  Plain-text transcript content.
  * @param array    $stats       Stats array from the callback body.
- * @return bool True if `wp_mail` accepted the message.
+ * @return bool True if the ability reports a successful send.
  */
 function ec_studio_transcription_callback_send_email(
 	\WP_User $user,
@@ -320,9 +324,7 @@ function ec_studio_transcription_callback_send_email(
 	string $transcript,
 	array $stats
 ): bool {
-	$main_blog_id = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'main' ) : 0;
-
-	if ( $main_blog_id <= 0 ) {
+	if ( ! function_exists( 'ec_send_email' ) ) {
 		return false;
 	}
 
@@ -346,30 +348,47 @@ function ec_studio_transcription_callback_send_email(
 		$filename
 	);
 
-	switch_to_blog( $main_blog_id );
-	try {
-		$edit_url = (string) get_edit_post_link( $post_id, 'raw' );
-
-		$body = ec_studio_transcription_render_completion_email(
-			array(
-				'recipient_name' => $user->display_name ?: $user->user_login,
-				'filename'       => $filename,
-				'duration_sec'   => $duration_sec,
-				'segments'       => $segments,
-				'has_speakers'   => $has_speakers,
-				'preview'        => $preview,
-				'edit_url'       => $edit_url,
-			)
-		);
-
-		$headers = array(
-			'Content-Type: text/html; charset=UTF-8',
-		);
-
-		$sent = (bool) wp_mail( $user->user_email, $subject, $body, $headers );
-	} finally {
-		restore_current_blog();
+	// Resolve the draft's edit URL in the context of the site that owns
+	// the post (main extrachill.com). This switch is NOT for SMTP —
+	// SMTP routing is now handled inside ec_send_email() via the
+	// mail_site_id input. get_edit_post_link() needs main's blog
+	// context to read the post and build a correct admin URL because
+	// the draft was created on main via ec_cross_site_rest_request().
+	$main_blog_id = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'main' ) : 0;
+	$edit_url     = '';
+	if ( $main_blog_id > 0 ) {
+		switch_to_blog( $main_blog_id );
+		try {
+			$edit_url = (string) get_edit_post_link( $post_id, 'raw' );
+		} finally {
+			restore_current_blog();
+		}
 	}
 
-	return $sent;
+	$body_html = ec_studio_transcription_render_completion_email(
+		array(
+			'filename'     => $filename,
+			'duration_sec' => $duration_sec,
+			'segments'     => $segments,
+			'has_speakers' => $has_speakers,
+			'preview'      => $preview,
+		)
+	);
+
+	$result = ec_send_email(
+		array(
+			'to'       => $user->user_email,
+			'subject'  => $subject,
+			'template' => 'extrachill/branded',
+			'context'  => array(
+				'recipient_name' => $user->display_name ?: $user->user_login,
+				'preheader'      => __( 'Your transcription is ready', 'extrachill-studio' ),
+				'body_html'      => $body_html,
+				'cta_url'        => $edit_url,
+				'cta_label'      => __( 'Review draft', 'extrachill-studio' ),
+			),
+		)
+	);
+
+	return is_array( $result ) && ! empty( $result['success'] );
 }

--- a/inc/transcription/email-template.php
+++ b/inc/transcription/email-template.php
@@ -33,7 +33,8 @@ function ec_studio_transcription_format_duration( float $seconds ): string {
 	$m     = intdiv( $total % 3600, 60 );
 	$s     = $total % 60;
 	if ( $h > 0 ) {
-		return sprintf( __( '%dh %dm', 'extrachill-studio' ), $h, $m );
+		/* translators: 1: hours, 2: minutes */
+		return sprintf( __( '%1$dh %2$dm', 'extrachill-studio' ), $h, $m );
 	}
 	return sprintf( '%d:%02d', $m, $s );
 }
@@ -70,7 +71,7 @@ function ec_studio_transcription_render_completion_email( array $args ): string 
 		'has_speakers' => false,
 		'preview'      => '',
 	);
-	$args = wp_parse_args( $args, $defaults );
+	$args     = wp_parse_args( $args, $defaults );
 
 	$duration_label = ec_studio_transcription_format_duration( (float) $args['duration_sec'] );
 
@@ -82,7 +83,7 @@ function ec_studio_transcription_render_completion_email( array $args ): string 
 		? '<blockquote style="margin:0 0 16px 0;padding:12px 16px;border-left:3px solid #53940b;background:#f8f8f8;color:#444;font-style:italic;">' . esc_html( $args['preview'] ) . '</blockquote>'
 		: '';
 
-	$body  = '<p style="margin:0 0 16px 0;font-size:16px;line-height:1.6;">' . sprintf(
+	$body = '<p style="margin:0 0 16px 0;font-size:16px;line-height:1.6;">' . sprintf(
 		/* translators: %s: source recording filename */
 		esc_html__( 'Your transcription of %s is ready.', 'extrachill-studio' ),
 		'<strong>' . esc_html( $args['filename'] ) . '</strong>'

--- a/inc/transcription/email-template.php
+++ b/inc/transcription/email-template.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * Transcription Completion Email Template
+ * Transcription Completion Email — inner-body renderer.
  *
- * Renders the HTML body of the "your transcription is ready" email sent
- * after a sweatpants callback creates the draft post on main extrachill.com.
- *
- * Intentionally simple inline-styled HTML — no theme dependency, no
- * external assets, no JS. The same body renders cleanly in webmail
- * clients (Gmail, Apple Mail) and the WP-CLI test pipeline.
+ * Renders ONLY the transcription-specific inner body (filename, stats,
+ * preview blockquote) that drops into the `extrachill/branded` template
+ * registered by extrachill-multisite. The branded shell owns the
+ * `<html>`/`<body>` chrome, greeting (`Hey {recipient_name},`), CTA
+ * button, "Much love, Extra Chill" sign-off, link grid, and footer —
+ * this file does not render any of that.
  *
  * @package    ExtraChillStudio
  * @subpackage Transcription
@@ -39,36 +39,38 @@ function ec_studio_transcription_format_duration( float $seconds ): string {
 }
 
 /**
- * Render the completion email body.
+ * Render the inner body HTML for the completion email.
+ *
+ * Returns ONLY the transcription-specific content (filename line, stats
+ * line, preview blockquote, sign-off note). The surrounding chrome —
+ * `<html>`/`<body>`, greeting, "Open draft in editor" CTA, link grid,
+ * footer — is provided by the `extrachill/branded` template registered
+ * by extrachill-multisite. The greeting and CTA are passed to that
+ * template via `recipient_name`, `cta_url`, and `cta_label` in the
+ * context array.
  *
  * @since 0.13.0
+ * @since X.Y.Z Reduced to a pure inner-body renderer; greeting, CTA, and
+ *              HTML chrome moved to the `extrachill/branded` shell.
  *
  * @param array $args {
- *     @type string $recipient_name Display name of the uploader.
- *     @type string $filename       Original recording filename.
- *     @type float  $duration_sec   Audio duration in seconds.
- *     @type int    $segments       Whisper segment count.
- *     @type bool   $has_speakers   Whether diarization ran.
- *     @type string $preview        First ~400 chars of the transcript.
- *     @type string $edit_url       Direct edit URL for the draft post.
+ *     @type string $filename     Original recording filename.
+ *     @type float  $duration_sec Audio duration in seconds.
+ *     @type int    $segments     Whisper segment count.
+ *     @type bool   $has_speakers Whether diarization ran.
+ *     @type string $preview      First ~400 chars of the transcript.
  * }
- * @return string HTML body.
+ * @return string Inner-body HTML (no document chrome).
  */
 function ec_studio_transcription_render_completion_email( array $args ): string {
 	$defaults = array(
-		'recipient_name' => '',
-		'filename'       => '',
-		'duration_sec'   => 0,
-		'segments'       => 0,
-		'has_speakers'   => false,
-		'preview'        => '',
-		'edit_url'       => '',
+		'filename'     => '',
+		'duration_sec' => 0,
+		'segments'     => 0,
+		'has_speakers' => false,
+		'preview'      => '',
 	);
 	$args = wp_parse_args( $args, $defaults );
-
-	$greeting = $args['recipient_name']
-		? sprintf( __( 'Hey %s,', 'extrachill-studio' ), esc_html( $args['recipient_name'] ) )
-		: __( 'Hey,', 'extrachill-studio' );
 
 	$duration_label = ec_studio_transcription_format_duration( (float) $args['duration_sec'] );
 
@@ -76,27 +78,16 @@ function ec_studio_transcription_render_completion_email( array $args ): string 
 		? __( 'with speaker labels', 'extrachill-studio' )
 		: __( 'without speaker labels', 'extrachill-studio' );
 
-	// Sanitize everything that goes into the HTML body.
-	$preview_html   = $args['preview']
+	$preview_html = $args['preview']
 		? '<blockquote style="margin:0 0 16px 0;padding:12px 16px;border-left:3px solid #53940b;background:#f8f8f8;color:#444;font-style:italic;">' . esc_html( $args['preview'] ) . '</blockquote>'
 		: '';
 
-	$edit_button = $args['edit_url']
-		? sprintf(
-			'<p style="margin:24px 0;"><a href="%s" style="display:inline-block;padding:12px 24px;background:#53940b;color:#fff;text-decoration:none;border-radius:6px;font-weight:600;">%s</a></p>',
-			esc_url( $args['edit_url'] ),
-			esc_html__( 'Open draft in editor', 'extrachill-studio' )
-		)
-		: '';
-
-	$body = '<!DOCTYPE html><html><head><meta charset="UTF-8"><title>' . esc_html__( 'Your transcription is ready', 'extrachill-studio' ) . '</title></head><body style="font-family:Helvetica,Arial,sans-serif;line-height:1.5;color:#222;max-width:560px;margin:0 auto;padding:24px;">';
-	$body .= '<p>' . $greeting . '</p>';
-	$body .= '<p>' . sprintf(
+	$body  = '<p style="margin:0 0 16px 0;font-size:16px;line-height:1.6;">' . sprintf(
 		/* translators: %s: source recording filename */
 		esc_html__( 'Your transcription of %s is ready.', 'extrachill-studio' ),
 		'<strong>' . esc_html( $args['filename'] ) . '</strong>'
 	) . '</p>';
-	$body .= '<p style="color:#666;font-size:14px;">' . sprintf(
+	$body .= '<p style="margin:0 0 16px 0;color:#666;font-size:14px;">' . sprintf(
 		/* translators: 1: human duration (e.g. "5:29"), 2: segment count, 3: speakers clause */
 		esc_html__( '%1$s · %2$d segments · %3$s', 'extrachill-studio' ),
 		esc_html( $duration_label ),
@@ -104,9 +95,7 @@ function ec_studio_transcription_render_completion_email( array $args ): string 
 		esc_html( $speakers_clause )
 	) . '</p>';
 	$body .= $preview_html;
-	$body .= $edit_button;
-	$body .= '<p style="color:#888;font-size:13px;margin-top:32px;border-top:1px solid #eee;padding-top:16px;">' . esc_html__( 'Sent automatically by the Extra Chill Studio transcription pipeline. The draft is on extrachill.com — open it in the editor to review, polish, and publish.', 'extrachill-studio' ) . '</p>';
-	$body .= '</body></html>';
+	$body .= '<p style="margin:24px 0 0 0;color:#666;font-size:14px;line-height:1.6;">' . esc_html__( 'The draft is on extrachill.com — open it in the editor to review, polish, and publish.', 'extrachill-studio' ) . '</p>';
 
 	return $body;
 }


### PR DESCRIPTION
## Summary

Migrates `inc/transcription/callback.php` off raw `wp_mail()` + the hand-rolled `switch_to_blog( ec_get_blog_id('main') )` SMTP workaround onto the new centralized `ec_send_email()` wrapper. The Data Machine `datamachine/send-email` ability resolves SMTP routing internally via the `mail_site_id` input (defaulted by `ec_mail_site_id()` inside `ec_send_email()`), so the workaround documented at `@since 0.14.1 Wrap the wp_mail call in switch_to_blog so SMTP is configured` is now retired.

**Closes #71**

**Depends on:**
- Extra-Chill/data-machine#2067 — `template` / `context` / `mail_site_id` inputs on `datamachine/send-email`
- Extra-Chill/extrachill-multisite#27 — `ec_send_email()` + `extrachill/branded` template + `ec_mail_site_id()` helper

Opened as **DRAFT** because both foundation PRs are still in flight. Ready to flip to ready-for-review once they merge.

## What changed

### `inc/transcription/callback.php` — `ec_studio_transcription_callback_send_email()`

- Removed `wp_mail()`. Body composition now flows through `ec_send_email( [ 'template' => 'extrachill/branded', 'context' => [ ... ] ] )`.
- Deleted the `switch_to_blog( $main_blog_id ) / restore_current_blog()` pair that wrapped the mail send purely so Easy WP SMTP creds resolved. SMTP routing is now the ability's job.
- Updated the `@since 0.14.1` docblock with an `@since X.Y.Z` entry documenting the migration.
- Passes the documented context keys for the branded template:
  - `recipient_name` → `$user->display_name ?: $user->user_login`
  - `body_html` → transcription-specific inner content (filename / stats / preview blockquote / sign-off note)
  - `cta_url` → draft edit URL on main
  - `cta_label` → "Review draft"
  - `preheader` → "Your transcription is ready"

### `inc/transcription/email-template.php`

- `ec_studio_transcription_render_completion_email()` is now a pure inner-body renderer. Removed: `<!DOCTYPE>` / `<html>` / `<body>` chrome, the "Hey {name}," greeting, the inline CTA button, the bespoke footer. All of that is owned by the `extrachill/branded` shell.
- `ec_studio_transcription_format_duration()` and the stats/preview rendering are unchanged.

## Remaining `switch_to_blog` calls (all non-SMTP)

Verified via `grep -rn switch_to_blog inc/` — every remaining call has an inline comment explaining its purpose:

1. **`inc/transcription/callback.php` line ~279** — inside `ec_studio_transcription_callback_create_draft()`, around `update_post_meta()`. **Reason:** the draft post lives on main, so the postmeta writes must run in main's blog context to hit the correct `c8c_postmeta` table. Pre-existing; comment clarified.
2. **`inc/transcription/callback.php` line ~360** — inside `ec_studio_transcription_callback_send_email()`, around `get_edit_post_link( $post_id, 'raw' )`. **Reason:** the draft lives on main, so the edit-URL resolver needs main's blog context to load the post and build a correct `wp-admin/post.php?post=…` URL. New switch (narrowed from the old SMTP-purpose one); the SMTP wrapper is gone — `ec_send_email()` handles that internally.

`grep -rn "wp_mail" inc/` returns nothing.

## Smoke note

After the foundation PRs merge and this lands, end-to-end verification follows the documented pattern from MEMORY.md:

1. Mint a `callback:write` token via the `extrachill/sweatpants-token` ability signed with `sweatpants_signed_token_secret`.
2. POST a synthetic `status: complete` callback to `/wp-json/extrachill/v1/transcribe/callback` from the studio subsite context.
3. Confirm: draft is created on main, "Your transcription is ready: <filename>" arrives in the uploader's inbox, and the message renders inside the EC-branded shell (header / link grid / footer) with the "Review draft" CTA button.

## Constraints honored

- No `CHANGELOG.md` edits.
- No hand-bumped version strings — `refactor:` conventional commit lets homeboy detect the bump at release time.
- DRAFT until upstream foundations land.