### PR TITLE
fix: rename BE settings key from iso to blocksEverywhere

### DIFF
--- a/inc/compose-editor.php
+++ b/inc/compose-editor.php
@@ -141,7 +141,7 @@ function configure_compose_editor( array $settings ): array {
 	$settings['editorType'] = 'studio';
 
 	// Configure allowed blocks — writing-focused.
-	$settings['iso']['blocks']['allowBlocks'] = apply_filters(
+	$settings['blocksEverywhere']['blocks']['allowBlocks'] = apply_filters(
 		'extrachill_studio_allowed_blocks',
 		array(
 			'core/paragraph',
@@ -158,8 +158,8 @@ function configure_compose_editor( array $settings ): array {
 
 	// Show the block inserter in the shared sidebar mode, but detach the
 	// rendered sidebar into Studio's dedicated compose sidebar slot.
-	$settings['iso']['sidebar']['inserter'] = true;
-	$settings['iso']['sidebar']['detached'] = array(
+	$settings['blocksEverywhere']['sidebar']['inserter'] = true;
+	$settings['blocksEverywhere']['sidebar']['detached'] = array(
 		'target'    => '.ec-studio-compose-sidebar__slot',
 		'className' => 'ec-studio-compose-sidebar__content',
 		'persistent' => true,
@@ -167,7 +167,7 @@ function configure_compose_editor( array $settings ): array {
 	);
 
 	// Allow common embed types.
-	$settings['iso']['allowEmbeds'] = array(
+	$settings['blocksEverywhere']['allowEmbeds'] = array(
 		'youtube',
 		'vimeo',
 		'spotify',
@@ -195,13 +195,13 @@ function configure_compose_editor( array $settings ): array {
 	// in style.css under html.is-fullscreen-mode and hides Studio chrome
 	// that sits outside the editor skeleton (title input, toolbar, save
 	// actions, detached sidebar). See Phase 1 scoping in MEMORY.md.
-	$settings['iso']['moreMenu']                                = array(
+	$settings['blocksEverywhere']['moreMenu']                                = array(
 		'fullscreen' => true,
 	);
-	$settings['iso']['defaultPreferences']                      = isset( $settings['iso']['defaultPreferences'] ) && is_array( $settings['iso']['defaultPreferences'] )
-		? $settings['iso']['defaultPreferences']
+	$settings['blocksEverywhere']['defaultPreferences']                      = isset( $settings['blocksEverywhere']['defaultPreferences'] ) && is_array( $settings['blocksEverywhere']['defaultPreferences'] )
+		? $settings['blocksEverywhere']['defaultPreferences']
 		: array();
-	$settings['iso']['defaultPreferences']['fullscreenMode']    = false;
+	$settings['blocksEverywhere']['defaultPreferences']['fullscreenMode']    = false;
 
 	return $settings;
 }


### PR DESCRIPTION
## Why

Blocks Everywhere v3.0.0 ([Extra-Chill/blocks-everywhere#18](https://github.com/Extra-Chill/blocks-everywhere/pull/18)) renamed the editor settings key from `iso` to `blocksEverywhere` as a clean-cut breaking change away from IBE-shape naming. BE no longer reads `$settings['iso'][...]` at all — it only reads `$settings['blocksEverywhere'][...]`.

Studio's `inc/compose-editor.php` filters `blocks_everywhere_editor_settings` and was still writing to the old `iso` key, so **every Studio-specific editor config was being silently dropped** when BE wired up the compose editor.

## User-visible impact

Before this PR (with BE v3.0.0 deployed): the detached sidebar on studio.extrachill.com's compose editor disappeared. The `target: '.ec-studio-compose-sidebar__slot'` config never reached BE, so the inserter / block settings rendered inline inside the editor instead of in Studio's dedicated sidebar slot.

Other configs that were also being dropped (and are restored by this PR):
- Studio's writing-focused allowed-blocks allowlist
- `allowEmbeds` (youtube, vimeo, spotify, soundcloud, twitter, instagram)
- More Menu fullscreen toggle
- Default preferences (fullscreenMode: false on boot)

## After this PR

BE reads Studio's config again — detached sidebar, allowed blocks, embeds, More Menu, and default preferences all restored. Shape of the settings array is identical; only the top-level key changed.

## The change

Mechanical rename in `inc/compose-editor.php`:

```diff
- $settings['iso']['blocks']['allowBlocks']
+ $settings['blocksEverywhere']['blocks']['allowBlocks']
- $settings['iso']['sidebar']['inserter']
+ $settings['blocksEverywhere']['sidebar']['inserter']
- $settings['iso']['sidebar']['detached']
+ $settings['blocksEverywhere']['sidebar']['detached']
- $settings['iso']['allowEmbeds']
+ $settings['blocksEverywhere']['allowEmbeds']
- $settings['iso']['moreMenu']
+ $settings['blocksEverywhere']['moreMenu']
- $settings['iso']['defaultPreferences']
+ $settings['blocksEverywhere']['defaultPreferences']
- $settings['iso']['defaultPreferences']['fullscreenMode']
+ $settings['blocksEverywhere']['defaultPreferences']['fullscreenMode']
```

8 occurrences total, all in `inc/compose-editor.php`. Verified post-edit: zero remaining `$settings['iso']` references anywhere in the plugin source.

## Smoke test

BE v3.0.0+ is already deployed at HEAD on production, so the verification path after this PR ships is just:

1. Merge + deploy this PR (homeboy release + deploy)
2. Hard-reload the compose editor on studio.extrachill.com
3. Confirm detached sidebar reappears in `.ec-studio-compose-sidebar__slot`

Pure server-side change — no JS-side settings reader in this plugin.

## Hard constraints honored

- No `CHANGELOG.md` edits (homeboy owns it)
- No version string bumps (homeboy auto-detects from conventional commit)
- Conventional commit: `fix:` prefix (consumer-side breaking-change adaptation)

cc @chubes — ready for review.