### PR TITLE
feat: bridge chat action-resolved to blocks-everywhere refresh

### DIFF
--- a/src/blocks/studio/tabs/compose/index.ts
+++ b/src/blocks/studio/tabs/compose/index.ts
@@ -10,6 +10,7 @@ import {
 import { ActionRow, FieldGroup, InlineStatus, Panel, PanelHeader } from '@extrachill/components';
 import type { StudioPaneProps } from '../../types/studio';
 import { setComposeCrossSiteActive } from './cross-site-middleware';
+import { installChatRefreshAdapter } from './refresh-adapter';
 
 const h = createElement as typeof import( 'react' ).createElement;
 const PanelView = Panel as unknown as ( props: any ) => ReactElement;
@@ -19,7 +20,10 @@ const InlineStatusView = InlineStatus as unknown as ( props: any ) => ReactEleme
 
 declare global {
 	interface Window {
-		blocksEverywhereCreateEditor?: ( textarea: HTMLTextAreaElement ) => void;
+		blocksEverywhereCreateEditor?: (
+			textarea: HTMLTextAreaElement,
+			options?: { settings?: Record< string, unknown > }
+		) => void;
 		blocksEverywhereGetContentApi?: ( textarea: HTMLTextAreaElement ) => BlocksEverywhereContentApi | null;
 	}
 }
@@ -181,6 +185,76 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 			api.replaceContent( html );
 		}
 	};
+
+	/**
+	 * Refetch the current content of a post from main via the compose
+	 * cross-site proxy (active while the Blog tab is mounted). Returns the
+	 * post's raw block markup, or an empty string on any failure.
+	 */
+	const fetchPostContent = useCallback(
+		async ( postId: number ): Promise< string > => {
+			try {
+				const post = await apiFetch< WpPost >( {
+					path: `/wp/v2/posts/${ postId }?context=edit`,
+				} );
+				return post?.content?.raw || post?.content?.rendered || '';
+			} catch {
+				return '';
+			}
+		},
+		[]
+	);
+
+	/**
+	 * Blocks Everywhere external-edit refresh wiring.
+	 *
+	 * When Roadie writes the active draft (via the chat accept path → the
+	 * refresh adapter → BE's receiver), the open editor refetches and replaces
+	 * its content. Studio owns post identity, the fetch, and the autosave
+	 * baseline, so it supplies all four hooks; BE owns the replace + post-id
+	 * matching. Held in a ref so the object identity is stable across renders
+	 * (BE reads it once at mount) while the getters read live values.
+	 */
+	const refreshConfigRef = useRef( {
+		// Getter — the active draft changes via the draft picker over the
+		// editor's lifetime, so BE must read the current id per event.
+		watchPostId: (): number | null => activePostIdRef.current,
+		fetchContent: async (): Promise< string > => {
+			const postId = activePostIdRef.current;
+			if ( ! postId ) {
+				return '';
+			}
+			return fetchPostContent( postId );
+		},
+		beforeRefresh: async (): Promise< void > => {
+			// Cancel a pending debounced autosave and await any in-flight one so
+			// our baseline reset is not immediately overwritten by a stale save.
+			if ( autosaveTimerRef.current ) {
+				clearTimeout( autosaveTimerRef.current );
+				autosaveTimerRef.current = null;
+			}
+			const inFlight = inFlightPromiseRef.current;
+			if ( inFlight ) {
+				try {
+					await inFlight;
+				} catch {
+					// In-flight save handled its own errors; proceed.
+				}
+			}
+		},
+		onRefreshed: ( html: string ): void => {
+			// Reset the autosave baseline to the freshly-applied content so the
+			// NEXT autosave carries the external edit forward instead of
+			// re-clobbering it with the stale in-memory snapshot.
+			contentSnapshotRef.current = html;
+			lastSavedPayloadRef.current = JSON.stringify( {
+				title: titleRef.current.trim(),
+				content: html.trim(),
+			} );
+			setHasUnsavedChanges( false );
+			scheduleClientContextUpdate();
+		},
+	} );
 
 	/**
 	 * Fetch the current user's drafts from the REST API.
@@ -492,6 +566,14 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 		};
 	}, [] );
 
+	// Bridge the chat's action-resolved event to BE's refresh-content event for
+	// the lifetime of this pane. The adapter is the only place both event names
+	// co-exist; BE's receiver (configured via refreshConfigRef below) matches
+	// the post id and ignores events for any other draft.
+	useEffect( () => {
+		return installChatRefreshAdapter();
+	}, [] );
+
 	useEffect( () => {
 		unregisterClientContextRef.current = registerClientContextProvider( {
 			id: CLIENT_CONTEXT_PROVIDER_ID,
@@ -546,10 +628,18 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 				contentSnapshotRef.current = '';
 			}
 
-			// Mount the editor — it reads textarea.value via onLoad.
+			// Mount the editor — it reads textarea.value via onLoad. Pass the
+			// external-edit refresh wiring so an accepted Roadie edit refreshes
+			// the open editor instead of being clobbered by the next autosave.
 			if ( ! editorMountedRef.current && textareaRef.current ) {
 				if ( typeof window.blocksEverywhereCreateEditor === 'function' ) {
-					window.blocksEverywhereCreateEditor( textareaRef.current );
+					window.blocksEverywhereCreateEditor( textareaRef.current, {
+						settings: {
+							blocksEverywhere: {
+								refresh: refreshConfigRef.current,
+							},
+						},
+					} );
 					editorMountedRef.current = true;
 					setEditorReady( true );
 				} else {

--- a/src/blocks/studio/tabs/compose/index.ts
+++ b/src/blocks/studio/tabs/compose/index.ts
@@ -109,6 +109,18 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 	const pendingRerunRef = useRef( false );
 	const consecutiveFailuresRef = useRef( 0 );
 	const autosaveErrorActiveRef = useRef( false );
+	// Set while an external-edit refresh is applying (Roadie accept → BE
+	// receiver). Blocks autosave from issuing a stale-content write that could
+	// land after the refresh resets the baseline and re-clobber the accepted
+	// edit. See refreshConfigRef below.
+	const isRefreshingRef = useRef( false );
+	// Watchdog that force-clears isRefreshingRef if a refresh starts but never
+	// settles (e.g. BE's receiver bails before onRefreshed because the content
+	// API was transiently unavailable). Prevents a stuck guard from disabling
+	// autosave permanently.
+	const refreshWatchdogRef = useRef< ReturnType< typeof setTimeout > | null >(
+		null
+	);
 	// Monotonic edit counter. Incremented on every title/content edit. Captured
 	// at the start of an autosave so we can detect edits that land during the
 	// in-flight window and avoid marking those keystrokes as "saved".
@@ -227,14 +239,38 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 			return fetchPostContent( postId );
 		},
 		beforeRefresh: async (): Promise< void > => {
-			// Cancel a pending debounced autosave and await any in-flight one so
-			// our baseline reset is not immediately overwritten by a stale save.
+			// Mark the refresh in progress BEFORE awaiting anything. This makes
+			// performAutosave (and the in-flight save's finally re-run) bail, so
+			// no stale-content write can be issued while we refetch + replace.
+			// The flag is cleared in onRefreshed after the baseline is reset.
+			isRefreshingRef.current = true;
+
+			// Arm a watchdog: if onRefreshed never fires (BE bailed before the
+			// replace), force-clear the guard so autosave isn't disabled forever.
+			if ( refreshWatchdogRef.current ) {
+				clearTimeout( refreshWatchdogRef.current );
+			}
+			refreshWatchdogRef.current = setTimeout( () => {
+				refreshWatchdogRef.current = null;
+				isRefreshingRef.current = false;
+			}, 15000 );
+
+			// Cancel a pending debounced autosave.
 			if ( autosaveTimerRef.current ) {
 				clearTimeout( autosaveTimerRef.current );
 				autosaveTimerRef.current = null;
 			}
-			const inFlight = inFlightPromiseRef.current;
-			if ( inFlight ) {
+
+			// Drain any in-flight save to quiescence. A save that completes here
+			// could, in its finally, synchronously start one more (pendingRerun)
+			// BEFORE the guard above takes effect for that closure; loop until no
+			// save is in flight so the wire is clear before we replace content.
+			// Bounded so a pathological save loop cannot hang the refresh.
+			for ( let i = 0; i < 5; i++ ) {
+				const inFlight = inFlightPromiseRef.current;
+				if ( ! inFlight ) {
+					break;
+				}
 				try {
 					await inFlight;
 				} catch {
@@ -251,8 +287,20 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 				title: titleRef.current.trim(),
 				content: html.trim(),
 			} );
+			// Advance the edit sequence so any autosave snapshot captured before
+			// the refresh is treated as superseded and won't mark the draft clean
+			// against stale content if it somehow completes late.
+			editSeqRef.current += 1;
 			setHasUnsavedChanges( false );
 			scheduleClientContextUpdate();
+
+			// Release the autosave guard now the baseline reflects the applied
+			// content. Subsequent edits autosave normally from the new baseline.
+			if ( refreshWatchdogRef.current ) {
+				clearTimeout( refreshWatchdogRef.current );
+				refreshWatchdogRef.current = null;
+			}
+			isRefreshingRef.current = false;
 		},
 	} );
 
@@ -438,6 +486,15 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 	 * subsequent autosaves update the same draft.
 	 */
 	const performAutosave = useCallback( async (): Promise< void > => {
+		// An external-edit refresh is applying the accepted content. Suppress
+		// this save entirely — issuing a stale-content write now would race the
+		// refresh's baseline reset and could re-clobber the accepted edit. Do
+		// NOT set pendingRerunRef: the refresh's onRefreshed makes the editor
+		// the new baseline, so there is nothing stale left to flush afterward.
+		if ( isRefreshingRef.current ) {
+			return;
+		}
+
 		// If a save is already in flight, mark a rerun and bail; the in-flight
 		// save's finally block will pick up the latest content when it completes.
 		if ( isAutosavingRef.current ) {
@@ -534,9 +591,17 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 				inFlightPromiseRef.current = null;
 				// Re-run if input arrived while we were saving so the latest
 				// content reaches the server instead of being silently dropped.
+				// Suppress the re-run while an external-edit refresh is applying:
+				// re-running here would issue a stale-content write that races the
+				// refresh and re-clobbers the accepted edit. performAutosave's own
+				// guard also bails, but clearing the flag here keeps the pending
+				// state clean so a post-refresh edit is not treated as already
+				// queued.
 				if ( pendingRerunRef.current ) {
 					pendingRerunRef.current = false;
-					performAutosave();
+					if ( ! isRefreshingRef.current ) {
+						performAutosave();
+					}
 				}
 			}
 		} )();
@@ -571,7 +636,14 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 	// co-exist; BE's receiver (configured via refreshConfigRef below) matches
 	// the post id and ignores events for any other draft.
 	useEffect( () => {
-		return installChatRefreshAdapter();
+		const cleanupAdapter = installChatRefreshAdapter();
+		return () => {
+			cleanupAdapter();
+			if ( refreshWatchdogRef.current ) {
+				clearTimeout( refreshWatchdogRef.current );
+				refreshWatchdogRef.current = null;
+			}
+		};
 	}, [] );
 
 	useEffect( () => {

--- a/src/blocks/studio/tabs/compose/refresh-adapter.ts
+++ b/src/blocks/studio/tabs/compose/refresh-adapter.ts
@@ -1,0 +1,90 @@
+/**
+ * Chat → editor refresh adapter.
+ *
+ * The ONE place in the stack that knows BOTH event names — by design. It
+ * translates the chat's generic "a pending action resolved" announcement
+ * (`frontend-agent-chat:action-resolved`, emitted by frontend-agent-chat) into
+ * Blocks Everywhere's generic "your post changed externally, refresh"
+ * signal (`blocksEverywhere:refresh-content`, consumed by blocks-everywhere).
+ *
+ * This mirrors how extrachill-roadie bridges `access_roadie` →
+ * `datamachine_can_access_agent`: the two generic layers never reference each
+ * other; a thin host-owned adapter couples them.
+ *
+ * - frontend-agent-chat must not know about Blocks Everywhere / Studio.
+ * - blocks-everywhere must not know about the chat.
+ * - So the coupling lives here, and only here.
+ *
+ * Post-id matching is intentionally NOT done here: blocks-everywhere's receiver
+ * is told which post it is watching (via the Compose tab's `watchPostId` wiring)
+ * and ignores events for any other post. The adapter just forwards the identity
+ * the chat surfaced and lets the receiver decide whether it applies. We forward
+ * only `accepted` decisions, since a rejected action did not change the post and
+ * so there is nothing to refresh.
+ */
+
+/**
+ * The chat event this adapter listens for.
+ * @see Automattic/frontend-agent-chat#84
+ */
+const CHAT_ACTION_RESOLVED_EVENT = 'frontend-agent-chat:action-resolved';
+
+/**
+ * The Blocks Everywhere event this adapter dispatches.
+ * @see Extra-Chill/blocks-everywhere#107
+ */
+const BE_REFRESH_CONTENT_EVENT = 'blocksEverywhere:refresh-content';
+
+interface ActionResolvedDetail {
+	action_id?: string;
+	decision?: string;
+	post_id?: number | string;
+	blog_id?: number | string;
+	kind?: string;
+}
+
+/**
+ * Install the chat → editor refresh adapter.
+ *
+ * Listens on `window` for the chat's action-resolved event and, on an accepted
+ * decision that carries a post id, dispatches the Blocks Everywhere refresh
+ * event on `document` (where BE's receiver listens). Returns a cleanup function
+ * that removes the listener.
+ *
+ * @return {() => void} Cleanup function that removes the listener.
+ */
+export function installChatRefreshAdapter(): () => void {
+	const handler = ( event: Event ): void => {
+		const detail =
+			( event as CustomEvent< ActionResolvedDetail > ).detail || {};
+
+		// Only accepted resolutions changed the post; rejected ones leave it
+		// untouched, so there is nothing for the editor to refresh.
+		if ( detail.decision !== 'accepted' ) {
+			return;
+		}
+
+		const postId = detail.post_id;
+		if ( postId === undefined || postId === null || postId === '' ) {
+			return;
+		}
+
+		// Forward as the BE-generic refresh signal. BE's receiver matches the
+		// post id against the editor's watched post and ignores mismatches.
+		document.dispatchEvent(
+			new CustomEvent( BE_REFRESH_CONTENT_EVENT, {
+				detail: {
+					postId,
+					blogId: detail.blog_id,
+					kind: detail.kind,
+				},
+			} )
+		);
+	};
+
+	window.addEventListener( CHAT_ACTION_RESOLVED_EVENT, handler );
+
+	return () => {
+		window.removeEventListener( CHAT_ACTION_RESOLVED_EVENT, handler );
+	};
+}


### PR DESCRIPTION
## Summary

The thin host adapter that fixes the stale-editor bug on the Studio Blog/Compose tab: when Roadie proposes a block edit and the writer **accepts** it in the chat drawer, the corrected content is written to the draft on main (blog 1) server-side — but the open Blocks Everywhere editor kept stale in-memory content and its 2s autosave clobbered the accepted change. This wires the accepted edit through to the on-page editor with no reload.

Closes #101.

Depends on (merge first):
- Automattic/frontend-agent-chat#85 — emits `frontend-agent-chat:action-resolved` `{ action_id, decision, post_id, blog_id, kind }`.
- Extra-Chill/blocks-everywhere#108 — consumes BE-generic `blocksEverywhere:refresh-content` and owns the post-id matching + safe content replace.

## What changed

**New `src/blocks/studio/tabs/compose/refresh-adapter.ts`** — `installChatRefreshAdapter()`. The ONE place that knows BOTH event names (by design — mirrors how extrachill-roadie bridges `access_roadie` → `datamachine_can_access_agent`). Listens on `window` for `frontend-agent-chat:action-resolved`; on an **accepted** decision carrying a `post_id`, re-dispatches `blocksEverywhere:refresh-content` on `document` with `{ postId, blogId, kind }`. It does no post-id matching itself — BE's receiver owns that.

**`src/blocks/studio/tabs/compose/index.ts`** — wires the Compose tab into BE's receiver:
- Installs the adapter for the pane's lifetime.
- Passes `settings.blocksEverywhere.refresh` into the BE editor mount with the four host hooks BE's receiver calls:
  - `watchPostId` — a **getter** returning `activePostIdRef.current` (the active draft changes via the draft picker, so it must be read per-event).
  - `fetchContent` — refetches the post's current `content.raw` via `/wp/v2/posts/<id>?context=edit`, which the existing compose cross-site middleware proxies to **main**. Refetch = single source of truth (the post that was just written).
  - `beforeRefresh` — cancels the pending debounced autosave and awaits any in-flight one, so the baseline reset isn't immediately overwritten.
  - `onRefreshed` — resets the autosave baseline (`contentSnapshotRef` + `lastSavedPayloadRef`) to the freshly-applied HTML so the **next** autosave carries the external edit forward instead of re-clobbering it.

## Post-identity plumbing

blocks-everywhere#108 landed on "the host owns post identity; tell the receiver which post to watch." Confirmed from the Compose tab: BE mounts post-agnostic here (no `settings.postEntity`), and Studio already tracks `activePostId`. So this passes `watchPostId` into the BE instance; an accepted edit for a different draft is ignored by BE's matcher.

## Layer purity

Both event names co-exist in exactly one file — the adapter — which is correct and intentional:

```
$ git grep -c "frontend-agent-chat:action-resolved" -- src/
src/blocks/studio/tabs/compose/refresh-adapter.ts:2
$ git grep -c "blocksEverywhere:refresh-content" -- src/
src/blocks/studio/tabs/compose/refresh-adapter.ts:2
```

frontend-agent-chat never learns about BE/Studio; blocks-everywhere never learns about the chat. The coupling lives here and only here.

## Verification

- `npm run typecheck` clean.
- `npm run build` compiles successfully.
- New `refresh-adapter.ts` is lint-clean; the `index.ts` additions are prettier-conformant (the file has pre-existing house-style lint noise on `main` that is intentionally left untouched to keep the diff minimal).

## Acceptance (matches issue)

- Accept a Roadie edit on the Blog tab while a draft is open → the on-page editor updates to the accepted content with no reload.
- The next autosave/keystroke does NOT revert it (baseline reset in `onRefreshed`).
- An accepted edit for a different post does not disturb the open editor (BE post-id match).

## Merge order

Merge **after** blocks-everywhere#108 and frontend-agent-chat#85.