### PR TITLE
feat: instrument Studio usage as team-experience analytics events

### DIFF
--- a/extrachill-studio.php
+++ b/extrachill-studio.php
@@ -29,6 +29,7 @@ define( 'EXTRACHILL_STUDIO_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'EXTRACHILL_STUDIO_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'EXTRACHILL_STUDIO_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 
+require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/team-experience/events.php';
 require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/assets.php';
 require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/breadcrumbs.php';
 require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/social-drafts.php';

--- a/inc/compose/rest.php
+++ b/inc/compose/rest.php
@@ -317,6 +317,16 @@ function ec_studio_compose_create_post( \WP_REST_Request $request ) {
 		)
 	);
 
+	// On a successful create, emit a draft-created or submitted-for-review
+	// event (extrachill-users#127 shared contract). A brand-new compose post
+	// defaults to draft when status is omitted.
+	ec_studio_compose_emit_lifecycle_event(
+		$response,
+		isset( $params['status'] ) ? (string) $params['status'] : 'draft',
+		$user_id,
+		true
+	);
+
 	return ec_studio_compose_relay_response( $response );
 }
 
@@ -352,7 +362,68 @@ function ec_studio_compose_update_post( \WP_REST_Request $request ) {
 		)
 	);
 
+	// On a successful update, emit submitted-for-review when the writer
+	// transitions the post to pending (extrachill-users#127 shared contract).
+	// Plain draft updates are intentionally NOT counted as draft-created —
+	// that event fires once, at create.
+	ec_studio_compose_emit_lifecycle_event(
+		$response,
+		isset( $params['status'] ) ? (string) $params['status'] : '',
+		$user_id,
+		false
+	);
+
 	return ec_studio_compose_relay_response( $response );
+}
+
+/**
+ * Emit a Studio compose lifecycle analytics event for a successful write.
+ *
+ * Maps the resolved post status to the shared-contract event type:
+ *   - status 'pending' → studio_submitted_for_review (create or update)
+ *   - status 'draft'   → studio_draft_created (create only)
+ *
+ * No-op when the cross-site write errored or returned no post id, so we
+ * never count a failed save.
+ *
+ * @since 0.17.0
+ *
+ * @param array|\WP_Error $response  Cross-site write result.
+ * @param string          $status    Resolved post status that was written.
+ * @param int             $user_id   Acting/subject user id.
+ * @param bool            $is_create Whether this was a create (vs update).
+ * @return void
+ */
+function ec_studio_compose_emit_lifecycle_event( $response, string $status, int $user_id, bool $is_create ): void {
+	if ( ! function_exists( 'ec_studio_emit_team_experience_event' ) ) {
+		return;
+	}
+
+	if ( is_wp_error( $response ) ) {
+		return;
+	}
+
+	$post_id = is_array( $response ) && isset( $response['id'] ) ? (int) $response['id'] : 0;
+	if ( $post_id <= 0 ) {
+		return;
+	}
+
+	if ( 'pending' === $status ) {
+		ec_studio_emit_team_experience_event(
+			'studio_submitted_for_review',
+			$user_id,
+			array( 'post_id' => $post_id )
+		);
+		return;
+	}
+
+	if ( $is_create && 'draft' === $status ) {
+		ec_studio_emit_team_experience_event(
+			'studio_draft_created',
+			$user_id,
+			array( 'post_id' => $post_id )
+		);
+	}
 }
 
 /**

--- a/inc/team-experience/events.php
+++ b/inc/team-experience/events.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Studio Team Experience Analytics Events
+ *
+ * Thin emit helper for Studio usage analytics events.
+ *
+ * SHARED EVENT CONTRACT (Extra-Chill/extrachill-users#127)
+ * --------------------------------------------------------
+ * The team-experience instrumentation spans three plugins
+ * (extrachill-users, extrachill-studio, extrachill-roadie). The event
+ * NAMES and payload shape are a shared contract defined once and reused
+ * verbatim at every emit site, so the team-cohort rollup in
+ * extrachill-users (`extrachill/get-team-experience-stats`) can join the
+ * events against the `extra_chill_team` role on `user_id`.
+ *
+ * Event types emitted by extrachill-studio:
+ *   - studio_draft_created          (compose REST create, status draft)
+ *   - studio_submitted_for_review   (compose REST create/update, status pending)
+ *   - studio_transcription_run      (transcription completion callback)
+ *
+ * Payload convention: every event carries a `user_id` key in event_data
+ * identifying the SUBJECT (the team member who took the action). Studio
+ * emit sites pass it explicitly because some run in contexts where the
+ * acting user the analytics table records may be 0 (e.g. the HMAC-signed
+ * transcription callback is unauthenticated).
+ *
+ * All emits route through the existing `extrachill/track-analytics-event`
+ * ability — never write the analytics table directly.
+ *
+ * @package    ExtraChillStudio
+ * @subpackage TeamExperience
+ * @since      0.17.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Emit a Studio team-experience analytics event via the canonical ability.
+ *
+ * No-op (returns 0) when the analytics ability is unavailable, so emit
+ * sites never need to guard the call themselves.
+ *
+ * @param string $event_type Event type identifier from the shared contract.
+ * @param int    $user_id    Subject user ID (the team member who acted).
+ * @param array  $extra      Optional additional payload keys merged into event_data.
+ * @return int Event ID on success, 0 on failure / when unavailable.
+ */
+function ec_studio_emit_team_experience_event( string $event_type, int $user_id, array $extra = array() ): int {
+	if ( '' === $event_type ) {
+		return 0;
+	}
+
+	if ( ! function_exists( 'wp_get_ability' ) ) {
+		return 0;
+	}
+
+	$ability = wp_get_ability( 'extrachill/track-analytics-event' );
+	if ( ! $ability ) {
+		return 0;
+	}
+
+	$event_data = array_merge( array( 'user_id' => $user_id ), $extra );
+
+	$result = $ability->execute(
+		array(
+			'event_type' => $event_type,
+			'event_data' => $event_data,
+		)
+	);
+
+	return is_int( $result ) ? $result : 0;
+}

--- a/inc/transcription/callback.php
+++ b/inc/transcription/callback.php
@@ -153,6 +153,21 @@ function ec_studio_transcription_handle_callback( \WP_REST_Request $request ) {
 		return $post_id;
 	}
 
+	// Emit studio_transcription_run (extrachill-users#127 shared contract).
+	// The acting user the analytics table records is 0 here (unauthenticated
+	// HMAC callback), so the uploader's id is passed in the payload.
+	if ( function_exists( 'ec_studio_emit_team_experience_event' ) ) {
+		ec_studio_emit_team_experience_event(
+			'studio_transcription_run',
+			$user_id,
+			array(
+				'post_id'  => (int) $post_id,
+				'job_id'   => $job_id,
+				'segments' => isset( $stats['segments'] ) ? (int) $stats['segments'] : 0,
+			)
+		);
+	}
+
 	// --- Email the user -----------------------------------------------
 	$email_sent = ec_studio_transcription_callback_send_email( $user, $post_id, $filename, $transcript, $stats );
 


### PR DESCRIPTION
## Summary

Implements the **extrachill-studio** portion of team-experience instrumentation (Extra-Chill/extrachill-users#127). Studio previously had **zero** analytics hooks.

## Events emitted (via existing `extrachill/track-analytics-event` ability)

| Event | Emit site |
|-------|-----------|
| `studio_draft_created` | compose REST create (`ec_studio_compose_create_post`), status `draft` — fires once at create |
| `studio_submitted_for_review` | compose REST create/update, status `pending` — fires on the draft→pending transition |
| `studio_transcription_run` | transcription completion callback, after the draft lands |

Logic: a shared `ec_studio_compose_emit_lifecycle_event()` maps the resolved post status to the contract event, and only fires on a successful cross-site write (non-error response with a post id). Plain draft updates are intentionally **not** counted as draft-created.

The transcription callback passes the uploader's `user_id` explicitly because the HMAC-signed callback is unauthenticated (`get_current_user_id()` is 0 there).

## Shared event-name contract

Reuses the event NAMES + `user_id`-in-payload convention defined in Extra-Chill/extrachill-users#127 (documented in `inc/team-experience/events.php`). The team-cohort rollup (`extrachill/get-team-experience-stats`) reads these counts.

## Verification

- `php -l` clean on all changed files.
- phpcs (WordPress): **zero new findings** — pre-change and post-change counts on `inc/compose/rest.php` are identical (the 2 pre-existing findings are in the unrelated media-upload handler).
- Emit→read round-trip confirmed live: emitting `studio_draft_created` via the ability lands a row and `wp extrachill analytics summary` shows it (test row cleaned up).

Refs Extra-Chill/extrachill-users#127