### PR TITLE
feat: hide socials tab for users without brand_socials access

### DIFF
--- a/src/blocks/studio/app/tabs.ts
+++ b/src/blocks/studio/app/tabs.ts
@@ -1,29 +1,47 @@
 import { __ } from '@wordpress/i18n';
 import type { StudioTab } from '../types/studio';
 
-export const getStudioTabs = (): StudioTab[] => [
-	{
-		id: 'compose',
-		pane: 'compose',
-		label: __( 'Blog', 'extrachill-studio' ),
-		preview: __( 'Draft and submit blog posts using the block editor.', 'extrachill-studio' ),
-	},
-	{
-		id: 'socials',
-		pane: 'socials',
-		label: __( 'Socials', 'extrachill-studio' ),
-		preview: __( 'Publish and manage posts across social platforms.', 'extrachill-studio' ),
-	},
-	{
-		id: 'transcribe',
-		pane: 'transcribe',
-		label: __( 'Transcribe', 'extrachill-studio' ),
-		preview: __( 'Transcribe audio with Whisper.', 'extrachill-studio' ),
-	},
-	{
-		id: 'qr-codes',
-		pane: 'qr-codes',
-		label: __( 'QR Codes', 'extrachill-studio' ),
-		preview: __( 'Generate downloadable QR codes for any URL.', 'extrachill-studio' ),
-	},
-];
+/**
+ * Options controlling which Studio tabs are available to the current user.
+ */
+export interface StudioTabOptions {
+	/**
+	 * Whether the user may access the shared brand social accounts. When
+	 * false, the Socials tab is dropped from the tab list. Defaults to true
+	 * so unconfigured callers see the full surface.
+	 */
+	canBrandSocials?: boolean;
+}
+
+export const getStudioTabs = ( options: StudioTabOptions = {} ): StudioTab[] => {
+	const { canBrandSocials = true } = options;
+
+	const tabs: StudioTab[] = [
+		{
+			id: 'compose',
+			pane: 'compose',
+			label: __( 'Blog', 'extrachill-studio' ),
+			preview: __( 'Draft and submit blog posts using the block editor.', 'extrachill-studio' ),
+		},
+		{
+			id: 'socials',
+			pane: 'socials',
+			label: __( 'Socials', 'extrachill-studio' ),
+			preview: __( 'Publish and manage posts across social platforms.', 'extrachill-studio' ),
+		},
+		{
+			id: 'transcribe',
+			pane: 'transcribe',
+			label: __( 'Transcribe', 'extrachill-studio' ),
+			preview: __( 'Transcribe audio with Whisper.', 'extrachill-studio' ),
+		},
+		{
+			id: 'qr-codes',
+			pane: 'qr-codes',
+			label: __( 'QR Codes', 'extrachill-studio' ),
+			preview: __( 'Generate downloadable QR codes for any URL.', 'extrachill-studio' ),
+		},
+	];
+
+	return tabs.filter( ( tab ) => tab.id !== 'socials' || canBrandSocials );
+};

--- a/src/blocks/studio/render.php
+++ b/src/blocks/studio/render.php
@@ -75,6 +75,18 @@ $allowed_platforms = apply_filters( 'extrachill_studio_social_platforms', array(
 	'facebook',
 ) );
 
+/*
+ * Whether this user may access the shared brand social accounts. The Socials
+ * tab operates the official Extra Chill accounts (credentials stored
+ * network-wide), so it is gated behind the EC `brand_socials` rollout feature
+ * (admin-only by default). The boolean is passed to the React app, which drops
+ * the Socials tab when it is false. Defaults to true if the gate helper is
+ * unavailable so the surface is not hidden by a missing dependency.
+ */
+$can_brand_socials = function_exists( 'ec_feature_available' )
+	? ec_feature_available( 'brand_socials' )
+	: true;
+
 ?>
 
 <div
@@ -88,6 +100,7 @@ $allowed_platforms = apply_filters( 'extrachill_studio_social_platforms', array(
 	data-headline="<?php echo esc_attr( $headline ); ?>"
 	data-description="<?php echo esc_attr( $description ); ?>"
 	data-social-platforms="<?php echo esc_attr( wp_json_encode( $allowed_platforms ) ); ?>"
+	data-can-brand-socials="<?php echo $can_brand_socials ? 'true' : 'false'; ?>"
 >
 	<div class="ec-studio-app__mount" data-ec-studio-app></div>
 </div>

--- a/src/blocks/studio/types/studio.ts
+++ b/src/blocks/studio/types/studio.ts
@@ -12,6 +12,8 @@ export interface StudioContext {
 	description: string;
 	/** Allowed social platform slugs. Empty array = show all. */
 	socialPlatforms: string[];
+	/** Whether the user may access the shared brand social accounts. */
+	canBrandSocials: boolean;
 }
 
 export interface StudioTab {

--- a/src/blocks/studio/view.ts
+++ b/src/blocks/studio/view.ts
@@ -21,7 +21,7 @@ const STUDIO_PANES: Record< string, ComponentType< StudioPaneProps > > = {
 };
 
 const StudioApp = ( { context }: { context: StudioContext } ): ReactElement => {
-	const tabs = getStudioTabs();
+	const tabs = getStudioTabs( { canBrandSocials: context.canBrandSocials } );
 	const [ activeTab, setActiveTab ] = useState( tabs[ 0 ]?.id || 'compose' );
 	const renderPanel = ( id: string ): ReactElement => {
 		const ActivePane = STUDIO_PANES[ id ] || ComposePane;
@@ -86,6 +86,7 @@ const initRoot = ( root: HTMLElement ): void => {
 		headline: root.dataset.headline || '',
 		description: root.dataset.description || '',
 		socialPlatforms,
+		canBrandSocials: root.dataset.canBrandSocials === 'true',
 	};
 
 	const appMount = root.querySelector< HTMLElement >( '[data-ec-studio-app]' );


### PR DESCRIPTION
## What changed

Hides Studio's **Socials** tab for users who fail the `brand_socials` gate. The Socials tab operates the shared official Extra Chill accounts (now admin-only by default via extrachill-users#131 / data-machine-socials#174), so users without access should not see the tab at all.

## File / lines

- `src/blocks/studio/render.php` (~L78) — compute `$can_brand_socials = ec_feature_available( 'brand_socials' )` (defaults to `true` if the helper is unavailable so a missing dependency never hides the surface) and pass it to the React app as `data-can-brand-socials`.
- `src/blocks/studio/view.ts` — read `root.dataset.canBrandSocials === 'true'` into `StudioContext`, and call `getStudioTabs( { canBrandSocials: context.canBrandSocials } )`.
- `src/blocks/studio/app/tabs.ts` — `getStudioTabs()` now accepts `{ canBrandSocials }` and filters out the `socials` tab when false (defaults to `true`).
- `src/blocks/studio/types/studio.ts` — add `canBrandSocials: boolean` to `StudioContext`.

Uses the existing `data-*` server→React context mechanism already in render.php/view.ts (matching `data-social-platforms`); no new wiring invented. Build artifacts under `build/` are gitignored and regenerated at deploy by homeboy, so only source files are committed (matching repo convention).

## Server↔client contract

`render.php` emits `data-can-brand-socials="true|false"` → `view.ts` parses it into `StudioContext.canBrandSocials` → `getStudioTabs()` drops the `socials` tab when false. The editor preview (`edit.tsx`) calls `getStudioTabs()` with no args → defaults to showing all tabs.

## Verification

- `npm run typecheck` (tsc --noEmit) → passes.
- `npm run build` (wp-scripts build) → compiles successfully.
- `php -l src/blocks/studio/render.php` → no syntax errors.
- ESLint/prettier errors observed are pre-existing baseline across the whole block (untouched files like `edit.tsx` report the same prettier formatting deltas); the changed files follow the surrounding committed tab-indentation style.

Closes #131