### PR TITLE
chore: bump @extrachill/components to ^0.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.1.0",
 			"dependencies": {
 				"@extrachill/chat": "^0.7.0",
-				"@extrachill/components": "^0.4.50",
+				"@extrachill/components": "^0.5.2",
 				"@extrachill/tokens": "^0.4.2"
 			},
 			"devDependencies": {
@@ -2686,9 +2686,9 @@
 			}
 		},
 		"node_modules/@extrachill/components": {
-			"version": "0.4.50",
-			"resolved": "https://registry.npmjs.org/@extrachill/components/-/components-0.4.50.tgz",
-			"integrity": "sha512-DCQOuurmUvPoX0QBPSgHumJlx+fvIKVQEEgkrsMTFYqXeHo66xLAGbRUAxmZjivugqFkKT7qknte1yV4lZcIKQ==",
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/@extrachill/components/-/components-0.5.2.tgz",
+			"integrity": "sha512-vBacRRqb72EXuZNjgmMMaOO9Ztl7BXMmOnA5idX3PuvLVdeDif1lRoqhtKnOZ+8JFLcajXXrI1N2kGocPnbE2Q==",
 			"license": "GPL-2.0+",
 			"peerDependencies": {
 				"react": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	},
 	"dependencies": {
 		"@extrachill/chat": "^0.7.0",
-		"@extrachill/components": "^0.4.50",
+		"@extrachill/components": "^0.5.2",
 		"@extrachill/tokens": "^0.4.2"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## Summary

Bumps `@extrachill/components` from `^0.4.50` → `^0.5.2` and resolves the lockfile to `0.5.2`.

## What changed

- `package.json`: `@extrachill/components` dependency range `^0.4.x → ^0.5.2`
- `package-lock.json`: regenerated via `npm install`, resolves `@extrachill/components@0.5.2`
- Assets rebuilt via `npm run build` (build succeeded with no errors). Note: `build/` is gitignored in this repo, so no compiled assets appear in the diff — the new component code/styles will land in CI/deploy builds.

## Behavior changes riding along (please smoke-test)

`0.5.2` carries three component-level changes that affect Studio surfaces:

1. **BlockShellInner centering fix** — `margin-inline:auto` for narrow/wide layouts. Check block centering in narrow and wide alignments.
2. **SearchBox canonical button classes** — verify SearchBox renders and styles correctly.
3. **InlineStatus / Badge dark-mode token parity** — verify InlineStatus and Badge appearance in dark mode.

## Build

- `npm run build` completed successfully: `webpack 5.105.4 compiled successfully`.

## Lint

`homeboy lint extrachill-studio` reports 57 pre-existing phpstan findings across PHP files (`inc/*.php`, `src/blocks/studio/render.php`). **None are introduced by this change** — this PR only touches `package.json` and `package-lock.json`. Pre-existing PHP debt left as-is per scope.