### PR TITLE
feat(studio): broadcast active tab to Roadie via the generic tabs context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.1.0",
 			"dependencies": {
 				"@extrachill/chat": "^0.14.0",
-				"@extrachill/components": "^0.5.2",
+				"@extrachill/components": "^0.7.0",
 				"@extrachill/tokens": "^0.4.2"
 			},
 			"devDependencies": {
@@ -2711,12 +2711,12 @@
 			}
 		},
 		"node_modules/@extrachill/components": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/@extrachill/components/-/components-0.5.2.tgz",
-			"integrity": "sha512-vBacRRqb72EXuZNjgmMMaOO9Ztl7BXMmOnA5idX3PuvLVdeDif1lRoqhtKnOZ+8JFLcajXXrI1N2kGocPnbE2Q==",
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/@extrachill/components/-/components-0.7.0.tgz",
+			"integrity": "sha512-F3bm3IcrEXcQddTPV0tdbfSF8Qp/wu+OuI0NARrkYGwKrUCuPuc1xXxKRREMeBHieni/6X0sg6AWNqEB5xUOYQ==",
 			"license": "GPL-2.0+",
 			"peerDependencies": {
-				"react": ">=18.0.0"
+				"react": "^18.0.0 || ^19.0.0"
 			}
 		},
 		"node_modules/@extrachill/tokens": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	},
 	"dependencies": {
 		"@extrachill/chat": "^0.14.0",
-		"@extrachill/components": "^0.5.2",
+		"@extrachill/components": "^0.7.0",
 		"@extrachill/tokens": "^0.4.2"
 	},
 	"devDependencies": {

--- a/src/blocks/studio/view.ts
+++ b/src/blocks/studio/view.ts
@@ -48,6 +48,13 @@ const StudioApp = ( { context }: { context: StudioContext } ): ReactElement => {
 							onChange: setActiveTab,
 							renderPanel,
 							showDesktopTabs: true,
+							// Broadcast the active Studio tab into the shared
+							// client-context registry so Roadie's chat knows
+							// which tab the team member is on. Generic — handled
+							// entirely by ResponsiveTabs; Studio just names the
+							// surface. The Compose pane layers its richer
+							// draft-specific context on top at higher priority.
+							contextSurface: 'studio',
 						} ),
 					],
 				}


### PR DESCRIPTION
## Summary

Wire Studio into the generic active-tab broadcast added to `@extrachill/components` 0.7.0 (Extra-Chill/extrachill-components#14). Every Studio tab — Blog, Socials, Transcribe, QR Codes — now tells Roadie's chat which tab the team member is viewing.

## What changed

One line: pass `contextSurface="studio"` to `ResponsiveTabs`. The component handles everything — it registers a provider into the shared `window.ecClientContextRegistry` (browser-only, consumed by the chat widget on every page) describing the active tab. No per-tab code, no coupling to the chat layer.

Plus the dep bump: `@extrachill/components` `^0.5.2` → `^0.7.0`.

## Compose's provider is kept (it's enrichment, not a duplicate)

The Compose pane already registers its own `kind:'editor'` provider with the active draft's id / status / title / content excerpt. That's **complementary** to the generic `kind:'tabs'` signal — "user is editing draft #X" vs. "user is on the Blog tab" — and it sits at higher priority (100 vs the tab broadcast's 10), so it layers on top. Left as-is.

## Net effect for Roadie

- On **any** Studio tab: Roadie knows which tab is open (`{ kind:'tabs', surface:'studio', activeTab, activeTabLabel, availableTabs }`).
- On the **Blog** tab specifically: it additionally gets the rich draft context from Compose's provider.
- Previously only the Blog tab broadcast anything; Socials/Transcribe/QR were invisible to Roadie.

## Verification

Typecheck + build green; `ecClientContextRegistry` access confirmed present in the built `view.js`. The broadcast is a silent no-op if no chat widget is on the page.

Depends on: Extra-Chill/extrachill-components#14 (merged, released as 0.7.0)
Refs #75

cc <@1493317298151489577>