### PR TITLE
fix: Compose autosave reliability (items 1, 3, 4, 5, 7, 8 of #77)

### DIFF
--- a/src/blocks/studio/tabs/compose/index.ts
+++ b/src/blocks/studio/tabs/compose/index.ts
@@ -88,6 +88,7 @@ const ComposePane = ( _props: StudioPaneProps ): ReactElement => {
 	const autosaveTimerRef = useRef< ReturnType< typeof setTimeout > | null >( null );
 	const lastSavedPayloadRef = useRef( '' );
 	const isAutosavingRef = useRef( false );
+	const pendingRerunRef = useRef( false );
 	const activePostIdRef = useRef< number | null >( null );
 	const titleRef = useRef( '' );
 	const contentSnapshotRef = useRef( '' );
@@ -296,7 +297,10 @@ const ComposePane = ( _props: StudioPaneProps ): ReactElement => {
 	 * subsequent autosaves update the same draft.
 	 */
 	const performAutosave = useCallback( async (): Promise< void > => {
+		// If a save is already in flight, mark a rerun and bail; the in-flight
+		// save's finally block will pick up the latest content when it completes.
 		if ( isAutosavingRef.current ) {
+			pendingRerunRef.current = true;
 			return;
 		}
 
@@ -349,6 +353,12 @@ const ComposePane = ( _props: StudioPaneProps ): ReactElement => {
 			// Silent — user can still manually save.
 		} finally {
 			isAutosavingRef.current = false;
+			// Re-run if input arrived while we were saving so the latest
+			// content reaches the server instead of being silently dropped.
+			if ( pendingRerunRef.current ) {
+				pendingRerunRef.current = false;
+				performAutosave();
+			}
 		}
 	}, [] );
 

--- a/src/blocks/studio/tabs/compose/index.ts
+++ b/src/blocks/studio/tabs/compose/index.ts
@@ -88,6 +88,7 @@ const ComposePane = ( _props: StudioPaneProps ): ReactElement => {
 	const autosaveTimerRef = useRef< ReturnType< typeof setTimeout > | null >( null );
 	const lastSavedPayloadRef = useRef( '' );
 	const isAutosavingRef = useRef( false );
+	const inFlightPromiseRef = useRef< Promise< void > | null >( null );
 	const pendingRerunRef = useRef( false );
 	const activePostIdRef = useRef< number | null >( null );
 	const titleRef = useRef( '' );
@@ -199,8 +200,17 @@ const ComposePane = ( _props: StudioPaneProps ): ReactElement => {
 			autosaveTimerRef.current = null;
 		}
 
-		if ( isAutosavingRef.current ) {
-			return;
+		// If a save is in flight, wait for it to finish instead of bailing.
+		// Bailing here silently discards keystrokes when the user switches
+		// drafts during an in-flight save. Capture the promise locally so we
+		// don't deadlock on our own subsequent save.
+		const inFlight = inFlightPromiseRef.current;
+		if ( inFlight ) {
+			try {
+				await inFlight;
+			} catch {
+				// In-flight save already handled its own errors; proceed.
+			}
 		}
 
 		const postId = activePostIdRef.current;
@@ -219,36 +229,44 @@ const ComposePane = ( _props: StudioPaneProps ): ReactElement => {
 
 		isAutosavingRef.current = true;
 
-		try {
-			// Initial create: POST /wp/v2/posts with status=draft.
-			// Subsequent saves: POST /wp/v2/posts/<id>/autosaves (no status — preserves parent
-			// post status, so out-of-band transitions to pending/publish are not demoted).
-			// The /autosaves endpoint returns a revision object (id = revision ID, parent = post ID).
-			// Do NOT overwrite activePostIdRef with the revision ID.
-			if ( postId ) {
-				await apiFetch( {
-					path: `/wp/v2/posts/${ postId }/autosaves`,
-					method: 'POST',
-					data: { title: currentTitle, content: currentContent },
-				} );
-			} else {
-				const post = await apiFetch< WpPost >( {
-					path: '/wp/v2/posts',
-					method: 'POST',
-					data: { title: currentTitle, content: currentContent, status: 'draft' },
-				} );
-				// Capture new ID on first-create so subsequent saves target the same draft.
-				if ( post?.id ) {
-					activePostIdRef.current = post.id;
-					setActivePostId( post.id );
+		// Expose our save as the in-flight promise so any concurrent autosave
+		// or flush waits for us instead of racing.
+		const operation = ( async (): Promise< void > => {
+			try {
+				// Initial create: POST /wp/v2/posts with status=draft.
+				// Subsequent saves: POST /wp/v2/posts/<id>/autosaves (no status — preserves
+				// parent status, so out-of-band transitions to pending/publish are not demoted).
+				// The /autosaves endpoint returns a revision object (id = revision ID, parent = post ID).
+				// Do NOT overwrite activePostIdRef with the revision ID.
+				if ( postId ) {
+					await apiFetch( {
+						path: `/wp/v2/posts/${ postId }/autosaves`,
+						method: 'POST',
+						data: { title: currentTitle, content: currentContent },
+					} );
+				} else {
+					const post = await apiFetch< WpPost >( {
+						path: '/wp/v2/posts',
+						method: 'POST',
+						data: { title: currentTitle, content: currentContent, status: 'draft' },
+					} );
+					// Capture new ID on first-create so subsequent saves target the same draft.
+					if ( post?.id ) {
+						activePostIdRef.current = post.id;
+						setActivePostId( post.id );
+					}
 				}
+				lastSavedPayloadRef.current = payload;
+			} catch {
+				// Best-effort — don't block the switch.
+			} finally {
+				isAutosavingRef.current = false;
+				inFlightPromiseRef.current = null;
 			}
-			lastSavedPayloadRef.current = payload;
-		} catch {
-			// Best-effort — don't block the switch.
-		} finally {
-			isAutosavingRef.current = false;
-		}
+		} )();
+
+		inFlightPromiseRef.current = operation;
+		await operation;
 	}, [] );
 
 	/**
@@ -322,44 +340,53 @@ const ComposePane = ( _props: StudioPaneProps ): ReactElement => {
 
 		isAutosavingRef.current = true;
 
-		try {
-			// Initial create: POST /wp/v2/posts with status=draft.
-			// Subsequent autosaves: POST /wp/v2/posts/<id>/autosaves (no status — preserves
-			// parent status, so out-of-band transitions to pending/publish are not demoted).
-			// The /autosaves endpoint returns a revision object (id = revision ID, parent = post ID).
-			// Do NOT overwrite activePostIdRef with the revision ID — the parent ID is stable.
-			if ( postId ) {
-				await apiFetch( {
-					path: `/wp/v2/posts/${ postId }/autosaves`,
-					method: 'POST',
-					data: { title: currentTitle, content: currentContent },
-				} );
-			} else {
-				const post = await apiFetch< WpPost >( {
-					path: '/wp/v2/posts',
-					method: 'POST',
-					data: { title: currentTitle, content: currentContent, status: 'draft' },
-				} );
-				// Capture new ID on first-create so subsequent autosaves
-				// update the same draft instead of creating duplicates.
-				if ( post?.id ) {
-					activePostIdRef.current = post.id;
-					setActivePostId( post.id );
+		// Expose the in-flight operation as a promise so flushCurrentDraft (and
+		// other callers that need to await a save) can wait for it without
+		// re-issuing a duplicate request.
+		const operation = ( async (): Promise< void > => {
+			try {
+				// Initial create: POST /wp/v2/posts with status=draft.
+				// Subsequent autosaves: POST /wp/v2/posts/<id>/autosaves (no status — preserves
+				// parent status, so out-of-band transitions to pending/publish are not demoted).
+				// The /autosaves endpoint returns a revision object (id = revision ID, parent = post ID).
+				// Do NOT overwrite activePostIdRef with the revision ID — the parent ID is stable.
+				if ( postId ) {
+					await apiFetch( {
+						path: `/wp/v2/posts/${ postId }/autosaves`,
+						method: 'POST',
+						data: { title: currentTitle, content: currentContent },
+					} );
+				} else {
+					const post = await apiFetch< WpPost >( {
+						path: '/wp/v2/posts',
+						method: 'POST',
+						data: { title: currentTitle, content: currentContent, status: 'draft' },
+					} );
+					// Capture new ID on first-create so subsequent autosaves
+					// update the same draft instead of creating duplicates.
+					if ( post?.id ) {
+						activePostIdRef.current = post.id;
+						setActivePostId( post.id );
+					}
+				}
+				lastSavedPayloadRef.current = payload;
+				setHasUnsavedChanges( false );
+			} catch {
+				// Silent — user can still manually save.
+			} finally {
+				isAutosavingRef.current = false;
+				inFlightPromiseRef.current = null;
+				// Re-run if input arrived while we were saving so the latest
+				// content reaches the server instead of being silently dropped.
+				if ( pendingRerunRef.current ) {
+					pendingRerunRef.current = false;
+					performAutosave();
 				}
 			}
-			lastSavedPayloadRef.current = payload;
-			setHasUnsavedChanges( false );
-		} catch {
-			// Silent — user can still manually save.
-		} finally {
-			isAutosavingRef.current = false;
-			// Re-run if input arrived while we were saving so the latest
-			// content reaches the server instead of being silently dropped.
-			if ( pendingRerunRef.current ) {
-				pendingRerunRef.current = false;
-				performAutosave();
-			}
-		}
+		} )();
+
+		inFlightPromiseRef.current = operation;
+		await operation;
 	}, [] );
 
 	const scheduleAutosave = useCallback( (): void => {

--- a/src/blocks/studio/tabs/compose/index.ts
+++ b/src/blocks/studio/tabs/compose/index.ts
@@ -92,6 +92,7 @@ const ComposePane = ( _props: StudioPaneProps ): ReactElement => {
 	const pendingRerunRef = useRef( false );
 	const consecutiveFailuresRef = useRef( 0 );
 	const autosaveErrorActiveRef = useRef( false );
+	const hasUnsavedChangesRef = useRef( false );
 	const activePostIdRef = useRef< number | null >( null );
 	const titleRef = useRef( '' );
 	const contentSnapshotRef = useRef( '' );
@@ -521,6 +522,27 @@ const ComposePane = ( _props: StudioPaneProps ): ReactElement => {
 			}
 		};
 	}, [ scheduleAutosave, performAutosave, scheduleClientContextUpdate ] );
+
+	// Sync hasUnsavedChanges state into a ref so the beforeunload/pagehide
+	// listeners (registered once with stale closures) can read the latest
+	// value without re-binding on every change.
+	useEffect( () => {
+		hasUnsavedChangesRef.current = hasUnsavedChanges;
+	}, [ hasUnsavedChanges ] );
+
+	// beforeunload guard: native browser prompt when navigating away with
+	// unsaved changes. Registered once; the handler reads from a ref.
+	useEffect( () => {
+		const handler = ( e: BeforeUnloadEvent ): void => {
+			if ( hasUnsavedChangesRef.current ) {
+				e.preventDefault();
+				// Legacy property required by some browsers for the prompt to fire.
+				e.returnValue = '';
+			}
+		};
+		window.addEventListener( 'beforeunload', handler );
+		return () => window.removeEventListener( 'beforeunload', handler );
+	}, [] );
 
 	const submitForReview = async (): Promise< void > => {
 		const content = getContent();

--- a/src/blocks/studio/tabs/compose/index.ts
+++ b/src/blocks/studio/tabs/compose/index.ts
@@ -36,6 +36,17 @@ interface WpPost {
 	status: string;
 	date: string;
 	modified: string;
+	modified_gmt?: string;
+}
+
+interface WpAutosave {
+	id: number;
+	parent: number;
+	author: number;
+	title?: { rendered: string; raw?: string };
+	content?: { rendered: string; raw?: string };
+	modified?: string;
+	modified_gmt?: string;
 }
 
 /** Autosave debounce interval in milliseconds. */
@@ -283,16 +294,45 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 
 		if ( post ) {
 			activePostIdRef.current = post.id;
-			titleRef.current = post.title.raw || post.title.rendered || '';
 			setActivePostId( post.id );
-			setTitle( post.title.raw || post.title.rendered || '' );
-			const content = post.content.raw || post.content.rendered || '';
+
+			// Since autosaves migrated to /wp/v2/posts/<id>/autosaves (per-user
+			// revision rows), the parent post body returned in the drafts list
+			// is stale relative to in-flight typing. Check for a user autosave
+			// newer than the parent and prefer it. Falls back to parent on any
+			// error so the picker always works.
+			let title = post.title.raw || post.title.rendered || '';
+			let content = post.content.raw || post.content.rendered || '';
+			try {
+				const currentUser = ( select( 'core' ) as { getCurrentUser?: () => { id?: number } | undefined } )
+					.getCurrentUser?.();
+				const currentUserId = currentUser?.id;
+				if ( currentUserId ) {
+					const autosaves = await apiFetch< WpAutosave[] >( {
+						path: `/wp/v2/posts/${ post.id }/autosaves?context=edit`,
+					} );
+					const userAutosave = Array.isArray( autosaves )
+						? autosaves.find( ( a ) => a?.author === currentUserId )
+						: null;
+					if (
+						userAutosave &&
+						userAutosave.modified_gmt &&
+						post.modified_gmt &&
+						userAutosave.modified_gmt > post.modified_gmt
+					) {
+						title = userAutosave.title?.raw || title;
+						content = userAutosave.content?.raw || content;
+					}
+				}
+			} catch {
+				// Best-effort recovery — fall back to parent content silently.
+			}
+
+			titleRef.current = title;
+			setTitle( title );
 			contentSnapshotRef.current = content;
 			replaceEditorContent( content );
-			lastSavedPayloadRef.current = JSON.stringify( {
-				title: post.title.raw || post.title.rendered || '',
-				content,
-			} );
+			lastSavedPayloadRef.current = JSON.stringify( { title, content } );
 		} else {
 			activePostIdRef.current = null;
 			titleRef.current = '';

--- a/src/blocks/studio/tabs/compose/index.ts
+++ b/src/blocks/studio/tabs/compose/index.ts
@@ -67,7 +67,8 @@ function extractPlainText( html: string ): string {
  * a new draft on first activity when none is active (title or content must
  * be non-empty), then updates the same draft on subsequent autosaves.
  */
-const ComposePane = ( _props: StudioPaneProps ): ReactElement => {
+const ComposePane = ( props: StudioPaneProps ): ReactElement => {
+	const restNonce = props.context.restNonce;
 	const textareaRef = useRef< HTMLTextAreaElement >( null );
 	const editorMountedRef = useRef( false );
 
@@ -533,16 +534,52 @@ const ComposePane = ( _props: StudioPaneProps ): ReactElement => {
 	// beforeunload guard: native browser prompt when navigating away with
 	// unsaved changes. Registered once; the handler reads from a ref.
 	useEffect( () => {
-		const handler = ( e: BeforeUnloadEvent ): void => {
+		const beforeUnloadHandler = ( e: BeforeUnloadEvent ): void => {
 			if ( hasUnsavedChangesRef.current ) {
 				e.preventDefault();
 				// Legacy property required by some browsers for the prompt to fire.
 				e.returnValue = '';
 			}
 		};
-		window.addEventListener( 'beforeunload', handler );
-		return () => window.removeEventListener( 'beforeunload', handler );
-	}, [] );
+
+		// pagehide + sendBeacon: best-effort last-write when the tab is being
+		// torn down. Fires for tab close, navigation, and bfcache suspension.
+		// sendBeacon is the only request that's guaranteed to be delivered
+		// during unload — apiFetch/XHR will be cancelled.
+		//
+		// Limitation: when no postId exists yet (initial draft never created),
+		// there's no /autosaves endpoint to target. We accept that loss; the
+		// next session will start blank rather than firing a synchronous POST
+		// to /wp/v2/posts (which sendBeacon also can't reliably do for create
+		// because we'd never see the returned ID).
+		const pageHideHandler = (): void => {
+			if ( ! hasUnsavedChangesRef.current ) {
+				return;
+			}
+			const postId = activePostIdRef.current;
+			if ( ! postId ) {
+				return;
+			}
+			try {
+				const body = JSON.stringify( {
+					title: titleRef.current.trim(),
+					content: contentSnapshotRef.current.trim(),
+				} );
+				const blob = new Blob( [ body ], { type: 'application/json' } );
+				const url = `/wp-json/wp/v2/posts/${ postId }/autosaves?_wpnonce=${ encodeURIComponent( restNonce ) }`;
+				navigator.sendBeacon( url, blob );
+			} catch {
+				// Best-effort — nothing else we can do during unload.
+			}
+		};
+
+		window.addEventListener( 'beforeunload', beforeUnloadHandler );
+		window.addEventListener( 'pagehide', pageHideHandler );
+		return () => {
+			window.removeEventListener( 'beforeunload', beforeUnloadHandler );
+			window.removeEventListener( 'pagehide', pageHideHandler );
+		};
+	}, [ restNonce ] );
 
 	const submitForReview = async (): Promise< void > => {
 		const content = getContent();

--- a/src/blocks/studio/tabs/compose/index.ts
+++ b/src/blocks/studio/tabs/compose/index.ts
@@ -219,22 +219,28 @@ const ComposePane = ( _props: StudioPaneProps ): ReactElement => {
 		isAutosavingRef.current = true;
 
 		try {
-			const path = postId ? `/wp/v2/posts/${ postId }` : '/wp/v2/posts';
-			// Only set status on initial create — on update, omit it so out-of-band
-			// transitions to pending/publish are not silently demoted back to draft.
-			const data: Record< string, unknown > = { title: currentTitle, content: currentContent };
-			if ( ! postId ) {
-				data.status = 'draft';
-			}
-			const post = await apiFetch< WpPost >( {
-				path,
-				method: 'POST',
-				data,
-			} );
-			// Capture new ID on first-create so subsequent saves target the same draft.
-			if ( ! postId && post?.id ) {
-				activePostIdRef.current = post.id;
-				setActivePostId( post.id );
+			// Initial create: POST /wp/v2/posts with status=draft.
+			// Subsequent saves: POST /wp/v2/posts/<id>/autosaves (no status — preserves parent
+			// post status, so out-of-band transitions to pending/publish are not demoted).
+			// The /autosaves endpoint returns a revision object (id = revision ID, parent = post ID).
+			// Do NOT overwrite activePostIdRef with the revision ID.
+			if ( postId ) {
+				await apiFetch( {
+					path: `/wp/v2/posts/${ postId }/autosaves`,
+					method: 'POST',
+					data: { title: currentTitle, content: currentContent },
+				} );
+			} else {
+				const post = await apiFetch< WpPost >( {
+					path: '/wp/v2/posts',
+					method: 'POST',
+					data: { title: currentTitle, content: currentContent, status: 'draft' },
+				} );
+				// Capture new ID on first-create so subsequent saves target the same draft.
+				if ( post?.id ) {
+					activePostIdRef.current = post.id;
+					setActivePostId( post.id );
+				}
 			}
 			lastSavedPayloadRef.current = payload;
 		} catch {
@@ -313,23 +319,29 @@ const ComposePane = ( _props: StudioPaneProps ): ReactElement => {
 		isAutosavingRef.current = true;
 
 		try {
-			const path = postId ? `/wp/v2/posts/${ postId }` : '/wp/v2/posts';
-			// Only set status on initial create — on update, omit it so out-of-band
-			// transitions to pending/publish are not silently demoted back to draft.
-			const data: Record< string, unknown > = { title: currentTitle, content: currentContent };
-			if ( ! postId ) {
-				data.status = 'draft';
-			}
-			const post = await apiFetch< WpPost >( {
-				path,
-				method: 'POST',
-				data,
-			} );
-			// Capture new ID on first-create so subsequent autosaves
-			// update the same draft instead of creating duplicates.
-			if ( ! postId && post?.id ) {
-				activePostIdRef.current = post.id;
-				setActivePostId( post.id );
+			// Initial create: POST /wp/v2/posts with status=draft.
+			// Subsequent autosaves: POST /wp/v2/posts/<id>/autosaves (no status — preserves
+			// parent status, so out-of-band transitions to pending/publish are not demoted).
+			// The /autosaves endpoint returns a revision object (id = revision ID, parent = post ID).
+			// Do NOT overwrite activePostIdRef with the revision ID — the parent ID is stable.
+			if ( postId ) {
+				await apiFetch( {
+					path: `/wp/v2/posts/${ postId }/autosaves`,
+					method: 'POST',
+					data: { title: currentTitle, content: currentContent },
+				} );
+			} else {
+				const post = await apiFetch< WpPost >( {
+					path: '/wp/v2/posts',
+					method: 'POST',
+					data: { title: currentTitle, content: currentContent, status: 'draft' },
+				} );
+				// Capture new ID on first-create so subsequent autosaves
+				// update the same draft instead of creating duplicates.
+				if ( post?.id ) {
+					activePostIdRef.current = post.id;
+					setActivePostId( post.id );
+				}
 			}
 			lastSavedPayloadRef.current = payload;
 			setHasUnsavedChanges( false );

--- a/src/blocks/studio/tabs/compose/index.ts
+++ b/src/blocks/studio/tabs/compose/index.ts
@@ -90,6 +90,8 @@ const ComposePane = ( _props: StudioPaneProps ): ReactElement => {
 	const isAutosavingRef = useRef( false );
 	const inFlightPromiseRef = useRef< Promise< void > | null >( null );
 	const pendingRerunRef = useRef( false );
+	const consecutiveFailuresRef = useRef( 0 );
+	const autosaveErrorActiveRef = useRef( false );
 	const activePostIdRef = useRef< number | null >( null );
 	const titleRef = useRef( '' );
 	const contentSnapshotRef = useRef( '' );
@@ -371,8 +373,26 @@ const ComposePane = ( _props: StudioPaneProps ): ReactElement => {
 				}
 				lastSavedPayloadRef.current = payload;
 				setHasUnsavedChanges( false );
-			} catch {
-				// Silent — user can still manually save.
+				// Successful save — reset failure counter and clear any prior
+				// autosave error message (but not manual save errors).
+				consecutiveFailuresRef.current = 0;
+				if ( autosaveErrorActiveRef.current ) {
+					autosaveErrorActiveRef.current = false;
+					setError( '' );
+				}
+			} catch ( err ) {
+				consecutiveFailuresRef.current += 1;
+				// Surface the error in the UI after 2 consecutive failures so a
+				// single transient blip doesn't spook the user, but real
+				// outages become visible.
+				if ( consecutiveFailuresRef.current >= 2 ) {
+					const message = ( err as Error )?.message || __( 'Unknown error', 'extrachill-studio' );
+					autosaveErrorActiveRef.current = true;
+					setError(
+						/* translators: 1: number of consecutive failures, 2: error message */
+						`${ __( 'Autosave failed', 'extrachill-studio' ) } (${ consecutiveFailuresRef.current } ${ __( 'attempt(s)', 'extrachill-studio' ) }): ${ message }`
+					);
+				}
 			} finally {
 				isAutosavingRef.current = false;
 				inFlightPromiseRef.current = null;


### PR DESCRIPTION
Implements the load-bearing Compose autosave reliability fixes from #77.
All changes confined to `src/blocks/studio/tabs/compose/index.ts`.

PR #78 already shipped items 6 (omit status on update) and 9 (author-scope
loadDrafts). Items 2 and 6 from the original list are subsumed by the
changes below.

Closes items 1, 3, 4, 5, 7, 8 of #77.

## Changes (one commit per item)

### 1. Switch autosave POST to `/wp/v2/posts/<id>/autosaves` (item 5)
Subsequent autosaves now hit WP core's `/autosaves` endpoint instead of
overwriting the parent post via `/wp/v2/posts/<id>`. This:
- Uses WP core's per-user autosave isolation, dedupe, and snapshot semantics.
- Stops clobbering parent status (a draft published in another tab is no longer
  demoted back to draft on next keystroke).
- Eliminates revision spam — autosaves no longer pollute revision history.
- Omits `status` entirely on update (the `/autosaves` endpoint preserves
  parent status by design).

Initial create still POSTs to `/wp/v2/posts` with `status=draft`. The
`/autosaves` endpoint returns a revision object whose `id` is the revision ID
(not the parent), so `activePostIdRef` is intentionally left untouched after
the initial create — the parent ID is stable. Same path change applied in
`flushCurrentDraft`.

### 2. Queue post-flight autosaves instead of dropping events (item 1)
Replaced the silent early-return when a save is in flight with a
`pendingRerunRef` flag. The in-flight save's `finally` block now checks the
flag and re-invokes `performAutosave` once, capturing the latest content.
The rerun naturally collapses multiple queued requests into one trailing
save.

### 3. `flushCurrentDraft` awaits in-flight save (item 3)
Introduced `inFlightPromiseRef` that both `performAutosave` and
`flushCurrentDraft` publish their save promise to. `flushCurrentDraft` now
captures the current in-flight promise locally and awaits it before doing
its own save, so draft switches no longer silently discard pre-switch
keystrokes. The local capture prevents self-deadlock when
`flushCurrentDraft` issues its own subsequent save.

### 4. Surface autosave failures after consecutive attempts (item 4)
Added `consecutiveFailuresRef`. After 2 consecutive failures, the error is
surfaced through the existing `InlineStatusView` via `setError`. Reset on
the next successful save, but only if the active error is an autosave error
(`autosaveErrorActiveRef` guards against clobbering errors from manual
save/submit handlers).

### 5. `beforeunload` guard for unsaved changes (item 7)
Native browser "Leave site?" prompt when the user closes/reloads the tab
with unsaved changes. Handler reads from `hasUnsavedChangesRef` (synced
via a small effect) because the listener is registered once and would
otherwise capture stale state.

### 6. `pagehide` + `sendBeacon` flush (item 8)
Best-effort last-write when the tab is torn down. `sendBeacon` is the only
request guaranteed to be delivered during unload. The nonce is read from
`props.context.restNonce` (already populated from `data-rest-nonce` in
`render.php`).

**Limitation:** when no `postId` exists yet (initial draft never created),
there's no `/autosaves` endpoint to target. The beacon is skipped and we
accept the loss; documented inline.

## Test plan (manual)

1. **Autosave path migration**
   - Type into a new Compose draft. Watch network tab. First save is
     `POST /wp/v2/posts`. Subsequent saves go to
     `POST /wp/v2/posts/<id>/autosaves`.
   - Manually publish the draft from wp-admin in another tab → `status`
     becomes `publish`. Type more in Studio Compose. Verify the autosave
     does NOT demote the post back to draft.
2. **Queue post-flight**
   - Type a fast burst of text. Throttle network to "Slow 3G" in DevTools.
     Verify the post-burst typing reaches the server.
3. **Flush awaits in-flight**
   - Same throttled network. Type, immediately switch drafts via the picker.
     Verify pre-switch content survives on the source draft.
4. **Error surface**
   - Block `/wp/v2/posts/.../autosaves` via DevTools network blocking. Type.
     Verify error appears in `InlineStatusView` after 2 attempts.
5. **beforeunload**
   - Type, close tab. Browser shows native "Leave site?" prompt.
6. **pagehide / sendBeacon**
   - Type, close tab (confirm leave). Reload Compose, select the same draft.
     Verify last-typed content is available via
     `GET /wp/v2/posts/<id>/autosaves`.
7. **Build:** `npm run build` ✅ passes locally. `npx tsc --noEmit` ✅ clean.

## Out of scope
- Restoring autosave content into the editor on load (would require fetching
  the latest autosave revision via `GET /wp/v2/posts/<id>/autosaves` and
  seeding the editor). Filed as follow-up if needed.
- Items 6 and 9 — already shipped in #78.

Refs Extra-Chill/extrachill-studio#77