### PR TITLE
fix: guard ability category registration against double-fire _doing_it_wrong notice

### DIFF
--- a/extrachill-studio.php
+++ b/extrachill-studio.php
@@ -61,6 +61,13 @@ function extrachill_studio_register_ability_category() {
 		return;
 	}
 
+	// Core's wp_abilities_api_categories_init action can fire more than once per
+	// request on multisite; guard against re-registration to avoid a
+	// _doing_it_wrong notice from WP_Ability_Categories_Registry::register().
+	if ( function_exists( 'wp_has_ability_category' ) && wp_has_ability_category( 'extrachill' ) ) {
+		return;
+	}
+
 	wp_register_ability_category(
 		'extrachill',
 		array(


### PR DESCRIPTION
## The notice

```
PHP Notice: Function WP_Ability_Categories_Registry::register was called incorrectly.
Ability category "extrachill" is already registered.
in /var/www/extrachill.com/wp-includes/functions.php on line 6170
```

## Root cause

On this multisite, WordPress core's `wp_abilities_api_categories_init` action fires more than once per request. Our `extrachill_studio_register_ability_category()` callback called `wp_register_ability_category( 'extrachill', ... )` unconditionally, so the second hook fire re-registered an already-registered category and tripped `_doing_it_wrong`.

## The fix

Added core's idempotency check `wp_has_ability_category( 'extrachill' )` (guarded with `function_exists` since it ships with the same core API) before the registration call. A repeat hook fire is now a clean no-op. Slug, label, description, and hook are unchanged.

This is one of ~15 plugins across the network being fixed for the same network-wide root cause.