### PR TITLE
fix(compose): don't mark draft clean when edits land mid-autosave

### DIFF
--- a/src/blocks/studio/tabs/compose/index.ts
+++ b/src/blocks/studio/tabs/compose/index.ts
@@ -104,6 +104,10 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 	const pendingRerunRef = useRef( false );
 	const consecutiveFailuresRef = useRef( 0 );
 	const autosaveErrorActiveRef = useRef( false );
+	// Monotonic edit counter. Incremented on every title/content edit. Captured
+	// at the start of an autosave so we can detect edits that land during the
+	// in-flight window and avoid marking those keystrokes as "saved".
+	const editSeqRef = useRef( 0 );
 	const hasUnsavedChangesRef = useRef( false );
 	const activePostIdRef = useRef< number | null >( null );
 	const titleRef = useRef( '' );
@@ -382,6 +386,12 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 			return;
 		}
 
+		// Capture the edit sequence for this snapshot. If the user types during
+		// the in-flight await, editSeqRef advances past this value and we must
+		// NOT mark the draft clean — the trailing keystrokes aren't on the
+		// server yet.
+		const savedSeq = editSeqRef.current;
+
 		isAutosavingRef.current = true;
 
 		// Expose the in-flight operation as a promise so flushCurrentDraft (and
@@ -413,8 +423,17 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 						setActivePostId( post.id );
 					}
 				}
-				lastSavedPayloadRef.current = payload;
-				setHasUnsavedChanges( false );
+				// Only record this payload as the saved baseline and clear the
+				// unsaved flag if no edit landed during the in-flight window.
+				// If editSeqRef advanced, the user typed while we were saving —
+				// those keystrokes are unsaved, so keep hasUnsavedChanges true
+				// and schedule a re-run to flush them.
+				if ( editSeqRef.current === savedSeq ) {
+					lastSavedPayloadRef.current = payload;
+					setHasUnsavedChanges( false );
+				} else {
+					pendingRerunRef.current = true;
+				}
 				// Successful save — reset failure counter and clear any prior
 				// autosave error message (but not manual save errors).
 				consecutiveFailuresRef.current = 0;
@@ -546,6 +565,7 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 		}
 
 		const onContentChange = (): void => {
+			editSeqRef.current += 1;
 			contentSnapshotRef.current = getContent();
 			const payload = JSON.stringify( { title: titleRef.current.trim(), content: contentSnapshotRef.current.trim() } );
 			setHasUnsavedChanges( payload !== lastSavedPayloadRef.current );
@@ -744,6 +764,7 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 	};
 
 	const onTitleChange = ( e: ChangeEvent< HTMLInputElement > ): void => {
+		editSeqRef.current += 1;
 		titleRef.current = e.target.value;
 		setTitle( e.target.value );
 		setError( '' );


### PR DESCRIPTION
Closes #77 (the last open reliability item — items 1, 3, 4, 5, 6, 7, 8, 9 already shipped in v0.15.x).

## The bug (issue #77 item 2 — stale snapshot)

`performAutosave()` captures a `{ title, content }` snapshot, then awaits the POST. On success it **unconditionally** ran:

```ts
lastSavedPayloadRef.current = payload;   // the pre-await snapshot
setHasUnsavedChanges( false );
```

But any keystrokes the user typed **during** the in-flight await are not in that snapshot. Marking the draft clean at that moment is wrong:

```
t0  autosave fires, snapshot = "hello"
t1  POST starts (800ms await)
t2  user types " world" → onContentChange → hasUnsavedChanges = true
t3  POST resolves → lastSavedPayloadRef = "hello"
t4  setHasUnsavedChanges(false)   ← WRONG: " world" is not on the server
```

The `beforeunload` and `pagehide`/`sendBeacon` guards read `hasUnsavedChangesRef`, so there's a window right after a save where closing the tab drops the trailing keystrokes with no prompt and no beacon.

## The fix

A monotonic `editSeqRef`:

- Bumped on every `onContentChange` and `onTitleChange`.
- Captured as `savedSeq` at the start of `performAutosave`, before the await.
- After the await, only mark the draft clean **if `editSeqRef.current === savedSeq`** (no edit landed during the in-flight window).
- If the seq advanced, keep `hasUnsavedChanges` true and set `pendingRerunRef = true` so the existing `finally`-block re-run (item 1's mechanism) fires another save immediately and flushes the trailing edits.

This composes cleanly with the in-flight re-run machinery already in place from item 1 — no new timers, no new state, just a correctness gate on the success path.

## Scope

23-line change, confined to `src/blocks/studio/tabs/compose/index.ts`. No PHP, REST, or ability changes.

## Verification

- `npm run build` compiles clean (wp-scripts, no TS errors).
- Diff is 3 edits: add `editSeqRef`, gate the success-side state update on the seq, bump seq in the two edit handlers.

## Issue #77 status after this PR

| # | Item | Status |
|---|---|---|
| 1 | In-flight guard drops events | ✅ shipped (pendingRerunRef) |
| 2 | Stale snapshot | ✅ **this PR** |
| 3 | flushCurrentDraft bails | ✅ shipped (awaits in-flight) |
| 4 | Errors swallowed | ✅ shipped (consecutive-failure surface) |
| 5 | No conflict detection | ✅ shipped (/autosaves endpoint) |
| 6 | status sent on update | ✅ shipped (omitted on autosaves) |
| 7 | No beforeunload | ✅ shipped |
| 8 | No pagehide/sendBeacon | ✅ shipped |
| 9 | loadDrafts not author-scoped | ✅ shipped (&author filter) |

All 9 resolved — issue closes with this.