### PR TITLE
fix: align @extrachill/chat to ^0.14.0 to reconnect Studio client-context to Roadie

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "extrachill-studio",
 			"version": "0.1.0",
 			"dependencies": {
-				"@extrachill/chat": "^0.7.0",
+				"@extrachill/chat": "^0.14.0",
 				"@extrachill/components": "^0.5.2",
 				"@extrachill/tokens": "^0.4.2"
 			},
@@ -2698,16 +2698,16 @@
 			"license": "GPL-2.0+"
 		},
 		"node_modules/@extrachill/chat": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/@extrachill/chat/-/chat-0.7.0.tgz",
-			"integrity": "sha512-+wVvJqPcv/Q4o3O1ZejiB4ysWeCaU0vvM20CrlT4jfnzBP6emeC3h/5Uq/OSD1HPt7cZoYPVuv/NvpXybYVi4g==",
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/@extrachill/chat/-/chat-0.14.0.tgz",
+			"integrity": "sha512-reP65ZD0vR3RwJmqQqu9NzG235033tgkEKpFCw8ZdpqEI8Z/8iVE2NV1xfm4YMmDjo25WH0fA9y3r9cSPsUDyQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"react-markdown": "^10.1.0"
 			},
 			"peerDependencies": {
-				"react": ">=18.0.0",
-				"react-dom": ">=18.0.0"
+				"react": "^18.0.0 || ^19.0.0",
+				"react-dom": "^18.0.0 || ^19.0.0"
 			}
 		},
 		"node_modules/@extrachill/components": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@extrachill/chat": "^0.7.0",
+		"@extrachill/chat": "^0.14.0",
 		"@extrachill/components": "^0.5.2",
 		"@extrachill/tokens": "^0.4.2"
 	},


### PR DESCRIPTION
## Summary

Studio's Compose pane registers a rich editor client-context provider (active draft id, status, title, excerpt, char count, `surface: 'compose'`), and the entire downstream stack is already built to consume it — but `extrachill-studio` was pinned to `@extrachill/chat` **^0.7.0** while the Roadie chat widget (`frontend-agent-chat`) runs **^0.14.0**.

Both plugins webpack-bundle their own copy of `@extrachill/chat` and share one global `window.ecClientContextRegistry` singleton on `studio.extrachill.com`. Studio registered its provider against the **0.7.0** registry/snapshot shape while the widget reads + serializes via **0.14.0** — an order-dependent skew that silently drops the draft context before it reaches the agent. The full pipeline (chat 0.14.0 serialization → `Chat` component merge → `frontend-agent-chat` `clientContext: true` → data-machine `ClientContextDirective::build_editor_guidance`) is already built; this version pin was the only break.

## The fix

- Bump `@extrachill/chat` `^0.7.0` → `^0.14.0` in `package.json`.
- `npm install` regenerated `package-lock.json` (resolved `0.14.0`, lock not hand-edited).
- `npm run build` emits clean to `build/blocks`; `npm run typecheck` (`tsc --noEmit`) passes with exit 0.

Build artifacts are gitignored, so the diff is just `package.json` + `package-lock.json`.

## Import surface verified against 0.14.0

Studio imports exactly two symbols from `@extrachill/chat` (`src/blocks/studio/tabs/compose/index.ts:6-9`):

- `getOrCreateClientContextRegistry`
- `registerClientContextProvider`

Both are still exported in 0.14.0 — confirmed in `node_modules/@extrachill/chat/dist/index.d.ts:11`:

```
export { getOrCreateClientContextRegistry, registerClientContextProvider, getClientContextMetadata, useClientContextMetadata, ... } from './client-context.ts';
```

No other `@extrachill/chat` imports exist in `src/`. The 0.8→0.14 changelog is additive (run controls, tool timeline, citations, React 19 support in 0.13); no client-context API was removed.

## TS / peer-dep issues

None.

- TypeScript: `tsc --noEmit` clean (exit 0), no type errors introduced by the bump.
- React peers: 0.14.0 declares `react`/`react-dom` `^18.0.0 || ^19.0.0`. Studio is on `@types/react@^18` / `@wordpress/element@^6.36`; React 18 satisfies the peer range, so the 0.13 React 19 support did **not** force a React 19 upgrade and there was no peer conflict.

## Manual verification (no automated e2e for the editor — perform post-deploy)

On `studio.extrachill.com` Blog/Compose tab as a team member:

1. Open a draft, type a title + body.
2. In the browser console, run `getClientContextMetadata()` (or inspect `window.ecClientContextRegistry.getSnapshot()` / `getOrCreateClientContextRegistry().getSnapshot()`) and confirm `active_context` carries `{ kind:'editor', surface:'compose', resource:{ id, status, title }, content:{ excerpt, characterCount } }`.
3. Inspect the outgoing chat request to the Roadie widget and confirm that payload is present under `client_context`.
4. Ask Roadie "what post am I working on?" — it should answer with the current draft title/status **without** asking for a URL or post ID, proving data-machine's `ClientContextDirective` fired.

Closes #92