### PR TITLE
chore(deps): bump @extrachill/components to ^0.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.1.0",
 			"dependencies": {
 				"@extrachill/chat": "^0.14.0",
-				"@extrachill/components": "^0.7.0",
+				"@extrachill/components": "^0.8.0",
 				"@extrachill/tokens": "^0.4.2"
 			},
 			"devDependencies": {
@@ -2711,9 +2711,9 @@
 			}
 		},
 		"node_modules/@extrachill/components": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/@extrachill/components/-/components-0.7.0.tgz",
-			"integrity": "sha512-F3bm3IcrEXcQddTPV0tdbfSF8Qp/wu+OuI0NARrkYGwKrUCuPuc1xXxKRREMeBHieni/6X0sg6AWNqEB5xUOYQ==",
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/@extrachill/components/-/components-0.8.0.tgz",
+			"integrity": "sha512-VrXHNEe/TX2unoXTShkEuJSmANgXB19szBFVUadBnF5HQtqBm69ZKdsaPx8Ylkx2cFrLs1ueT2hagqMyuOVpCg==",
 			"license": "GPL-2.0+",
 			"peerDependencies": {
 				"react": "^18.0.0 || ^19.0.0"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	},
 	"dependencies": {
 		"@extrachill/chat": "^0.14.0",
-		"@extrachill/components": "^0.7.0",
+		"@extrachill/components": "^0.8.0",
 		"@extrachill/tokens": "^0.4.2"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## Summary

Bump `@extrachill/components` `^0.7.0` → `^0.8.0` to pick up the **broadcast-on-by-default** active-tab context (extrachill-components#15, released as 0.8.0).

Studio already passes `contextSurface="studio"` to `ResponsiveTabs` (from #95). As of 0.8.0 that prop is just a human-readable label — broadcasting is automatic — so all four Studio tabs (Blog, Socials, Transcribe, QR Codes) report the active tab to agent consumers (Roadie's chat) with no further code.

## Verification

- `npm install` resolved `@extrachill/components@0.8.0`.
- Build + typecheck green; `ecClientContextRegistry` access present in the built `view.js`.

Part of the platform-wide rollout of the default-on tab broadcast (one PR per consuming plugin).

cc <@1493317298151489577>