### PR TITLE
fix: Compose autosave reliability quick wins (omit status on update, scope drafts to author)

### DIFF
--- a/src/blocks/studio/tabs/compose/index.ts
+++ b/src/blocks/studio/tabs/compose/index.ts
@@ -2,6 +2,7 @@ import { __ } from '@wordpress/i18n';
 import { createElement, useEffect, useRef, useState, useCallback } from '@wordpress/element';
 import type { ReactElement, ChangeEvent } from 'react';
 import apiFetch from '@wordpress/api-fetch';
+import { select } from '@wordpress/data';
 import {
 	getOrCreateClientContextRegistry,
 	registerClientContextProvider,
@@ -159,12 +160,27 @@ const ComposePane = ( _props: StudioPaneProps ): ReactElement => {
 		}
 	};
 
-	/** Fetch user's drafts from the REST API. */
+	/**
+	 * Fetch the current user's drafts from the REST API.
+	 *
+	 * Scoped to the current user via the author filter so users with
+	 * edit_others_posts (editors, admins) do not see and hot-swap into
+	 * other authors' drafts via the Compose draft picker.
+	 */
 	const loadDrafts = useCallback( async (): Promise< WpPost[] > => {
 		try {
-			const result = await apiFetch< WpPost[] >( {
-				path: '/wp/v2/posts?status=draft&per_page=20&orderby=modified&order=desc&context=edit',
-			} );
+			const currentUser = ( select( 'core' ) as { getCurrentUser?: () => { id?: number } | undefined } )
+				.getCurrentUser?.();
+			const userId = currentUser?.id;
+			let path = '/wp/v2/posts?status=draft&per_page=20&orderby=modified&order=desc&context=edit';
+			if ( userId ) {
+				path += `&author=${ userId }`;
+			}
+			// If userId is genuinely unavailable client-side, fall through without
+			// the author filter rather than ship a half-broken query. In practice
+			// @wordpress/data core selector should always resolve for logged-in
+			// users on Studio (gated by team-member capability check server-side).
+			const result = await apiFetch< WpPost[] >( { path } );
 			return Array.isArray( result ) ? result : [];
 		} catch {
 			return [];

--- a/src/blocks/studio/tabs/compose/index.ts
+++ b/src/blocks/studio/tabs/compose/index.ts
@@ -204,10 +204,16 @@ const ComposePane = ( _props: StudioPaneProps ): ReactElement => {
 
 		try {
 			const path = postId ? `/wp/v2/posts/${ postId }` : '/wp/v2/posts';
+			// Only set status on initial create — on update, omit it so out-of-band
+			// transitions to pending/publish are not silently demoted back to draft.
+			const data: Record< string, unknown > = { title: currentTitle, content: currentContent };
+			if ( ! postId ) {
+				data.status = 'draft';
+			}
 			const post = await apiFetch< WpPost >( {
 				path,
 				method: 'POST',
-				data: { title: currentTitle, content: currentContent, status: 'draft' },
+				data,
 			} );
 			// Capture new ID on first-create so subsequent saves target the same draft.
 			if ( ! postId && post?.id ) {
@@ -292,10 +298,16 @@ const ComposePane = ( _props: StudioPaneProps ): ReactElement => {
 
 		try {
 			const path = postId ? `/wp/v2/posts/${ postId }` : '/wp/v2/posts';
+			// Only set status on initial create — on update, omit it so out-of-band
+			// transitions to pending/publish are not silently demoted back to draft.
+			const data: Record< string, unknown > = { title: currentTitle, content: currentContent };
+			if ( ! postId ) {
+				data.status = 'draft';
+			}
 			const post = await apiFetch< WpPost >( {
 				path,
 				method: 'POST',
-				data: { title: currentTitle, content: currentContent, status: 'draft' },
+				data,
 			} );
 			// Capture new ID on first-create so subsequent autosaves
 			// update the same draft instead of creating duplicates.


### PR DESCRIPTION
Closes parts of #77 — items 6 and 9.

## Changes

- **Omit `status` on update POSTs** (`performAutosave` ~line 293, `flushCurrentDraft` ~line 206). Only send `status: "draft"` on initial create. Prevents silent demotion of posts moved to `pending` or `publish` out-of-band (other tab, other user, editorial workflow).
- **Scope `loadDrafts` query to `author=<currentUserId>`** (~line 168). Prevents users with `edit_others_posts` from seeing and clobbering other authors' drafts via the Compose draft picker. Current user ID resolved via `wp.data.select('core').getCurrentUser()`. Falls through without the author filter if the ID is genuinely unavailable client-side (defensive — should not happen in practice; Studio is server-gated to team members).

Manual `saveDraft` and `submitForReview` paths are intentionally **unchanged** — their explicit status semantics (`draft` and `pending` respectively) are intended.

## Verification

- `npm run build` — clean
- `npm run typecheck` — clean

## Out of scope

The remaining 7 items in #77 (in-flight queueing, snapshot-at-flush, error surface, beforeunload, sendBeacon, autosaves endpoint migration, etc.) depend on the shared `useAutosave` hook design in Extra-Chill/extrachill-components#4. Those land in a follow-up once the hook is ready.