### PR TITLE
feat(compose): make Studio blog drafts born on main extrachill.com

### DIFF
--- a/extrachill-studio.php
+++ b/extrachill-studio.php
@@ -33,6 +33,7 @@ require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/assets.php';
 require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/breadcrumbs.php';
 require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/social-drafts.php';
 require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/compose-editor.php';
+require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/compose/rest.php';
 require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/abilities/resolve-instagram-media.php';
 require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/abilities/run-giveaway.php';
 require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/abilities/sweatpants-token.php';

--- a/inc/compose-editor.php
+++ b/inc/compose-editor.php
@@ -238,12 +238,6 @@ function configure_compose_editor( array $settings ): array {
 	//      enforcement in the compose media proxy route.
 	$settings['maxUploadFileSize'] = (int) extrachill_studio_compose_main_max_upload_size();
 
-	// Provide Studio-specific REST endpoints.
-	$settings['studio'] = array(
-		'postsEndpoint' => rest_url( 'wp/v2/posts' ),
-		'mediaEndpoint' => rest_url( 'extrachill/v1/media' ),
-	);
-
 	// Expose IBE's More Menu so writers can toggle fullscreen mode and
 	// keyboard shortcuts. Default to non-fullscreen on boot — users opt in
 	// via the menu (or Ctrl/Cmd+Shift+Alt+F). Fullscreen-state CSS lives

--- a/inc/compose-editor.php
+++ b/inc/compose-editor.php
@@ -17,6 +17,35 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
+ * Resolve main extrachill.com's maximum upload size in bytes.
+ *
+ * Compose images are written to MAIN (blog 1), so the editor's client-side
+ * size check must validate against main's allowance — not Studio's. Resolved
+ * inside main's blog context so PHP ini + WP filters for the destination site
+ * apply. Falls back to the local limit if multisite helpers are unavailable.
+ *
+ * @since 0.16.0
+ *
+ * @return int Max upload size in bytes.
+ */
+function extrachill_studio_compose_main_max_upload_size(): int {
+	if ( ! function_exists( 'ec_get_blog_id' ) ) {
+		return (int) wp_max_upload_size();
+	}
+
+	$main_blog_id = (int) ec_get_blog_id( 'main' );
+	if ( $main_blog_id <= 0 ) {
+		return (int) wp_max_upload_size();
+	}
+
+	switch_to_blog( $main_blog_id );
+	$max = (int) wp_max_upload_size();
+	restore_current_blog();
+
+	return $max;
+}
+
+/**
  * Register the Studio compose editor as a Blocks Everywhere context.
  *
  * @param array $contexts Registered contexts.
@@ -179,6 +208,21 @@ function configure_compose_editor( array $settings ): array {
 	// Provide MIME types so the Media tab in the inserter can show
 	// existing uploads filtered by type (images, video, audio).
 	$settings['editor']['allowedMimeTypes'] = get_allowed_mime_types();
+
+	// Set the client-side upload size limit so the editor rejects oversized
+	// images instantly — before any upload starts — with a clear message,
+	// rather than letting them fail opaquely at the server.
+	//
+	// Two reasons this is set explicitly here:
+	//   1. In this Blocks Everywhere frontend context, core resolves
+	//      maxUploadFileSize to 0, which DISABLES client-side size validation
+	//      entirely (the guard is `if ( maxUploadFileSize && ... )`). Setting a
+	//      real value re-enables it.
+	//   2. Compose images are written to MAIN (blog 1), so the limit that
+	//      matters is main's wp_max_upload_size(), not Studio's. We resolve it
+	//      in main's context so the client-side check matches the server-side
+	//      enforcement in the compose media proxy route.
+	$settings['maxUploadFileSize'] = (int) extrachill_studio_compose_main_max_upload_size();
 
 	// Provide Studio-specific REST endpoints.
 	$settings['studio'] = array(

--- a/inc/compose-editor.php
+++ b/inc/compose-editor.php
@@ -209,6 +209,20 @@ function configure_compose_editor( array $settings ): array {
 	// existing uploads filtered by type (images, video, audio).
 	$settings['editor']['allowedMimeTypes'] = get_allowed_mime_types();
 
+	// Enable the editor's image upload affordances (upload button, drag-and-
+	// drop onto the canvas, the Media Library tab's upload). Blocks Everywhere
+	// gates ALL of this — including whether it runs wp_enqueue_media() — on
+	// editor.hasUploadPermissions, and defaults it to unset (falsy). Without
+	// this flag the writer gets no working way to add an image at all, which
+	// is the confusing part of the experience.
+	//
+	// Gate on the WP core capability. Team members have `upload_files` on both
+	// Studio and main (the destination), so the editor enables uploads and the
+	// cross-site media proxy's write to main succeeds under the same user's
+	// caps. The proxy route enforces the capability again server-side, so this
+	// flag only governs UI affordances, never trust.
+	$settings['editor']['hasUploadPermissions'] = current_user_can( 'upload_files' );
+
 	// Set the client-side upload size limit so the editor rejects oversized
 	// images instantly — before any upload starts — with a clear message,
 	// rather than letting them fail opaquely at the server.

--- a/inc/compose/rest.php
+++ b/inc/compose/rest.php
@@ -398,12 +398,16 @@ function ec_studio_compose_create_autosave( \WP_REST_Request $request ) {
 	$post_id = (int) $request['id'];
 
 	// Only title/content are forwarded — status is intentionally never sent on
-	// autosave (see docblock).
+	// autosave (see docblock). Title/content are passed through unaltered:
+	// main's /wp/v2/posts autosave controller is the single sanitization
+	// authority and expects unslashed input, which get_json_params() returns.
+	// Pre-sanitizing here would double-process and mangle legitimate
+	// characters (e.g. backslashes), so we don't.
 	$raw  = $request->get_json_params();
 	$body = array();
 	if ( is_array( $raw ) ) {
 		if ( isset( $raw['title'] ) ) {
-			$body['title'] = sanitize_text_field( wp_unslash( (string) $raw['title'] ) );
+			$body['title'] = (string) $raw['title'];
 		}
 		if ( isset( $raw['content'] ) ) {
 			$body['content'] = (string) $raw['content'];
@@ -427,16 +431,25 @@ function ec_studio_compose_create_autosave( \WP_REST_Request $request ) {
  * Sanitize the post params accepted from the compose pane.
  *
  * Whitelists the small set of fields the compose pane sends — title, content,
- * status — so the proxy never forwards arbitrary REST fields cross-site. The
- * `status` value is validated against the lifecycle states the compose pane
- * is allowed to set (draft, pending). Content is left unescaped because the
- * block editor produces post HTML that main's `/wp/v2/posts` controller
- * sanitizes with the author's capabilities (post caps re-checked on main).
+ * status — so the proxy never forwards arbitrary REST fields cross-site.
+ *
+ * Title and content are passed through unaltered. Main's `/wp/v2/posts`
+ * controller is the single sanitization authority: it sanitizes the title via
+ * its schema and sanitizes post HTML with the author's capabilities (post caps
+ * are re-checked on main under the user's own auth). It expects UNSLASHED
+ * input, which `get_json_params()` returns — REST JSON bodies are not slashed.
+ * Pre-sanitizing or unslashing here would double-process and corrupt
+ * legitimate characters (e.g. backslashes), so we don't.
+ *
+ * The only field the proxy actively gates is `status`: it is validated against
+ * the lifecycle states the compose pane is allowed to set (draft, pending) —
+ * a policy gate, not sanitization — so the tool can never push a post straight
+ * to publish.
  *
  * @since 0.16.0
  *
  * @param mixed $raw Raw JSON params.
- * @return array Sanitized post params.
+ * @return array Whitelisted post params.
  */
 function ec_studio_compose_sanitize_post_params( $raw ): array {
 	$params = array();
@@ -446,7 +459,7 @@ function ec_studio_compose_sanitize_post_params( $raw ): array {
 	}
 
 	if ( isset( $raw['title'] ) ) {
-		$params['title'] = sanitize_text_field( wp_unslash( (string) $raw['title'] ) );
+		$params['title'] = (string) $raw['title'];
 	}
 
 	if ( isset( $raw['content'] ) ) {

--- a/inc/compose/rest.php
+++ b/inc/compose/rest.php
@@ -27,6 +27,8 @@
  *   - POST /extrachill/v1/studio/compose/posts/<id>            Update / submit-for-review on main.
  *   - GET  /extrachill/v1/studio/compose/posts/<id>/autosaves  List autosaves for a draft on main.
  *   - POST /extrachill/v1/studio/compose/posts/<id>/autosaves  Autosave a draft on main (status omitted).
+ *   - GET  /extrachill/v1/studio/compose/media                 Browse main's media library (inserter grid).
+ *   - GET  /extrachill/v1/studio/compose/media/<id>            Fetch a single attachment on main.
  *   - POST /extrachill/v1/studio/compose/media                 Upload an image into main's media library.
  *
  * The frontend installs an apiFetch middleware that rewrites the compose
@@ -128,9 +130,33 @@ function ec_studio_compose_register_routes(): void {
 		'/' . EC_STUDIO_COMPOSE_ROUTE . '/media',
 		array(
 			array(
+				'methods'             => 'GET',
+				'callback'            => 'ec_studio_compose_list_media',
+				'permission_callback' => 'ec_studio_compose_permission_check',
+			),
+			array(
 				'methods'             => 'POST',
 				'callback'            => 'ec_studio_compose_upload_media',
 				'permission_callback' => 'ec_studio_compose_permission_check',
+			),
+		)
+	);
+
+	register_rest_route(
+		EC_STUDIO_COMPOSE_NAMESPACE,
+		'/' . EC_STUDIO_COMPOSE_ROUTE . '/media/(?P<id>\d+)',
+		array(
+			array(
+				'methods'             => 'GET',
+				'callback'            => 'ec_studio_compose_get_media_item',
+				'permission_callback' => 'ec_studio_compose_permission_check',
+				'args'                => array(
+					'id' => array(
+						'required'          => true,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
+				),
 			),
 		)
 	);
@@ -435,6 +461,138 @@ function ec_studio_compose_sanitize_post_params( $raw ): array {
 	}
 
 	return $params;
+}
+
+/**
+ * Browse main extrachill.com's media library for the inserter grid.
+ *
+ * The block editor's Media Library tab does `GET /wp/v2/media` (with search,
+ * pagination, and mime-type filters) to browse existing uploads. The frontend
+ * middleware rewrites that here so writers see and re-insert images from
+ * MAIN's library (blog 1) — consistent with where uploads land — instead of
+ * Studio's (blog 12) library.
+ *
+ * All query params are forwarded verbatim so the editor's search, paging, and
+ * media_type/mime_type filters work unchanged. The X-WP-Total /
+ * X-WP-TotalPages headers the inserter relies on for pagination are emitted by
+ * the core media controller during the in-process dispatch and surfaced here.
+ *
+ * @since 0.16.0
+ *
+ * @param \WP_REST_Request $request REST request.
+ * @return \WP_REST_Response|\WP_Error
+ */
+function ec_studio_compose_list_media( \WP_REST_Request $request ) {
+	if ( ! function_exists( 'ec_get_blog_id' ) ) {
+		return new \WP_Error(
+			'multisite_helper_missing',
+			__( 'extrachill-multisite is required for cross-site media browse.', 'extrachill-studio' ),
+			array( 'status' => 500 )
+		);
+	}
+
+	$query = $request->get_query_params();
+
+	// The core-data media grid reads X-WP-Total / X-WP-TotalPages headers off
+	// the raw response for pagination (apiFetch parse:false). The generic
+	// cross-site helper returns only the decoded body and strips those
+	// headers, so we dispatch in-process here and re-emit the pagination
+	// headers onto our own WP_REST_Response.
+	return ec_studio_compose_dispatch_media_list_on_main( is_array( $query ) ? $query : array() );
+}
+
+/**
+ * Dispatch a media-list query on main and return a paginated REST response.
+ *
+ * Runs `GET /wp/v2/media` inside `switch_to_blog( main )` via rest_do_request
+ * so we can read the core controller's X-WP-Total / X-WP-TotalPages headers
+ * and forward them — the inserter grid relies on them for pagination.
+ *
+ * @since 0.16.0
+ *
+ * @param array $query Query params forwarded from the editor.
+ * @return \WP_REST_Response|\WP_Error
+ */
+function ec_studio_compose_dispatch_media_list_on_main( array $query ) {
+	$main_blog_id = (int) ec_get_blog_id( 'main' );
+	if ( $main_blog_id <= 0 ) {
+		return new \WP_Error(
+			'main_blog_unresolved',
+			__( 'Could not resolve the main site for media browse.', 'extrachill-studio' ),
+			array( 'status' => 500 )
+		);
+	}
+
+	$result = null;
+
+	switch_to_blog( $main_blog_id );
+	try {
+		$sub = new \WP_REST_Request( 'GET', '/wp/v2/media' );
+		$sub->set_query_params( $query );
+		$sub->add_header( 'X-EC-Forwarded', '1' );
+
+		$sub_response = rest_do_request( $sub );
+
+		if ( $sub_response->is_error() ) {
+			$error  = $sub_response->as_error();
+			$data   = $error->get_error_data();
+			$status = is_array( $data ) && isset( $data['status'] ) ? (int) $data['status'] : 500;
+			$result = new \WP_Error(
+				$error->get_error_code() ? $error->get_error_code() : 'ec_cross_site_error',
+				$error->get_error_message() ? $error->get_error_message() : __( 'Cross-site media browse failed.', 'extrachill-studio' ),
+				array( 'status' => $status )
+			);
+		} else {
+			$response = rest_ensure_response( $sub_response->get_data() );
+			// Forward the pagination headers the grid reads via parse:false.
+			$headers = $sub_response->get_headers();
+			foreach ( array( 'X-WP-Total', 'X-WP-TotalPages' ) as $header ) {
+				if ( isset( $headers[ $header ] ) ) {
+					$response->header( $header, (string) $headers[ $header ] );
+				}
+			}
+			$result = $response;
+		}
+	} finally {
+		restore_current_blog();
+	}
+
+	return $result;
+}
+
+/**
+ * Fetch a single attachment from main extrachill.com.
+ *
+ * The editor fetches `/wp/v2/media/<id>` to hydrate an attachment after
+ * insertion or when re-resolving a block's media. Forwarded to main so the
+ * blog-1 attachment is returned.
+ *
+ * @since 0.16.0
+ *
+ * @param \WP_REST_Request $request REST request.
+ * @return \WP_REST_Response|\WP_Error
+ */
+function ec_studio_compose_get_media_item( \WP_REST_Request $request ) {
+	$guard = ec_studio_compose_require_cross_site();
+	if ( is_wp_error( $guard ) ) {
+		return $guard;
+	}
+
+	$user_id       = (int) get_current_user_id();
+	$attachment_id = (int) $request['id'];
+	$query         = $request->get_query_params();
+
+	$response = ec_cross_site_rest_request(
+		'main',
+		'GET',
+		'/wp/v2/media/' . $attachment_id,
+		array(
+			'query'   => is_array( $query ) ? $query : array(),
+			'user_id' => $user_id,
+		)
+	);
+
+	return ec_studio_compose_relay_response( $response );
 }
 
 /**

--- a/inc/compose/rest.php
+++ b/inc/compose/rest.php
@@ -1,0 +1,593 @@
+<?php
+/**
+ * Compose REST Proxy — cross-site bridge for the Studio Blog tab.
+ *
+ * The Studio Compose pane is an internal team tool that drafts blog articles
+ * for editorial review and publishing on MAIN extrachill.com (blog 1). Studio
+ * itself lives on blog 12. If the compose pane wrote posts to the local Studio
+ * site, every submitted article would be stranded where no editor ever looks
+ * (see Extra-Chill/extrachill-studio#75).
+ *
+ * Rather than draft on Studio and migrate to main later — which means
+ * re-homing attachments, rewriting image URLs/IDs in block content, and
+ * recreating terms — posts are BORN ON MAIN from the very first draft. Studio
+ * stays a pure tool surface; the post lives on blog 1 its entire lifecycle
+ * (draft → pending → publish).
+ *
+ * The compose pane is a frontend React/TS app, so it cannot call the PHP
+ * `ec_cross_site_rest_request()` primitive directly. These thin Studio-local
+ * REST routes are the server-side bridge: each one proxies to main via
+ * `ec_cross_site_rest_request( 'main', ... )` (extrachill-multisite), which is
+ * in-process by default (switch_to_blog + rest_do_request — no HTTP loopback)
+ * and runs under the requesting user's auth, respecting WP core caps.
+ *
+ * Routes (all under the team-gated permission check):
+ *   - GET  /extrachill/v1/studio/compose/posts                 List the user's drafts on main.
+ *   - POST /extrachill/v1/studio/compose/posts                 Create a draft on main.
+ *   - POST /extrachill/v1/studio/compose/posts/<id>            Update / submit-for-review on main.
+ *   - GET  /extrachill/v1/studio/compose/posts/<id>/autosaves  List autosaves for a draft on main.
+ *   - POST /extrachill/v1/studio/compose/posts/<id>/autosaves  Autosave a draft on main (status omitted).
+ *   - POST /extrachill/v1/studio/compose/media                 Upload an image into main's media library.
+ *
+ * The frontend installs an apiFetch middleware that rewrites the compose
+ * pane's `/wp/v2/posts*` and `/wp/v2/media*` calls onto these proxy routes,
+ * which also captures the block editor's own inline media uploads so inserted
+ * images land in main's library — not Studio's — avoiding the very migration
+ * problem #75 set out to remove.
+ *
+ * @package    ExtraChillStudio
+ * @subpackage Compose
+ * @since      0.16.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST namespace and route prefix for the compose proxy.
+ */
+const EC_STUDIO_COMPOSE_NAMESPACE = 'extrachill/v1';
+const EC_STUDIO_COMPOSE_ROUTE     = 'studio/compose';
+
+/**
+ * Register the compose proxy REST routes.
+ *
+ * @since 0.16.0
+ *
+ * @return void
+ */
+function ec_studio_compose_register_routes(): void {
+	register_rest_route(
+		EC_STUDIO_COMPOSE_NAMESPACE,
+		'/' . EC_STUDIO_COMPOSE_ROUTE . '/posts',
+		array(
+			array(
+				'methods'             => 'GET',
+				'callback'            => 'ec_studio_compose_list_drafts',
+				'permission_callback' => 'ec_studio_compose_permission_check',
+			),
+			array(
+				'methods'             => 'POST',
+				'callback'            => 'ec_studio_compose_create_post',
+				'permission_callback' => 'ec_studio_compose_permission_check',
+			),
+		)
+	);
+
+	register_rest_route(
+		EC_STUDIO_COMPOSE_NAMESPACE,
+		'/' . EC_STUDIO_COMPOSE_ROUTE . '/posts/(?P<id>\d+)',
+		array(
+			array(
+				'methods'             => 'POST',
+				'callback'            => 'ec_studio_compose_update_post',
+				'permission_callback' => 'ec_studio_compose_permission_check',
+				'args'                => array(
+					'id' => array(
+						'required'          => true,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
+				),
+			),
+		)
+	);
+
+	register_rest_route(
+		EC_STUDIO_COMPOSE_NAMESPACE,
+		'/' . EC_STUDIO_COMPOSE_ROUTE . '/posts/(?P<id>\d+)/autosaves',
+		array(
+			array(
+				'methods'             => 'GET',
+				'callback'            => 'ec_studio_compose_list_autosaves',
+				'permission_callback' => 'ec_studio_compose_permission_check',
+				'args'                => array(
+					'id' => array(
+						'required'          => true,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
+				),
+			),
+			array(
+				'methods'             => 'POST',
+				'callback'            => 'ec_studio_compose_create_autosave',
+				'permission_callback' => 'ec_studio_compose_permission_check',
+				'args'                => array(
+					'id' => array(
+						'required'          => true,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
+				),
+			),
+		)
+	);
+
+	register_rest_route(
+		EC_STUDIO_COMPOSE_NAMESPACE,
+		'/' . EC_STUDIO_COMPOSE_ROUTE . '/media',
+		array(
+			array(
+				'methods'             => 'POST',
+				'callback'            => 'ec_studio_compose_upload_media',
+				'permission_callback' => 'ec_studio_compose_permission_check',
+			),
+		)
+	);
+}
+add_action( 'rest_api_init', 'ec_studio_compose_register_routes' );
+
+/**
+ * Permission check for the compose proxy routes.
+ *
+ * Mirrors the team-gating used by the compose editor surface itself
+ * (compose-editor.php / render.php): the caller must be a logged-in
+ * administrator or Extra Chill team member. The actual write on main is
+ * still performed under the user's own auth via the cross-site primitive,
+ * so main's core capability checks apply a second time.
+ *
+ * @since 0.16.0
+ *
+ * @return true|\WP_Error True when allowed, WP_Error otherwise.
+ */
+function ec_studio_compose_permission_check() {
+	if ( ! is_user_logged_in() ) {
+		return new \WP_Error(
+			'rest_forbidden',
+			__( 'You must be logged in to use the Studio compose tools.', 'extrachill-studio' ),
+			array( 'status' => 401 )
+		);
+	}
+
+	if ( ! current_user_can( 'manage_options' ) && function_exists( 'ec_is_team_member' ) && ! ec_is_team_member() ) {
+		return new \WP_Error(
+			'rest_forbidden',
+			__( 'Studio is available to Extra Chill team members only.', 'extrachill-studio' ),
+			array( 'status' => 403 )
+		);
+	}
+
+	return true;
+}
+
+/**
+ * Guard that extrachill-multisite's cross-site primitive is available.
+ *
+ * @since 0.16.0
+ *
+ * @return true|\WP_Error True when available, WP_Error otherwise.
+ */
+function ec_studio_compose_require_cross_site() {
+	if ( ! function_exists( 'ec_cross_site_rest_request' ) ) {
+		return new \WP_Error(
+			'multisite_helper_missing',
+			__( 'extrachill-multisite is required for cross-site compose.', 'extrachill-studio' ),
+			array( 'status' => 500 )
+		);
+	}
+
+	return true;
+}
+
+/**
+ * Normalize a cross-site response into a REST response, preserving WP_Error.
+ *
+ * @since 0.16.0
+ *
+ * @param array|\WP_Error $response Cross-site request result.
+ * @return \WP_REST_Response|\WP_Error
+ */
+function ec_studio_compose_relay_response( $response ) {
+	if ( is_wp_error( $response ) ) {
+		return $response;
+	}
+
+	return rest_ensure_response( $response );
+}
+
+/**
+ * List the current user's drafts on main extrachill.com.
+ *
+ * Author-scoped so users with edit_others_posts (editors, admins) only see
+ * their own Studio drafts in the compose picker — matching the frontend's
+ * author filter intent.
+ *
+ * @since 0.16.0
+ *
+ * @param \WP_REST_Request $request REST request.
+ * @return \WP_REST_Response|\WP_Error
+ */
+function ec_studio_compose_list_drafts( \WP_REST_Request $request ) {
+	$guard = ec_studio_compose_require_cross_site();
+	if ( is_wp_error( $guard ) ) {
+		return $guard;
+	}
+
+	$user_id = (int) get_current_user_id();
+
+	$query = array(
+		'status'   => 'draft',
+		'per_page' => 20,
+		'orderby'  => 'modified',
+		'order'    => 'desc',
+		'context'  => 'edit',
+		'author'   => $user_id,
+	);
+
+	$response = ec_cross_site_rest_request(
+		'main',
+		'GET',
+		'/wp/v2/posts',
+		array(
+			'query'   => $query,
+			'user_id' => $user_id,
+		)
+	);
+
+	return ec_studio_compose_relay_response( $response );
+}
+
+/**
+ * Create a post on main extrachill.com.
+ *
+ * Used for the initial draft create and for explicit "Save Draft" /
+ * "Submit for Review" actions when no post id exists yet. The post is born on
+ * main under the requesting user's authorship.
+ *
+ * @since 0.16.0
+ *
+ * @param \WP_REST_Request $request REST request.
+ * @return \WP_REST_Response|\WP_Error
+ */
+function ec_studio_compose_create_post( \WP_REST_Request $request ) {
+	$guard = ec_studio_compose_require_cross_site();
+	if ( is_wp_error( $guard ) ) {
+		return $guard;
+	}
+
+	$user_id = (int) get_current_user_id();
+	$params  = ec_studio_compose_sanitize_post_params( $request->get_json_params() );
+
+	// Always attribute the post to the requesting user on main.
+	$params['author'] = $user_id;
+
+	$response = ec_cross_site_rest_request(
+		'main',
+		'POST',
+		'/wp/v2/posts',
+		array(
+			'body'    => $params,
+			'user_id' => $user_id,
+		)
+	);
+
+	return ec_studio_compose_relay_response( $response );
+}
+
+/**
+ * Update an existing post on main extrachill.com.
+ *
+ * Handles "Update Draft" (status=draft) and "Submit for Review"
+ * (status=pending). The status the frontend sends is forwarded verbatim —
+ * the proxy does not demote or override it.
+ *
+ * @since 0.16.0
+ *
+ * @param \WP_REST_Request $request REST request.
+ * @return \WP_REST_Response|\WP_Error
+ */
+function ec_studio_compose_update_post( \WP_REST_Request $request ) {
+	$guard = ec_studio_compose_require_cross_site();
+	if ( is_wp_error( $guard ) ) {
+		return $guard;
+	}
+
+	$user_id = (int) get_current_user_id();
+	$post_id = (int) $request['id'];
+	$params  = ec_studio_compose_sanitize_post_params( $request->get_json_params() );
+
+	$response = ec_cross_site_rest_request(
+		'main',
+		'POST',
+		'/wp/v2/posts/' . $post_id,
+		array(
+			'body'    => $params,
+			'user_id' => $user_id,
+		)
+	);
+
+	return ec_studio_compose_relay_response( $response );
+}
+
+/**
+ * List autosaves for a draft on main extrachill.com.
+ *
+ * @since 0.16.0
+ *
+ * @param \WP_REST_Request $request REST request.
+ * @return \WP_REST_Response|\WP_Error
+ */
+function ec_studio_compose_list_autosaves( \WP_REST_Request $request ) {
+	$guard = ec_studio_compose_require_cross_site();
+	if ( is_wp_error( $guard ) ) {
+		return $guard;
+	}
+
+	$user_id = (int) get_current_user_id();
+	$post_id = (int) $request['id'];
+
+	$response = ec_cross_site_rest_request(
+		'main',
+		'GET',
+		'/wp/v2/posts/' . $post_id . '/autosaves',
+		array(
+			'query'   => array( 'context' => 'edit' ),
+			'user_id' => $user_id,
+		)
+	);
+
+	return ec_studio_compose_relay_response( $response );
+}
+
+/**
+ * Create an autosave for a draft on main extrachill.com.
+ *
+ * Deliberately omits `status` so the parent post's status is preserved — an
+ * out-of-band transition to pending/publish on main is never demoted back to
+ * draft by an in-flight autosave. This mirrors the frontend autosave
+ * contract.
+ *
+ * @since 0.16.0
+ *
+ * @param \WP_REST_Request $request REST request.
+ * @return \WP_REST_Response|\WP_Error
+ */
+function ec_studio_compose_create_autosave( \WP_REST_Request $request ) {
+	$guard = ec_studio_compose_require_cross_site();
+	if ( is_wp_error( $guard ) ) {
+		return $guard;
+	}
+
+	$user_id = (int) get_current_user_id();
+	$post_id = (int) $request['id'];
+
+	// Only title/content are forwarded — status is intentionally never sent on
+	// autosave (see docblock).
+	$raw  = $request->get_json_params();
+	$body = array();
+	if ( is_array( $raw ) ) {
+		if ( isset( $raw['title'] ) ) {
+			$body['title'] = sanitize_text_field( wp_unslash( (string) $raw['title'] ) );
+		}
+		if ( isset( $raw['content'] ) ) {
+			$body['content'] = (string) $raw['content'];
+		}
+	}
+
+	$response = ec_cross_site_rest_request(
+		'main',
+		'POST',
+		'/wp/v2/posts/' . $post_id . '/autosaves',
+		array(
+			'body'    => $body,
+			'user_id' => $user_id,
+		)
+	);
+
+	return ec_studio_compose_relay_response( $response );
+}
+
+/**
+ * Sanitize the post params accepted from the compose pane.
+ *
+ * Whitelists the small set of fields the compose pane sends — title, content,
+ * status — so the proxy never forwards arbitrary REST fields cross-site. The
+ * `status` value is validated against the lifecycle states the compose pane
+ * is allowed to set (draft, pending). Content is left unescaped because the
+ * block editor produces post HTML that main's `/wp/v2/posts` controller
+ * sanitizes with the author's capabilities (post caps re-checked on main).
+ *
+ * @since 0.16.0
+ *
+ * @param mixed $raw Raw JSON params.
+ * @return array Sanitized post params.
+ */
+function ec_studio_compose_sanitize_post_params( $raw ): array {
+	$params = array();
+
+	if ( ! is_array( $raw ) ) {
+		return $params;
+	}
+
+	if ( isset( $raw['title'] ) ) {
+		$params['title'] = sanitize_text_field( wp_unslash( (string) $raw['title'] ) );
+	}
+
+	if ( isset( $raw['content'] ) ) {
+		$params['content'] = (string) $raw['content'];
+	}
+
+	if ( isset( $raw['status'] ) ) {
+		$status = sanitize_key( (string) $raw['status'] );
+		if ( in_array( $status, array( 'draft', 'pending' ), true ) ) {
+			$params['status'] = $status;
+		}
+	}
+
+	return $params;
+}
+
+/**
+ * Upload an inserted editor image into main extrachill.com's media library.
+ *
+ * The block editor's media-utils `uploadMedia()` POSTs files to
+ * `/wp/v2/media` via apiFetch. The frontend middleware rewrites that onto
+ * this route so the attachment is created on MAIN (blog 1) — not Studio
+ * (blog 12). If it landed on Studio, the block content would reference
+ * blog-12 attachment URLs/IDs and recreate the cross-site migration problem
+ * #75 set out to eliminate.
+ *
+ * The multipart upload (`$_FILES`) does not survive an in-process
+ * rest_do_request dispatch cleanly, so this handler performs the upload
+ * directly inside `switch_to_blog( main )` — the same approach
+ * extrachill-api uses for product images that must land on the shop site.
+ * The response is shaped like core's `/wp/v2/media` create response
+ * (`prepare_item_for_response`) so the editor consumes it unchanged.
+ *
+ * @since 0.16.0
+ *
+ * @param \WP_REST_Request $request REST request.
+ * @return \WP_REST_Response|\WP_Error
+ */
+function ec_studio_compose_upload_media( \WP_REST_Request $request ) {
+	if ( ! function_exists( 'ec_get_blog_id' ) ) {
+		return new \WP_Error(
+			'multisite_helper_missing',
+			__( 'extrachill-multisite is required for cross-site media upload.', 'extrachill-studio' ),
+			array( 'status' => 500 )
+		);
+	}
+
+	$files = $request->get_file_params();
+	if ( empty( $files['file'] ) && isset( $_FILES['file'] ) ) {
+		$files['file'] = $_FILES['file']; // phpcs:ignore WordPress.Security.NonceVerification.Missing -- REST cookie nonce already validated by the auth layer; file params are validated below.
+	}
+
+	if ( empty( $files['file']['name'] ) ) {
+		return new \WP_Error(
+			'no_file',
+			__( 'No file was uploaded.', 'extrachill-studio' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	$uploaded_file = $files['file'];
+
+	$allowed_types = array( 'image/jpeg', 'image/png', 'image/gif', 'image/webp' );
+	$file_type     = wp_check_filetype_and_ext( $uploaded_file['tmp_name'], $uploaded_file['name'] );
+
+	if ( ! in_array( $file_type['type'], $allowed_types, true ) ) {
+		return new \WP_Error(
+			'invalid_file_type',
+			__( 'Invalid file type. Only JPG, PNG, GIF, and WebP images are allowed.', 'extrachill-studio' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	$main_blog_id = (int) ec_get_blog_id( 'main' );
+	if ( $main_blog_id <= 0 ) {
+		return new \WP_Error(
+			'main_blog_unresolved',
+			__( 'Could not resolve the main site for media upload.', 'extrachill-studio' ),
+			array( 'status' => 500 )
+		);
+	}
+
+	$user_id = (int) get_current_user_id();
+
+	// Optional caption/alt/title forwarded from the editor upload form.
+	$caption = $request->get_param( 'caption' );
+	$alt     = $request->get_param( 'alt_text' );
+	$title   = $request->get_param( 'title' );
+
+	$result = null;
+
+	switch_to_blog( $main_blog_id );
+	try {
+		if ( ! function_exists( 'wp_handle_upload' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+		}
+
+		$upload_result = wp_handle_upload( $uploaded_file, array( 'test_form' => false ) );
+
+		if ( ! $upload_result || isset( $upload_result['error'] ) ) {
+			$result = new \WP_Error(
+				'upload_failed',
+				isset( $upload_result['error'] ) ? $upload_result['error'] : __( 'Upload failed.', 'extrachill-studio' ),
+				array( 'status' => 500 )
+			);
+		} else {
+			$attachment = array(
+				'guid'           => $upload_result['url'],
+				'post_author'    => $user_id,
+				'post_mime_type' => $upload_result['type'],
+				'post_title'     => $title ? sanitize_text_field( $title ) : preg_replace( '/\.[^.]+$/', '', basename( $upload_result['file'] ) ),
+				'post_content'   => '',
+				'post_excerpt'   => $caption ? sanitize_textarea_field( $caption ) : '',
+				'post_status'    => 'inherit',
+			);
+
+			$attachment_id = wp_insert_attachment( $attachment, $upload_result['file'], 0, true );
+
+			if ( is_wp_error( $attachment_id ) ) {
+				$result = $attachment_id;
+			} else {
+				require_once ABSPATH . 'wp-admin/includes/image.php';
+				$attach_data = wp_generate_attachment_metadata( $attachment_id, $upload_result['file'] );
+				wp_update_attachment_metadata( $attachment_id, $attach_data );
+
+				if ( $alt ) {
+					update_post_meta( $attachment_id, '_wp_attachment_image_alt', sanitize_text_field( $alt ) );
+				}
+
+				$result = ec_studio_compose_prepare_media_response( $attachment_id );
+			}
+		}
+	} finally {
+		restore_current_blog();
+	}
+
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	return rest_ensure_response( $result );
+}
+
+/**
+ * Build a `/wp/v2/media`-shaped response for a freshly uploaded attachment.
+ *
+ * Delegates to the core media REST controller's prepare method so the block
+ * editor receives exactly the shape it expects from a normal media upload.
+ * Must be called inside the target blog context.
+ *
+ * @since 0.16.0
+ *
+ * @param int $attachment_id Attachment id on the current (switched) blog.
+ * @return array Prepared media response data.
+ */
+function ec_studio_compose_prepare_media_response( int $attachment_id ): array {
+	$controller = new \WP_REST_Attachments_Controller( 'attachment' );
+	$request    = new \WP_REST_Request( 'GET', '/wp/v2/media/' . $attachment_id );
+	$request->set_param( 'context', 'edit' );
+
+	$response = $controller->prepare_item_for_response( get_post( $attachment_id ), $request );
+
+	if ( is_wp_error( $response ) ) {
+		return array( 'id' => $attachment_id );
+	}
+
+	$data = $response->get_data();
+
+	return is_array( $data ) ? $data : array( 'id' => $attachment_id );
+}

--- a/inc/compose/rest.php
+++ b/inc/compose/rest.php
@@ -647,7 +647,7 @@ function ec_studio_compose_upload_media( \WP_REST_Request $request ) {
 	if ( ! in_array( $file_type['type'], $allowed_types, true ) ) {
 		return new \WP_Error(
 			'invalid_file_type',
-			__( 'Invalid file type. Only JPG, PNG, GIF, and WebP images are allowed.', 'extrachill-studio' ),
+			__( "That file isn't a supported image. Please upload a JPG, PNG, GIF, or WebP image.", 'extrachill-studio' ),
 			array( 'status' => 400 )
 		);
 	}
@@ -659,6 +659,18 @@ function ec_studio_compose_upload_media( \WP_REST_Request $request ) {
 			__( 'Could not resolve the main site for media upload.', 'extrachill-studio' ),
 			array( 'status' => 500 )
 		);
+	}
+
+	// Enforce the size limit against MAIN's allowance — that's where the file
+	// is actually written. Surface a clear, actionable message (file size +
+	// limit + what to do) rather than letting wp_handle_upload fail opaquely.
+	// This is the server-side backstop; the editor also validates client-side
+	// before the upload starts (see the maxUploadFileSize editor setting),
+	// which catches the common case (and absurdly large files) without a
+	// round trip.
+	$size_error = ec_studio_compose_check_upload_size( $uploaded_file, $main_blog_id );
+	if ( is_wp_error( $size_error ) ) {
+		return $size_error;
 	}
 
 	$user_id = (int) get_current_user_id();
@@ -720,6 +732,50 @@ function ec_studio_compose_upload_media( \WP_REST_Request $request ) {
 	}
 
 	return rest_ensure_response( $result );
+}
+
+/**
+ * Validate an uploaded file against main extrachill.com's upload size limit.
+ *
+ * The image is written to MAIN (blog 1), so the limit that matters is main's
+ * `wp_max_upload_size()` — not Studio's. Returns a WP_Error with a clear,
+ * non-technical, actionable message (naming the file's size and the limit, and
+ * telling the writer to resize/compress) when the file is too large.
+ *
+ * Note: files larger than the platform's edge/proxy limits (Cloudflare,
+ * nginx) are rejected before the request ever reaches PHP — the editor's
+ * client-side check is the first and primary line of defense against those.
+ * This server-side guard catches the in-between band and any non-editor
+ * caller, and guarantees a friendly JSON error instead of an opaque
+ * wp_handle_upload failure.
+ *
+ * @since 0.16.0
+ *
+ * @param array $uploaded_file The $_FILES entry for the upload.
+ * @param int   $main_blog_id  Resolved main blog id.
+ * @return true|\WP_Error True when within limits, WP_Error otherwise.
+ */
+function ec_studio_compose_check_upload_size( array $uploaded_file, int $main_blog_id ) {
+	$file_size = isset( $uploaded_file['size'] ) ? (int) $uploaded_file['size'] : 0;
+
+	switch_to_blog( $main_blog_id );
+	$max_size = (int) wp_max_upload_size();
+	restore_current_blog();
+
+	if ( $max_size <= 0 || $file_size <= $max_size ) {
+		return true;
+	}
+
+	return new \WP_Error(
+		'file_too_large',
+		sprintf(
+			/* translators: 1: the uploaded file's size (e.g. "40 MB"), 2: the maximum allowed size (e.g. "2 MB"). */
+			__( 'That image is too large (%1$s). The maximum upload size is %2$s — please resize or compress the image and try again.', 'extrachill-studio' ),
+			size_format( $file_size ),
+			size_format( $max_size )
+		),
+		array( 'status' => 413 )
+	);
 }
 
 /**

--- a/inc/transcription/callback.php
+++ b/inc/transcription/callback.php
@@ -148,7 +148,7 @@ function ec_studio_transcription_handle_callback( \WP_REST_Request $request ) {
 	$filename = ec_studio_transcription_callback_pick_filename( $body );
 
 	// --- Create draft on main extrachill.com --------------------------
-	$post_id = ec_studio_transcription_callback_create_draft( $user_id, $filename, $transcript, $job_id, $stats, $body );
+	$post_id = ec_studio_transcription_callback_create_draft( $user_id, $filename, $transcript, $job_id, $stats );
 	if ( is_wp_error( $post_id ) ) {
 		return $post_id;
 	}
@@ -215,7 +215,6 @@ function ec_studio_transcription_callback_pick_filename( array $body ): string {
  * @param string $transcript  Plain-text transcript content.
  * @param string $job_id      Sweatpants job UUID.
  * @param array  $stats       Stats array from the callback body.
- * @param array  $full_body   Whole callback body, retained for any meta we want.
  * @return int|\WP_Error Post id on success, WP_Error otherwise.
  */
 function ec_studio_transcription_callback_create_draft(
@@ -223,7 +222,8 @@ function ec_studio_transcription_callback_create_draft(
 	string $filename,
 	string $transcript,
 	string $job_id,
-	array $stats) {
+	array $stats
+) {
 	if ( ! function_exists( 'ec_cross_site_rest_request' ) ) {
 		return new \WP_Error(
 			'multisite_helper_missing',

--- a/src/blocks/studio/tabs/compose/cross-site-middleware.ts
+++ b/src/blocks/studio/tabs/compose/cross-site-middleware.ts
@@ -59,6 +59,7 @@ function splitPath( path: string ): [ string, string ] {
  *   - /wp/v2/posts/<id>                 → /extrachill/v1/studio/compose/posts/<id>
  *   - /wp/v2/posts/<id>/autosaves       → /extrachill/v1/studio/compose/posts/<id>/autosaves
  *   - /wp/v2/media                      → /extrachill/v1/studio/compose/media
+ *   - /wp/v2/media/<id>                 → /extrachill/v1/studio/compose/media/<id>
  *
  * @param path Full apiFetch path including any query string.
  * @return Rewritten path, or null when no rewrite applies.
@@ -85,7 +86,13 @@ function rewritePath( path: string ): string | null {
 		return `${ PROXY_PREFIX }/posts${ query }`;
 	}
 
-	// /wp/v2/media (block editor inline image uploads)
+	// /wp/v2/media/<id> (single attachment hydrate after upload / re-resolve)
+	const mediaItemMatch = normalized.match( /^\/wp\/v2\/media\/(\d+)$/ );
+	if ( mediaItemMatch ) {
+		return `${ PROXY_PREFIX }/media/${ mediaItemMatch[ 1 ] }${ query }`;
+	}
+
+	// /wp/v2/media (uploads via POST + Media Library browse grid via GET)
 	if ( normalized === '/wp/v2/media' ) {
 		return `${ PROXY_PREFIX }/media${ query }`;
 	}

--- a/src/blocks/studio/tabs/compose/cross-site-middleware.ts
+++ b/src/blocks/studio/tabs/compose/cross-site-middleware.ts
@@ -1,0 +1,122 @@
+/**
+ * Cross-site apiFetch middleware for the Studio compose pane.
+ *
+ * Studio (blog 12) is a pure tool surface; blog posts drafted in the Compose
+ * pane must be BORN ON MAIN extrachill.com (blog 1) so editorial review and
+ * publishing happen where editors actually look. See
+ * Extra-Chill/extrachill-studio#75.
+ *
+ * The compose pane and the Blocks Everywhere block editor both talk to core
+ * REST routes (`/wp/v2/posts`, `/wp/v2/posts/<id>/autosaves`, `/wp/v2/media`)
+ * through `@wordpress/api-fetch`. Rather than fork the editor or rewrite every
+ * call site, we install a single apiFetch middleware that transparently
+ * rewrites those paths onto Studio-local proxy routes
+ * (`/extrachill/v1/studio/compose/*`). Each proxy route forwards the request
+ * to main via `ec_cross_site_rest_request( 'main', ... )` (in-process,
+ * under the user's auth).
+ *
+ * Critically, this also catches the block editor's own inline media uploads
+ * (`uploadMedia()` POSTs to `/wp/v2/media` via apiFetch), so inserted images
+ * land in main's media library — not Studio's — avoiding the cross-site
+ * attachment migration problem.
+ *
+ * The middleware is registered exactly once and only rewrites the specific
+ * compose-related routes; all other apiFetch traffic (e.g. core editor
+ * bootstrap preloads, taxonomies, user lookups) passes through untouched so
+ * the editor still boots against the local Studio site.
+ */
+
+import apiFetch from '@wordpress/api-fetch';
+import type { APIFetchMiddleware, APIFetchOptions } from '@wordpress/api-fetch';
+
+/** Studio-local proxy route prefix that forwards to main. */
+const PROXY_PREFIX = '/extrachill/v1/studio/compose';
+
+let installed = false;
+
+/**
+ * Split an apiFetch path into its route and query-string parts.
+ *
+ * @param path Full apiFetch path, e.g. `/wp/v2/posts?status=draft&author=5`.
+ * @return Tuple of [route, query] where query includes the leading `?` or ''.
+ */
+function splitPath( path: string ): [ string, string ] {
+	const queryIndex = path.indexOf( '?' );
+	if ( queryIndex === -1 ) {
+		return [ path, '' ];
+	}
+	return [ path.slice( 0, queryIndex ), path.slice( queryIndex ) ];
+}
+
+/**
+ * Rewrite a core REST route onto its Studio compose proxy equivalent.
+ *
+ * Returns the rewritten path, or null when the route is not one we proxy
+ * (in which case the request is left untouched).
+ *
+ * Handled routes:
+ *   - /wp/v2/posts                      → /extrachill/v1/studio/compose/posts
+ *   - /wp/v2/posts/<id>                 → /extrachill/v1/studio/compose/posts/<id>
+ *   - /wp/v2/posts/<id>/autosaves       → /extrachill/v1/studio/compose/posts/<id>/autosaves
+ *   - /wp/v2/media                      → /extrachill/v1/studio/compose/media
+ *
+ * @param path Full apiFetch path including any query string.
+ * @return Rewritten path, or null when no rewrite applies.
+ */
+function rewritePath( path: string ): string | null {
+	const [ route, query ] = splitPath( path );
+	// Normalize leading slash so both `/wp/v2/...` and `wp/v2/...` match.
+	const normalized = route.startsWith( '/' ) ? route : `/${ route }`;
+
+	// /wp/v2/posts/<id>/autosaves
+	const autosaveMatch = normalized.match( /^\/wp\/v2\/posts\/(\d+)\/autosaves$/ );
+	if ( autosaveMatch ) {
+		return `${ PROXY_PREFIX }/posts/${ autosaveMatch[ 1 ] }/autosaves${ query }`;
+	}
+
+	// /wp/v2/posts/<id>
+	const postMatch = normalized.match( /^\/wp\/v2\/posts\/(\d+)$/ );
+	if ( postMatch ) {
+		return `${ PROXY_PREFIX }/posts/${ postMatch[ 1 ] }${ query }`;
+	}
+
+	// /wp/v2/posts (collection: list + create)
+	if ( normalized === '/wp/v2/posts' ) {
+		return `${ PROXY_PREFIX }/posts${ query }`;
+	}
+
+	// /wp/v2/media (block editor inline image uploads)
+	if ( normalized === '/wp/v2/media' ) {
+		return `${ PROXY_PREFIX }/media${ query }`;
+	}
+
+	return null;
+}
+
+/**
+ * Install the cross-site compose apiFetch middleware (idempotent).
+ *
+ * Safe to call multiple times — the middleware is registered with apiFetch
+ * only on the first invocation. Call this once when the compose pane mounts.
+ */
+export function installComposeCrossSiteMiddleware(): void {
+	if ( installed ) {
+		return;
+	}
+	installed = true;
+
+	const middleware: APIFetchMiddleware = ( options: APIFetchOptions, next ) => {
+		const path = typeof options.path === 'string' ? options.path : '';
+
+		if ( path ) {
+			const rewritten = rewritePath( path );
+			if ( rewritten ) {
+				return next( { ...options, path: rewritten } );
+			}
+		}
+
+		return next( options );
+	};
+
+	apiFetch.use( middleware );
+}

--- a/src/blocks/studio/tabs/compose/index.ts
+++ b/src/blocks/studio/tabs/compose/index.ts
@@ -9,6 +9,15 @@ import {
 } from '@extrachill/chat';
 import { ActionRow, FieldGroup, InlineStatus, Panel, PanelHeader } from '@extrachill/components';
 import type { StudioPaneProps } from '../../types/studio';
+import { installComposeCrossSiteMiddleware } from './cross-site-middleware';
+
+// Install the cross-site apiFetch middleware as soon as the compose module
+// loads, before any draft fetch or editor media upload fires. The middleware
+// rewrites the compose pane's /wp/v2/posts* and /wp/v2/media calls onto
+// Studio-local proxy routes that forward to main extrachill.com (blog 1), so
+// posts are born on main and inserted images upload to main's media library.
+// Idempotent — safe even though this module is imported from multiple places.
+installComposeCrossSiteMiddleware();
 
 const h = createElement as typeof import( 'react' ).createElement;
 const PanelView = Panel as unknown as ( props: any ) => ReactElement;
@@ -626,7 +635,12 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 					content: contentSnapshotRef.current.trim(),
 				} );
 				const blob = new Blob( [ body ], { type: 'application/json' } );
-				const url = `/wp-json/wp/v2/posts/${ postId }/autosaves?_wpnonce=${ encodeURIComponent( restNonce ) }`;
+				// The draft lives on main (blog 1), so this unload beacon must
+				// target the Studio cross-site proxy route — not the bare
+				// /wp/v2 endpoint, which would write to Studio (blog 12). The
+				// apiFetch middleware can't help here: sendBeacon bypasses
+				// apiFetch entirely, so the proxy path is hardcoded.
+				const url = `/wp-json/extrachill/v1/studio/compose/posts/${ postId }/autosaves?_wpnonce=${ encodeURIComponent( restNonce ) }`;
 				navigator.sendBeacon( url, blob );
 			} catch {
 				// Best-effort — nothing else we can do during unload.


### PR DESCRIPTION
## Summary

The Studio **Blog** tab (Compose pane) is an internal team tool for drafting articles and submitting them for editorial review. But it wrote posts to the **local Studio site** (blog 12) via relative `/wp/v2/posts` apiFetch calls — while review and publishing happen on **main extrachill.com** (blog 1). Submitted articles were stranded on Studio where no editor ever looks.

This PR makes the post **born on main from the very first draft**. We deliberately avoid a "draft on Studio then migrate to main" model — migrating posts across multisite (re-homing attachments, rewriting image URLs/IDs in block content, recreating terms) is exactly the mangling #75 documented as expensive toil. Instead, Studio stays a pure tool surface and the post lives on blog 1 its entire lifecycle (draft → pending → publish).

## Approach — Option A (Studio-local proxy routes)

I checked for an existing browser-callable cross-site proxy before building anything (per RULES.md):

- `extrachill/v1/media` (extrachill-api) is a **context-assign** endpoint (`user_avatar`, `artist_profile`, …), not a generic block-editor media upload — wrong shape, requires a `context` param. Not reusable.
- The HTTP-loopback `X-EC-Internal-*` path and the route-affinity map (`ec_get_route_site_affinity`) only forward `/extrachill/v1/*` prefixes — **no** existing route proxies bare `/wp/v2/posts` or `/wp/v2/media` cross-site from the browser.

So no existing primitive does this. I built thin Studio-local proxy routes that wrap the proven `ec_cross_site_rest_request('main', ...)` primitive (extrachill-multisite) — the same in-process pattern `inc/transcription/callback.php` already uses to create transcription drafts on main.

### New routes (`inc/compose/rest.php`, team-gated)

| Route | Proxies to main |
|-------|-----------------|
| `GET  /extrachill/v1/studio/compose/posts` | List the user's drafts (author-scoped) |
| `POST /extrachill/v1/studio/compose/posts` | Create draft |
| `POST /extrachill/v1/studio/compose/posts/<id>` | Update draft / submit-for-review (`pending`) |
| `GET  /extrachill/v1/studio/compose/posts/<id>/autosaves` | List autosaves |
| `POST /extrachill/v1/studio/compose/posts/<id>/autosaves` | Autosave (status omitted) |
| `POST /extrachill/v1/studio/compose/media` | Upload image into main's media library |

Each forwards under the requesting user's auth via `ec_cross_site_rest_request('main', ...)` (in-process: `switch_to_blog` + `rest_do_request`, no HTTP loopback), so main's core capability checks re-apply.

### Frontend — single apiFetch middleware

Rather than fork Blocks Everywhere or rewrite every call site, `src/blocks/studio/tabs/compose/cross-site-middleware.ts` installs **one** `apiFetch` middleware that transparently rewrites `/wp/v2/posts*` and `/wp/v2/media*` onto the proxy routes. It's idempotent, installed at compose-module load, and only rewrites those specific compose routes — all other apiFetch traffic (editor bootstrap preloads, taxonomies, `/users/me`) passes through untouched so the editor still boots against Studio locally.

## How media uploads were redirected to main

This was the trickiest part. The block editor's `uploadMedia()` (core `@wordpress/media-utils`) POSTs inserted images to `/wp/v2/media` **via apiFetch** — so the same middleware catches it with zero editor changes. The proxy `media` route can't ride an in-process `rest_do_request` for multipart `$_FILES`, so it performs the upload **directly inside `switch_to_blog( main )`** (the proven extrachill-api product-image pattern) and returns a `/wp/v2/media`-shaped response via `WP_REST_Attachments_Controller::prepare_item_for_response`, so the editor consumes it unchanged. Inserted images therefore land in **main's** media library and block content references blog-1 attachment IDs — no migration.

The unload `sendBeacon` autosave bypasses apiFetch entirely, so its URL is hardcoded to the proxy route (`/wp-json/extrachill/v1/studio/compose/posts/<id>/autosaves`) — otherwise that last-write would hit Studio.

## Autosave status-omission preserved

Yes. The frontend already omitted `status` on `/autosaves` to avoid demoting `pending`→`draft`; the proxy autosave handler forwards **only** title/content and never sends `status`, preserving that contract end-to-end.

## Manual test

There's no automated e2e for the editor. Log in as a team member on **studio.extrachill.com**, open the **Blog** tab:

1. Type a title + body, wait for autosave → confirm a draft appears on **extrachill.com/wp-admin** under your author (not on Studio's admin).
2. Insert an image via the block editor → confirm the attachment lives in **main's** media library and the block references a blog-1 attachment URL/ID.
3. Click **Submit for Review** → confirm a `pending` post appears on **main** under your author.
4. Reopen the Blog tab → confirm the draft picker loads **your** drafts from main (author-scoped).

## Also fixed

`ec_studio_transcription_callback_create_draft()` was **called with 6 args** but **defined with 5 params**, and its docblock documented an unused `@param array $full_body`. Dropped the stray call-site arg and reconciled the docblock — call site, signature, and docblock are now consistent.

Closes #75
Refs #29

cc <@1493317298151489577>