### PR TITLE
chore: bump @extrachill/tokens to ^0.8.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"dependencies": {
 				"@extrachill/chat": "^0.14.0",
 				"@extrachill/components": "^0.8.0",
-				"@extrachill/tokens": "^0.4.2"
+				"@extrachill/tokens": "^0.8.1"
 			},
 			"devDependencies": {
 				"@extrachill/api-client": "^0.7.0",
@@ -2720,9 +2720,9 @@
 			}
 		},
 		"node_modules/@extrachill/tokens": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/@extrachill/tokens/-/tokens-0.4.2.tgz",
-			"integrity": "sha512-UBjSjMpIMeuGNp6Y+Il3rWj2d0MPcrnUUPd5ERGKX8i5Zta//xJYoxEAuuCDmqULeWneJF84zlPYTWaF8+EHyg==",
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/@extrachill/tokens/-/tokens-0.8.1.tgz",
+			"integrity": "sha512-xBXIYfg9LBSwUZNItdaVZiIStWiaVeaQ3wdw+0/PLki86+OCRneFY+6gHmf6NTnVSKKAp1MEKOt4QVseQpFhhA==",
 			"license": "GPL-2.0+"
 		},
 		"node_modules/@floating-ui/core": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 	"dependencies": {
 		"@extrachill/chat": "^0.14.0",
 		"@extrachill/components": "^0.8.0",
-		"@extrachill/tokens": "^0.4.2"
+		"@extrachill/tokens": "^0.8.1"
 	},
 	"devDependencies": {
 		"@extrachill/api-client": "^0.7.0",


### PR DESCRIPTION
## Summary

Aligns `@extrachill/tokens` from `^0.4.2` → `^0.8.1` with the latest token release. Lockfile updated.

The dependency is declared but not yet imported in source, so this is a low-risk version alignment to keep the workspace consistent on a single tokens version.