### PR TITLE
fix(compose): scope cross-site rewriting to the Compose pane (follow-up to #90)

### DIFF
--- a/inc/compose/rest.php
+++ b/inc/compose/rest.php
@@ -37,6 +37,16 @@
  * images land in main's library — not Studio's — avoiding the very migration
  * problem #75 set out to remove.
  *
+ * Two dispatch strategies, by necessity:
+ *   - JSON routes (posts, autosaves, single-media GET) forward via
+ *     `ec_cross_site_rest_request( 'main', ... )` and guard on that helper
+ *     being available (`ec_studio_compose_require_cross_site()`).
+ *   - File/header-sensitive routes (media upload, media browse) do their own
+ *     `switch_to_blog( main )`: a multipart `$_FILES` upload can't ride the
+ *     in-process rest_do_request cleanly, and the browse grid needs the
+ *     core controller's X-WP-Total pagination headers, which the cross-site
+ *     helper strips. These guard on `ec_get_blog_id()` instead.
+ *
  * @package    ExtraChillStudio
  * @subpackage Compose
  * @since      0.16.0
@@ -292,7 +302,7 @@ function ec_studio_compose_create_post( \WP_REST_Request $request ) {
 	}
 
 	$user_id = (int) get_current_user_id();
-	$params  = ec_studio_compose_sanitize_post_params( $request->get_json_params() );
+	$params  = ec_studio_compose_whitelist_post_params( $request->get_json_params() );
 
 	// Always attribute the post to the requesting user on main.
 	$params['author'] = $user_id;
@@ -330,7 +340,7 @@ function ec_studio_compose_update_post( \WP_REST_Request $request ) {
 
 	$user_id = (int) get_current_user_id();
 	$post_id = (int) $request['id'];
-	$params  = ec_studio_compose_sanitize_post_params( $request->get_json_params() );
+	$params  = ec_studio_compose_whitelist_post_params( $request->get_json_params() );
 
 	$response = ec_cross_site_rest_request(
 		'main',
@@ -451,7 +461,7 @@ function ec_studio_compose_create_autosave( \WP_REST_Request $request ) {
  * @param mixed $raw Raw JSON params.
  * @return array Whitelisted post params.
  */
-function ec_studio_compose_sanitize_post_params( $raw ): array {
+function ec_studio_compose_whitelist_post_params( $raw ): array {
 	$params = array();
 
 	if ( ! is_array( $raw ) ) {

--- a/src/blocks/studio/tabs/compose/cross-site-middleware.ts
+++ b/src/blocks/studio/tabs/compose/cross-site-middleware.ts
@@ -20,10 +20,16 @@
  * land in main's media library — not Studio's — avoiding the cross-site
  * attachment migration problem.
  *
- * The middleware is registered exactly once and only rewrites the specific
- * compose-related routes; all other apiFetch traffic (e.g. core editor
- * bootstrap preloads, taxonomies, user lookups) passes through untouched so
- * the editor still boots against the local Studio site.
+ * Scope — this matters: apiFetch is a single global, shared by every Studio
+ * tab. The rewrite must apply ONLY while the Compose pane is active, because
+ * other tabs legitimately hit the same core routes against the LOCAL Studio
+ * site (e.g. the Socials tab POSTs `/wp/v2/posts` to create a Studio-local
+ * social draft). So the middleware is registered once but stays INERT until
+ * the Compose pane activates it on mount, and deactivates it on unmount. When
+ * inactive it passes every request through untouched. Even when active it only
+ * rewrites the specific compose routes below; all other traffic (core editor
+ * bootstrap preloads, taxonomies, user lookups) passes through so the editor
+ * still boots against the local Studio site.
  */
 
 import apiFetch from '@wordpress/api-fetch';
@@ -32,7 +38,14 @@ import type { APIFetchMiddleware, APIFetchOptions } from '@wordpress/api-fetch';
 /** Studio-local proxy route prefix that forwards to main. */
 const PROXY_PREFIX = '/extrachill/v1/studio/compose';
 
-let installed = false;
+/** Whether the middleware has been registered with apiFetch (once per page). */
+let registered = false;
+
+/**
+ * Whether rewriting is currently active. Gated to the Compose pane's lifetime
+ * so other Studio tabs' core-route calls reach the local Studio site.
+ */
+let active = false;
 
 /**
  * Split an apiFetch path into its route and query-string parts.
@@ -101,20 +114,24 @@ function rewritePath( path: string ): string | null {
 }
 
 /**
- * Install the cross-site compose apiFetch middleware (idempotent).
+ * Register the cross-site compose apiFetch middleware (idempotent).
  *
- * Safe to call multiple times — the middleware is registered with apiFetch
- * only on the first invocation. Call this once when the compose pane mounts.
+ * Registers the rewrite middleware with apiFetch exactly once per page. The
+ * middleware is INERT until {@link setComposeCrossSiteActive} turns it on, so
+ * registering it has no effect on other tabs' requests.
  */
-export function installComposeCrossSiteMiddleware(): void {
-	if ( installed ) {
+function registerMiddlewareOnce(): void {
+	if ( registered ) {
 		return;
 	}
-	installed = true;
+	registered = true;
 
 	const middleware: APIFetchMiddleware = ( options: APIFetchOptions, next ) => {
-		const path = typeof options.path === 'string' ? options.path : '';
+		if ( ! active ) {
+			return next( options );
+		}
 
+		const path = typeof options.path === 'string' ? options.path : '';
 		if ( path ) {
 			const rewritten = rewritePath( path );
 			if ( rewritten ) {
@@ -126,4 +143,19 @@ export function installComposeCrossSiteMiddleware(): void {
 	};
 
 	apiFetch.use( middleware );
+}
+
+/**
+ * Turn cross-site rewriting on or off.
+ *
+ * The Compose pane calls this with `true` on mount and `false` on unmount so
+ * the rewrite only applies while the writer is in the Blog tab. Registering
+ * the middleware lazily here keeps the whole mechanism dormant until Compose
+ * is actually used.
+ *
+ * @param next Whether rewriting should be active.
+ */
+export function setComposeCrossSiteActive( next: boolean ): void {
+	registerMiddlewareOnce();
+	active = next;
 }

--- a/src/blocks/studio/tabs/compose/index.ts
+++ b/src/blocks/studio/tabs/compose/index.ts
@@ -9,15 +9,7 @@ import {
 } from '@extrachill/chat';
 import { ActionRow, FieldGroup, InlineStatus, Panel, PanelHeader } from '@extrachill/components';
 import type { StudioPaneProps } from '../../types/studio';
-import { installComposeCrossSiteMiddleware } from './cross-site-middleware';
-
-// Install the cross-site apiFetch middleware as soon as the compose module
-// loads, before any draft fetch or editor media upload fires. The middleware
-// rewrites the compose pane's /wp/v2/posts* and /wp/v2/media calls onto
-// Studio-local proxy routes that forward to main extrachill.com (blog 1), so
-// posts are born on main and inserted images upload to main's media library.
-// Idempotent — safe even though this module is imported from multiple places.
-installComposeCrossSiteMiddleware();
+import { setComposeCrossSiteActive } from './cross-site-middleware';
 
 const h = createElement as typeof import( 'react' ).createElement;
 const PanelView = Panel as unknown as ( props: any ) => ReactElement;
@@ -488,6 +480,17 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 			performAutosave();
 		}, AUTOSAVE_DELAY );
 	}, [ performAutosave ] );
+
+	// Activate cross-site apiFetch rewriting for the lifetime of this pane only.
+	// Declared before the draft-load/editor-mount effect so rewriting is on
+	// before the first /wp/v2/posts fetch fires. Deactivated on unmount so other
+	// Studio tabs (e.g. Socials) keep hitting the local Studio site.
+	useEffect( () => {
+		setComposeCrossSiteActive( true );
+		return () => {
+			setComposeCrossSiteActive( false );
+		};
+	}, [] );
 
 	useEffect( () => {
 		unregisterClientContextRef.current = registerClientContextProvider( {


### PR DESCRIPTION
## Why this is separate from #90

PR #90 was squash-merged at commit `6fbbc74` (its 6th commit) **seconds before** the 7th commit landed on the branch. That 7th commit — the cross-tab scoping fix — therefore **missed the merge** and is not in main. This PR carries exactly that fix forward (cherry-picked clean onto current main).

## The bug now live in main

The apiFetch middleware from #90 installs at compose-module **load** and rewrites `/wp/v2/posts*` and `/wp/v2/media*` **app-wide**. But apiFetch is a single global shared by every Studio tab, and `view.ts` imports the Compose module eagerly — so the rewrite is active on **every page load, on every tab**.

This silently hijacks the **Socials tab's** own `POST /wp/v2/posts` (it creates a Studio-LOCAL social draft carrying `_studio_social_*` meta), redirecting it to **main** and stripping its meta via the compose post-param whitelist. The Socials publishing flow is broken until this lands.

## The fix

The middleware now registers once but stays **inert until activated**. The Compose pane toggles it on at mount / off at unmount via a `useEffect` declared before the draft-load effect — so rewriting is on before the first `/wp/v2/posts` fetch and off the moment the writer leaves the Blog tab. Other tabs keep hitting the local Studio site.

**Verified** (middleware contract simulation):
- Socials `/wp/v2/posts` stays **local** when Compose is inactive ✅
- All compose routes rewrite correctly with query strings preserved when active ✅
- Non-compose routes (`/wp/v2/users/me`, `/wp/v2/types`) untouched either way ✅
- Reverts to local after Compose unmount ✅

Also folds in two clarity items from the same commit: rename `_sanitize_post_params` → `_whitelist_post_params` (it whitelists + gates status, doesn't sanitize), and a file-header note documenting the two dispatch strategies (cross-site helper vs. `switch_to_blog`).

Lint / typecheck / build green.

Refs #90 #75

cc <@1493317298151489577>