### PR TITLE
refactor: reference canonical analytics event-name constants (users#129)

### DIFF
--- a/inc/compose/rest.php
+++ b/inc/compose/rest.php
@@ -410,7 +410,7 @@ function ec_studio_compose_emit_lifecycle_event( $response, string $status, int 
 
 	if ( 'pending' === $status ) {
 		ec_studio_emit_team_experience_event(
-			EC_STUDIO_EVENT_SUBMITTED_FOR_REVIEW,
+			EC_ANALYTICS_EVENT_STUDIO_SUBMITTED,
 			$user_id,
 			array( 'post_id' => $post_id )
 		);
@@ -419,7 +419,7 @@ function ec_studio_compose_emit_lifecycle_event( $response, string $status, int 
 
 	if ( $is_create && 'draft' === $status ) {
 		ec_studio_emit_team_experience_event(
-			EC_STUDIO_EVENT_DRAFT_CREATED,
+			EC_ANALYTICS_EVENT_STUDIO_DRAFT_CREATED,
 			$user_id,
 			array( 'post_id' => $post_id )
 		);

--- a/inc/compose/rest.php
+++ b/inc/compose/rest.php
@@ -410,7 +410,7 @@ function ec_studio_compose_emit_lifecycle_event( $response, string $status, int 
 
 	if ( 'pending' === $status ) {
 		ec_studio_emit_team_experience_event(
-			'studio_submitted_for_review',
+			EC_STUDIO_EVENT_SUBMITTED_FOR_REVIEW,
 			$user_id,
 			array( 'post_id' => $post_id )
 		);
@@ -419,7 +419,7 @@ function ec_studio_compose_emit_lifecycle_event( $response, string $status, int 
 
 	if ( $is_create && 'draft' === $status ) {
 		ec_studio_emit_team_experience_event(
-			'studio_draft_created',
+			EC_STUDIO_EVENT_DRAFT_CREATED,
 			$user_id,
 			array( 'post_id' => $post_id )
 		);

--- a/inc/team-experience/events.php
+++ b/inc/team-experience/events.php
@@ -34,6 +34,34 @@
 
 defined( 'ABSPATH' ) || exit;
 
+/*
+ * Event-name contract constants (Extra-Chill/extrachill-users#129).
+ * ----------------------------------------------------------------
+ * The Studio analytics event_type strings are defined ONCE here and
+ * referenced by every Studio emit site, so a rename is mechanical and a
+ * scattered-literal typo can't silently desync an emit from the shared
+ * contract (the "permanently-zero metric, no error" failure mode).
+ *
+ * Scope: these constants cover only the event types extrachill-studio
+ * emits. The read-side rollup lives in extrachill-users and owns its own
+ * constants for the same names — matching by documented contract, with no
+ * load-time cross-plugin dependency in either direction.
+ */
+const EC_STUDIO_EVENT_DRAFT_CREATED        = 'studio_draft_created';
+const EC_STUDIO_EVENT_SUBMITTED_FOR_REVIEW = 'studio_submitted_for_review';
+const EC_STUDIO_EVENT_TRANSCRIPTION_RUN    = 'studio_transcription_run';
+
+/**
+ * Full set of event types emitted by extrachill-studio.
+ *
+ * @var string[]
+ */
+const EC_STUDIO_TEAM_EXPERIENCE_EVENTS = array(
+	EC_STUDIO_EVENT_DRAFT_CREATED,
+	EC_STUDIO_EVENT_SUBMITTED_FOR_REVIEW,
+	EC_STUDIO_EVENT_TRANSCRIPTION_RUN,
+);
+
 /**
  * Emit a Studio team-experience analytics event via the canonical ability.
  *

--- a/inc/team-experience/events.php
+++ b/inc/team-experience/events.php
@@ -35,32 +35,18 @@
 defined( 'ABSPATH' ) || exit;
 
 /*
- * Event-name contract constants (Extra-Chill/extrachill-users#129).
- * ----------------------------------------------------------------
- * The Studio analytics event_type strings are defined ONCE here and
- * referenced by every Studio emit site, so a rename is mechanical and a
- * scattered-literal typo can't silently desync an emit from the shared
- * contract (the "permanently-zero metric, no error" failure mode).
- *
- * Scope: these constants cover only the event types extrachill-studio
- * emits. The read-side rollup lives in extrachill-users and owns its own
- * constants for the same names — matching by documented contract, with no
- * load-time cross-plugin dependency in either direction.
+ * Event-name contract (Extra-Chill/extrachill-users#129).
+ * -------------------------------------------------------
+ * The canonical Studio event_type names are defined ONCE in
+ * extrachill-analytics (inc/core/event-types.php) as the
+ * `EC_ANALYTICS_EVENT_STUDIO_*` constants. extrachill-analytics owns the
+ * analytics substrate and the `extrachill/track-analytics-event` ability
+ * this helper already calls at runtime, and is network-active, so those
+ * constants are guaranteed present wherever Studio emits — referencing
+ * them adds no new coupling. Studio's emit sites reference the analytics
+ * constants directly (no local copies of the literal strings), so a
+ * rename happens in exactly one place across the whole network.
  */
-const EC_STUDIO_EVENT_DRAFT_CREATED        = 'studio_draft_created';
-const EC_STUDIO_EVENT_SUBMITTED_FOR_REVIEW = 'studio_submitted_for_review';
-const EC_STUDIO_EVENT_TRANSCRIPTION_RUN    = 'studio_transcription_run';
-
-/**
- * Full set of event types emitted by extrachill-studio.
- *
- * @var string[]
- */
-const EC_STUDIO_TEAM_EXPERIENCE_EVENTS = array(
-	EC_STUDIO_EVENT_DRAFT_CREATED,
-	EC_STUDIO_EVENT_SUBMITTED_FOR_REVIEW,
-	EC_STUDIO_EVENT_TRANSCRIPTION_RUN,
-);
 
 /**
  * Emit a Studio team-experience analytics event via the canonical ability.

--- a/inc/transcription/callback.php
+++ b/inc/transcription/callback.php
@@ -158,7 +158,7 @@ function ec_studio_transcription_handle_callback( \WP_REST_Request $request ) {
 	// HMAC callback), so the uploader's id is passed in the payload.
 	if ( function_exists( 'ec_studio_emit_team_experience_event' ) ) {
 		ec_studio_emit_team_experience_event(
-			EC_STUDIO_EVENT_TRANSCRIPTION_RUN,
+			EC_ANALYTICS_EVENT_STUDIO_TRANSCRIPTION_RUN,
 			$user_id,
 			array(
 				'post_id'  => (int) $post_id,

--- a/inc/transcription/callback.php
+++ b/inc/transcription/callback.php
@@ -158,7 +158,7 @@ function ec_studio_transcription_handle_callback( \WP_REST_Request $request ) {
 	// HMAC callback), so the uploader's id is passed in the payload.
 	if ( function_exists( 'ec_studio_emit_team_experience_event' ) ) {
 		ec_studio_emit_team_experience_event(
-			'studio_transcription_run',
+			EC_STUDIO_EVENT_TRANSCRIPTION_RUN,
 			$user_id,
 			array(
 				'post_id'  => (int) $post_id,


### PR DESCRIPTION
## Summary
Repoints the Studio analytics emit sites at the **canonical event-name constants owned by extrachill-analytics** (Extra-Chill/extrachill-analytics#32). Part of a 5-PR set on branch `event-name-contract` resolving extrachill-users#129.

> **Revised approach:** the first pass used per-plugin `EC_STUDIO_EVENT_*` constants, which still duplicated the literal across plugins (studio's emit copy vs users' reader copy of `studio_draft_created`). This revision collapses every event-name literal to a single cross-plugin source in extrachill-analytics.

## Why extrachill-analytics is the home (zero new coupling)
Studio already calls `wp_get_ability('extrachill/track-analytics-event')` at runtime — an ability owned by extrachill-analytics — so a hard runtime dependency on analytics already exists; referencing its constants adds none. extrachill-analytics is `Network: true`, so the constants are always defined. Full rationale: Extra-Chill/extrachill-analytics#32.

## Changes
- `inc/team-experience/events.php` — dropped the per-plugin constants; documents that the canonical names live in analytics.
- `inc/compose/rest.php` — draft/submit emits reference `EC_ANALYTICS_EVENT_STUDIO_DRAFT_CREATED` / `EC_ANALYTICS_EVENT_STUDIO_SUBMITTED`.
- `inc/transcription/callback.php` — transcription-run emit references `EC_ANALYTICS_EVENT_STUDIO_TRANSCRIPTION_RUN`.

## Single-source proof
No bare Studio event-name literal remains in this repo — all references are to `EC_ANALYTICS_EVENT_STUDIO_*` constants.

## No behavior change
Constants resolve to the byte-identical `studio_draft_created` / `studio_submitted_for_review` / `studio_transcription_run` strings used before.

## Verification
- `php -l` clean; phpcs (WordPress): zero new findings in changed hunks (rest.php:256/724/725 are pre-existing).

## Related PRs (branch `event-name-contract`)
- **Keystone (constants home):** Extra-Chill/extrachill-analytics#32
- extrachill-users: Extra-Chill/extrachill-users#130
- extrachill-roadie: Extra-Chill/extrachill-roadie#52
- extrachill-artist-platform: Extra-Chill/extrachill-artist-platform#74

Refs Extra-Chill/extrachill-users#129. Review all 5 together; do not merge standalone.
