### PR TITLE
fix(compose): remove dead hasUploadPermissions setting injection

### DIFF
--- a/inc/compose-editor.php
+++ b/inc/compose-editor.php
@@ -176,9 +176,6 @@ function configure_compose_editor( array $settings ): array {
 		'instagram',
 	);
 
-	// Upload permissions for logged-in team members.
-	$settings['editor']['hasUploadPermissions'] = current_user_can( 'upload_files' );
-
 	// Provide MIME types so the Media tab in the inserter can show
 	// existing uploads filtered by type (images, video, audio).
 	$settings['editor']['allowedMimeTypes'] = get_allowed_mime_types();


### PR DESCRIPTION
Closes #73.

## Background

Issue #73 reported that team members composing in Studio hit HTTP 500 on every image upload (`async-upload.php`), leaving orphan attachments and empty image blocks. Root cause: the user (qrisg) was a "team member" via the old `extrachill_team` user-meta flag but had **no WP role on studio.extrachill.com**, so `current_user_can('upload_files')` returned false server-side while the custom `ec_is_team_member()` check let them into the Compose tab.

## What fixed the root cause

**extrachill-users#45** (closed) replaced the parallel meta-based team system with a first-class `extra_chill_team` WordPress role that:
- registers on every site in the network
- grants `upload_files` (plus `access_studio`, `edit_posts`, etc.)
- is the source of truth for `ec_is_team_member()`, which now resolves `user_can($uid, 'access_studio')`

Verified in production:
- `extra_chill_team` role exists on studio with `upload_files=yes`, `access_studio=yes`
- qrisg (38) now has `roles=editor,extra_chill_team`, `upload_files=yes`
- A non-team, non-admin user is **BLOCKED** from the Compose tab gate entirely

## This PR

The only Studio-side remnant was a dead settings injection:

```php
// Upload permissions for logged-in team members.
$settings['editor']['hasUploadPermissions'] = current_user_can( 'upload_files' );
```

- **No JS consumer.** Grep across `src/` and `build/` returns zero references to `hasUploadPermissions`. It was defensive data for a toolbar guard that was never wired up.
- **Now structurally redundant.** Any user who can open Compose passes the `ec_is_team_member()` gate → holds `access_studio` → holds `upload_files`. The flag would always be `true` for anyone who could read it.

Removing the dead line. The bug it was meant to defend against is impossible now that the role guarantees the cap.

## Verification

- `php -l` clean on `inc/compose-editor.php`
- No remaining `hasUploadPermissions` references in the repo
- The orphan-attachment incident from the issue body was already confirmed cleaned (see issue comment 2026-05-22) — nothing to remediate