### PR TITLE
feat: Network tab — team-facing analytics dashboard inside Studio

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
 				"@wordpress/i18n": "^6.9.0",
 				"@wordpress/scripts": "^31.1.0",
 				"ajv": "^8.20.0",
+				"chart.js": "^4.4.0",
 				"typescript": "^5.7.0"
 			}
 		},
@@ -3605,6 +3606,13 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
 			"integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@kurkle/color": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+			"integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -9357,6 +9365,19 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/chart.js": {
+			"version": "4.5.1",
+			"resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+			"integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@kurkle/color": "^0.3.0"
+			},
+			"engines": {
+				"pnpm": ">=8"
 			}
 		},
 		"node_modules/check-node-version": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 	"devDependencies": {
 		"@extrachill/api-client": "^0.7.0",
 		"@types/react": "^18.3.0",
+		"chart.js": "^4.4.0",
 		"@types/wordpress__block-editor": "^15.0.5",
 		"@types/wordpress__blocks": "^15.10.2",
 		"@types/wordpress__element": "^2.14.0",

--- a/src/blocks/studio/app/client.ts
+++ b/src/blocks/studio/app/client.ts
@@ -10,7 +10,9 @@ import type {
 	SurfaceGrowthResponse,
 } from '../types/analytics';
 
-export const studioClient = new ExtraChillClient( new WpApiFetchTransport( apiFetch ) );
+export const studioClient = new ExtraChillClient(
+	new WpApiFetchTransport( apiFetch )
+);
 
 interface InstagramMediaParams {
 	action?: string;
@@ -87,7 +89,9 @@ interface CommentReplyResponse {
 }
 
 export const studioSocialsApi = {
-	getInstagramMedia( params: InstagramMediaParams = {} ): Promise< InstagramMediaResponse > {
+	getInstagramMedia(
+		params: InstagramMediaParams = {}
+	): Promise< InstagramMediaResponse > {
 		const query = new URLSearchParams( {
 			action: params.action || 'list',
 			...( params.media_id ? { media_id: params.media_id } : {} ),
@@ -95,10 +99,15 @@ export const studioSocialsApi = {
 			...( params.after ? { after: params.after } : {} ),
 		} );
 
-		return apiFetch( { path: `/datamachine/v1/socials/instagram/media?${ query.toString() }` } );
+		return apiFetch( {
+			path: `/datamachine/v1/socials/instagram/media?${ query.toString() }`,
+		} );
 	},
 
-	getInstagramComments( mediaId: string, params: { limit?: number; after?: string } = {} ): Promise< InstagramCommentsResponse > {
+	getInstagramComments(
+		mediaId: string,
+		params: { limit?: number; after?: string } = {}
+	): Promise< InstagramCommentsResponse > {
 		const query = new URLSearchParams( {
 			action: 'comments',
 			media_id: mediaId,
@@ -106,10 +115,15 @@ export const studioSocialsApi = {
 			...( params.after ? { after: params.after } : {} ),
 		} );
 
-		return apiFetch( { path: `/datamachine/v1/socials/instagram/media?${ query.toString() }` } );
+		return apiFetch( {
+			path: `/datamachine/v1/socials/instagram/media?${ query.toString() }`,
+		} );
 	},
 
-	replyToInstagramComment( commentId: string, message: string ): Promise< unknown > {
+	replyToInstagramComment(
+		commentId: string,
+		message: string
+	): Promise< unknown > {
 		return apiFetch( {
 			path: '/datamachine/v1/socials/instagram/comments/reply',
 			method: 'POST',
@@ -122,20 +136,34 @@ export const studioSocialsApi = {
 
 	/**
 	 * Generic comments API — fetch all comments for a post, normalized.
+	 * @param platform
+	 * @param mediaId
 	 */
-	getAllComments( platform: string, mediaId: string ): Promise< GenericCommentsResponse > {
+	getAllComments(
+		platform: string,
+		mediaId: string
+	): Promise< GenericCommentsResponse > {
 		const query = new URLSearchParams( {
 			media_id: mediaId,
 			all: 'true',
 		} );
 
-		return apiFetch( { path: `/datamachine/v1/socials/comments/${ platform }?${ query.toString() }` } );
+		return apiFetch( {
+			path: `/datamachine/v1/socials/comments/${ platform }?${ query.toString() }`,
+		} );
 	},
 
 	/**
 	 * Generic comment reply API.
+	 * @param platform
+	 * @param commentId
+	 * @param message
 	 */
-	replyToComment( platform: string, commentId: string, message: string ): Promise< CommentReplyResponse > {
+	replyToComment(
+		platform: string,
+		commentId: string,
+		message: string
+	): Promise< CommentReplyResponse > {
 		return apiFetch( {
 			path: `/datamachine/v1/socials/comments/${ platform }/reply`,
 			method: 'POST',
@@ -164,7 +192,13 @@ export const studioSocialsApi = {
  * must tolerate a 403/401/404 and degrade gracefully rather than error.
  */
 export const studioAnalyticsApi = {
-	/** GET /extrachill/v1/analytics/summary — event counts by type over a window. */
+	/**
+	 * GET /extrachill/v1/analytics/summary — event counts by type over a window.
+	 * @param params
+	 * @param params.days
+	 * @param params.event_type
+	 * @param params.blog_id
+	 */
 	getSummary(
 		params: { days?: number; event_type?: string; blog_id?: number } = {}
 	): Promise< AnalyticsSummaryResponse > {
@@ -179,20 +213,38 @@ export const studioAnalyticsApi = {
 			query.set( 'blog_id', String( params.blog_id ) );
 		}
 		const qs = query.toString();
-		return apiFetch( { path: `/extrachill/v1/analytics/summary${ qs ? `?${ qs }` : '' }` } );
+		return apiFetch( {
+			path: `/extrachill/v1/analytics/summary${ qs ? `?${ qs }` : '' }`,
+		} );
 	},
 
-	/** GET /extrachill/v1/analytics/surface-growth — ranked cross-surface growth. */
-	getSurfaceGrowth( params: { weeks?: number } = {} ): Promise< SurfaceGrowthResponse > {
+	/**
+	 * GET /extrachill/v1/analytics/surface-growth — ranked cross-surface growth.
+	 * @param params
+	 * @param params.weeks
+	 */
+	getSurfaceGrowth(
+		params: { weeks?: number } = {}
+	): Promise< SurfaceGrowthResponse > {
 		const query = new URLSearchParams();
 		if ( params.weeks !== undefined ) {
 			query.set( 'weeks', String( params.weeks ) );
 		}
 		const qs = query.toString();
-		return apiFetch( { path: `/extrachill/v1/analytics/surface-growth${ qs ? `?${ qs }` : '' }` } );
+		return apiFetch( {
+			path: `/extrachill/v1/analytics/surface-growth${
+				qs ? `?${ qs }` : ''
+			}`,
+		} );
 	},
 
-	/** GET /extrachill/v1/analytics/retention — visitor return-rate + cohorts. */
+	/**
+	 * GET /extrachill/v1/analytics/retention — visitor return-rate + cohorts.
+	 * @param params
+	 * @param params.days
+	 * @param params.blog_id
+	 * @param params.cohort_weeks
+	 */
 	getRetention(
 		params: { days?: number; blog_id?: number; cohort_weeks?: number } = {}
 	): Promise< RetentionResponse > {
@@ -207,12 +259,24 @@ export const studioAnalyticsApi = {
 			query.set( 'cohort_weeks', String( params.cohort_weeks ) );
 		}
 		const qs = query.toString();
-		return apiFetch( { path: `/extrachill/v1/analytics/retention${ qs ? `?${ qs }` : '' }` } );
+		return apiFetch( {
+			path: `/extrachill/v1/analytics/retention${ qs ? `?${ qs }` : '' }`,
+		} );
 	},
 
-	/** GET /extrachill/v1/analytics/conversion-map — article -> platform reach. */
+	/**
+	 * GET /extrachill/v1/analytics/conversion-map — article -> platform reach.
+	 * @param params
+	 * @param params.days
+	 * @param params.top_articles
+	 * @param params.min_entry_sessions
+	 */
 	getConversionMap(
-		params: { days?: number; top_articles?: number; min_entry_sessions?: number } = {}
+		params: {
+			days?: number;
+			top_articles?: number;
+			min_entry_sessions?: number;
+		} = {}
 	): Promise< ConversionMapResponse > {
 		const query = new URLSearchParams();
 		if ( params.days !== undefined ) {
@@ -222,10 +286,17 @@ export const studioAnalyticsApi = {
 			query.set( 'top_articles', String( params.top_articles ) );
 		}
 		if ( params.min_entry_sessions !== undefined ) {
-			query.set( 'min_entry_sessions', String( params.min_entry_sessions ) );
+			query.set(
+				'min_entry_sessions',
+				String( params.min_entry_sessions )
+			);
 		}
 		const qs = query.toString();
-		return apiFetch( { path: `/extrachill/v1/analytics/conversion-map${ qs ? `?${ qs }` : '' }` } );
+		return apiFetch( {
+			path: `/extrachill/v1/analytics/conversion-map${
+				qs ? `?${ qs }` : ''
+			}`,
+		} );
 	},
 
 	/**
@@ -234,10 +305,18 @@ export const studioAnalyticsApi = {
 	 * Not yet team-accessible. Callers MUST catch and inspect the error: a 401/
 	 * 403 (and a 404 if the route is absent on this install) is the expected
 	 * "admins only / coming soon" path, not a failure to surface to the user.
+	 * @param params
+	 * @param params.hostname
+	 * @param params.start_date
+	 * @param params.end_date
+	 * @param params.limit
 	 */
-	getGaDateStats(
-		params: { hostname?: string; start_date: string; end_date: string; limit?: number }
-	): Promise< GaDateStatsResponse > {
+	getGaDateStats( params: {
+		hostname?: string;
+		start_date: string;
+		end_date: string;
+		limit?: number;
+	} ): Promise< GaDateStatsResponse > {
 		return apiFetch( {
 			path: '/datamachine/v1/analytics/ga',
 			method: 'POST',
@@ -246,13 +325,17 @@ export const studioAnalyticsApi = {
 				...( params.hostname ? { hostname: params.hostname } : {} ),
 				start_date: params.start_date,
 				end_date: params.end_date,
-				...( params.limit !== undefined ? { limit: params.limit } : {} ),
+				...( params.limit !== undefined
+					? { limit: params.limit }
+					: {} ),
 			},
 		} );
 	},
 };
 
-export const uploadStudioFile = async ( file: File ): Promise< SocialMediaUploadResponse > => {
+export const uploadStudioFile = async (
+	file: File
+): Promise< SocialMediaUploadResponse > => {
 	const formData = new FormData();
 	formData.append( 'file', file );
 

--- a/src/blocks/studio/app/client.ts
+++ b/src/blocks/studio/app/client.ts
@@ -2,6 +2,13 @@ import apiFetch from '@wordpress/api-fetch';
 import { ExtraChillClient } from '@extrachill/api-client';
 import { WpApiFetchTransport } from '@extrachill/api-client/wordpress';
 import type { SocialMediaUploadResponse } from '@extrachill/api-client';
+import type {
+	AnalyticsSummaryResponse,
+	ConversionMapResponse,
+	GaDateStatsResponse,
+	RetentionResponse,
+	SurfaceGrowthResponse,
+} from '../types/analytics';
 
 export const studioClient = new ExtraChillClient( new WpApiFetchTransport( apiFetch ) );
 
@@ -135,6 +142,111 @@ export const studioSocialsApi = {
 			data: {
 				comment_id: commentId,
 				message,
+			},
+		} );
+	},
+};
+
+/**
+ * Network-tab analytics reads.
+ *
+ * Mirrors the raw-`apiFetch` style of `studioSocialsApi` above — NO new fetch
+ * layer (per extrachill-studio#84, three JS API clients already coexist; we do
+ * not add a fourth). `apiFetch` injects the REST nonce globally, so these
+ * typed methods just build the query and hit the route.
+ *
+ * The four first-party routes are extrachill-api wrappers around
+ * extrachill-analytics abilities (relaxed to the team-readable tier in
+ * extrachill-analytics#95). The GA4 sessions route is Data Machine Business's
+ * generic analytics route; it is NOT yet team-accessible (depends on a DM
+ * read-only analytics cap + an Extra Chill `user_has_cap` grant still in
+ * flight — see extrachill-studio#104's permission-model comment), so its caller
+ * must tolerate a 403/401/404 and degrade gracefully rather than error.
+ */
+export const studioAnalyticsApi = {
+	/** GET /extrachill/v1/analytics/summary — event counts by type over a window. */
+	getSummary(
+		params: { days?: number; event_type?: string; blog_id?: number } = {}
+	): Promise< AnalyticsSummaryResponse > {
+		const query = new URLSearchParams();
+		if ( params.days !== undefined ) {
+			query.set( 'days', String( params.days ) );
+		}
+		if ( params.event_type ) {
+			query.set( 'event_type', params.event_type );
+		}
+		if ( params.blog_id ) {
+			query.set( 'blog_id', String( params.blog_id ) );
+		}
+		const qs = query.toString();
+		return apiFetch( { path: `/extrachill/v1/analytics/summary${ qs ? `?${ qs }` : '' }` } );
+	},
+
+	/** GET /extrachill/v1/analytics/surface-growth — ranked cross-surface growth. */
+	getSurfaceGrowth( params: { weeks?: number } = {} ): Promise< SurfaceGrowthResponse > {
+		const query = new URLSearchParams();
+		if ( params.weeks !== undefined ) {
+			query.set( 'weeks', String( params.weeks ) );
+		}
+		const qs = query.toString();
+		return apiFetch( { path: `/extrachill/v1/analytics/surface-growth${ qs ? `?${ qs }` : '' }` } );
+	},
+
+	/** GET /extrachill/v1/analytics/retention — visitor return-rate + cohorts. */
+	getRetention(
+		params: { days?: number; blog_id?: number; cohort_weeks?: number } = {}
+	): Promise< RetentionResponse > {
+		const query = new URLSearchParams();
+		if ( params.days !== undefined ) {
+			query.set( 'days', String( params.days ) );
+		}
+		if ( params.blog_id ) {
+			query.set( 'blog_id', String( params.blog_id ) );
+		}
+		if ( params.cohort_weeks !== undefined ) {
+			query.set( 'cohort_weeks', String( params.cohort_weeks ) );
+		}
+		const qs = query.toString();
+		return apiFetch( { path: `/extrachill/v1/analytics/retention${ qs ? `?${ qs }` : '' }` } );
+	},
+
+	/** GET /extrachill/v1/analytics/conversion-map — article -> platform reach. */
+	getConversionMap(
+		params: { days?: number; top_articles?: number; min_entry_sessions?: number } = {}
+	): Promise< ConversionMapResponse > {
+		const query = new URLSearchParams();
+		if ( params.days !== undefined ) {
+			query.set( 'days', String( params.days ) );
+		}
+		if ( params.top_articles !== undefined ) {
+			query.set( 'top_articles', String( params.top_articles ) );
+		}
+		if ( params.min_entry_sessions !== undefined ) {
+			query.set( 'min_entry_sessions', String( params.min_entry_sessions ) );
+		}
+		const qs = query.toString();
+		return apiFetch( { path: `/extrachill/v1/analytics/conversion-map${ qs ? `?${ qs }` : '' }` } );
+	},
+
+	/**
+	 * POST /datamachine/v1/analytics/ga (action: date_stats) — daily sessions.
+	 *
+	 * Not yet team-accessible. Callers MUST catch and inspect the error: a 401/
+	 * 403 (and a 404 if the route is absent on this install) is the expected
+	 * "admins only / coming soon" path, not a failure to surface to the user.
+	 */
+	getGaDateStats(
+		params: { hostname?: string; start_date: string; end_date: string; limit?: number }
+	): Promise< GaDateStatsResponse > {
+		return apiFetch( {
+			path: '/datamachine/v1/analytics/ga',
+			method: 'POST',
+			data: {
+				action: 'date_stats',
+				...( params.hostname ? { hostname: params.hostname } : {} ),
+				start_date: params.start_date,
+				end_date: params.end_date,
+				...( params.limit !== undefined ? { limit: params.limit } : {} ),
 			},
 		} );
 	},

--- a/src/blocks/studio/app/tabs.ts
+++ b/src/blocks/studio/app/tabs.ts
@@ -41,6 +41,15 @@ export const getStudioTabs = ( options: StudioTabOptions = {} ): StudioTab[] => 
 			label: __( 'QR Codes', 'extrachill-studio' ),
 			preview: __( 'Generate downloadable QR codes for any URL.', 'extrachill-studio' ),
 		},
+		{
+			// Visible to ALL team members — no extra feature gate. The server
+			// only emits Studio markup to team/admins, so the tab (and the
+			// team-readable analytics behind it) is inherently private.
+			id: 'network',
+			pane: 'network',
+			label: __( 'Network', 'extrachill-studio' ),
+			preview: __( 'Platform health — traffic, growth, retention, and conversion.', 'extrachill-studio' ),
+		},
 	];
 
 	return tabs.filter( ( tab ) => tab.id !== 'socials' || canBrandSocials );

--- a/src/blocks/studio/style.css
+++ b/src/blocks/studio/style.css
@@ -1022,3 +1022,74 @@ html.is-fullscreen-mode .ec-studio-compose-editor .interface-interface-skeleton_
 		border-bottom-color: var(--link-color, #0b5394);
 	}
 }
+
+
+/* ── Network tab ── */
+
+.ec-studio-network__intro {
+	margin: 0;
+	font-size: var(--font-size-body);
+	line-height: 1.6;
+}
+
+.ec-studio-network__grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+	gap: var(--spacing-md);
+	min-width: 0;
+}
+
+.ec-studio-network__card {
+	min-width: 0;
+}
+
+.ec-studio-network__card-body {
+	display: grid;
+	gap: var(--spacing-sm);
+	min-width: 0;
+}
+
+.ec-studio-network__chart-canvas {
+	position: relative;
+	width: 100%;
+	min-width: 0;
+}
+
+.ec-studio-network__chart-canvas canvas {
+	max-width: 100%;
+}
+
+.ec-studio-network__headline {
+	margin-bottom: var(--spacing-xs);
+	font-family: var(--font-family-heading);
+	font-size: var(--font-size-lg);
+}
+
+.ec-studio-network__placeholder {
+	margin: 0;
+	padding: var(--spacing-md) 0;
+	color: var(--text-color-muted, #666);
+	font-size: var(--font-size-body);
+}
+
+.ec-studio-network__status {
+	margin: var(--spacing-xs) 0 0;
+}
+
+.ec-studio-network__footnote,
+.ec-studio-network__chart-error {
+	margin: var(--spacing-xs) 0 0;
+	font-size: var(--font-size-sm);
+	color: var(--text-color-muted, #666);
+}
+
+.ec-studio-network__chart-error {
+	color: var(--color-error, #b3261e);
+}
+
+@media (max-width: 600px) {
+
+	.ec-studio-network__grid {
+		grid-template-columns: 1fr;
+	}
+}

--- a/src/blocks/studio/tabs/network/chart-canvas.tsx
+++ b/src/blocks/studio/tabs/network/chart-canvas.tsx
@@ -1,0 +1,94 @@
+/**
+ * ChartCanvas — mounts a Chart.js chart from a lazily-loaded constructor.
+ *
+ * Owns the canvas ref, async Chart.js load, instance creation, config updates,
+ * and teardown. Consumers pass a fully-formed Chart.js `configuration`; this
+ * component never knows about specific datasets — it just renders whatever
+ * config it is handed and recreates the chart when that config changes.
+ */
+import { useEffect, useRef, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import type { ReactElement } from 'react';
+import type { Chart as ChartType } from 'chart.js';
+
+import { loadChart, type ChartConfiguration } from './chart-loader';
+
+interface ChartCanvasProps {
+	/** Fully-formed Chart.js configuration (type, data, options). */
+	configuration: ChartConfiguration;
+	/** Accessible label for the chart canvas. */
+	ariaLabel?: string;
+	/** Fixed pixel height for the chart area. Defaults to 280. */
+	height?: number;
+}
+
+export const ChartCanvas = ( {
+	configuration,
+	ariaLabel,
+	height = 280,
+}: ChartCanvasProps ): ReactElement => {
+	const canvasRef = useRef< HTMLCanvasElement | null >( null );
+	const chartRef = useRef< ChartType | null >( null );
+	const [ loadError, setLoadError ] = useState( '' );
+
+	useEffect( () => {
+		let cancelled = false;
+
+		loadChart()
+			.then( ( Chart ) => {
+				if ( cancelled || ! canvasRef.current ) {
+					return;
+				}
+
+				// Recreate from scratch on config change — simplest correct
+				// lifecycle for a low-frequency dashboard (no animation churn).
+				if ( chartRef.current ) {
+					chartRef.current.destroy();
+					chartRef.current = null;
+				}
+
+				chartRef.current = new Chart(
+					canvasRef.current,
+					configuration
+				);
+			} )
+			.catch( ( error: unknown ) => {
+				if ( ! cancelled ) {
+					setLoadError(
+						( error as Error )?.message ||
+							__(
+								'Could not load the charting library.',
+								'extrachill-studio'
+							)
+					);
+				}
+			} );
+
+		return () => {
+			cancelled = true;
+			if ( chartRef.current ) {
+				chartRef.current.destroy();
+				chartRef.current = null;
+			}
+		};
+	}, [ configuration ] );
+
+	if ( loadError ) {
+		return (
+			<p className="ec-studio-network__chart-error" role="alert">
+				{ loadError }
+			</p>
+		);
+	}
+
+	return (
+		<div
+			className="ec-studio-network__chart-canvas"
+			style={ { height: `${ height }px` } }
+		>
+			<canvas ref={ canvasRef } aria-label={ ariaLabel } role="img" />
+		</div>
+	);
+};
+
+export default ChartCanvas;

--- a/src/blocks/studio/tabs/network/chart-card.tsx
+++ b/src/blocks/studio/tabs/network/chart-card.tsx
@@ -1,0 +1,123 @@
+/**
+ * ChartCard — a titled panel that renders one of the standard analytics states.
+ *
+ * Every Network-tab chart shares the same state machine:
+ *   loading          → fetch in flight
+ *   error            → the fetch failed (real, surfaceable failure)
+ *   notInstrumented  → the analytics layer returned a coverage gap (measured:
+ *                      false / not_instrumented). NOT a zero — render the gap
+ *                      reason rather than a misleading empty/zero chart.
+ *   empty            → fetch succeeded but there is genuinely nothing to show
+ *   default          → render children (the chart)
+ *
+ * Keeping the convention in one component means each chart only decides WHICH
+ * state it is in; the presentation stays consistent across all four charts.
+ */
+import { __ } from '@wordpress/i18n';
+import type { ReactElement, ReactNode } from 'react';
+import { InlineStatus, Panel, PanelHeader } from '@extrachill/components';
+
+export type ChartCardState =
+	| 'loading'
+	| 'error'
+	| 'notInstrumented'
+	| 'empty'
+	| 'ready';
+
+interface ChartCardProps {
+	title: string;
+	description?: string;
+	state: ChartCardState;
+	/** Shown in the error state. */
+	errorMessage?: string;
+	/** Shown in the notInstrumented state — the analytics coverage-gap reason. */
+	notInstrumentedReason?: string;
+	/** Shown in the empty state. */
+	emptyMessage?: string;
+	/** Optional headline figure rendered above the body in the ready state. */
+	headline?: ReactNode;
+	/** The chart / table — rendered only in the ready state. */
+	children?: ReactNode;
+}
+
+export const ChartCard = ( {
+	title,
+	description,
+	state,
+	errorMessage,
+	notInstrumentedReason,
+	emptyMessage,
+	headline,
+	children,
+}: ChartCardProps ): ReactElement => {
+	const renderBody = (): ReactNode => {
+		switch ( state ) {
+			case 'loading':
+				return (
+					<p
+						className="ec-studio-network__placeholder"
+						aria-busy="true"
+					>
+						{ __( 'Loading…', 'extrachill-studio' ) }
+					</p>
+				);
+			case 'error':
+				return (
+					<InlineStatus
+						tone="error"
+						className="ec-studio-network__status"
+					>
+						{ errorMessage ||
+							__(
+								'Could not load this data. Try again shortly.',
+								'extrachill-studio'
+							) }
+					</InlineStatus>
+				);
+			case 'notInstrumented':
+				return (
+					<InlineStatus
+						tone="warning"
+						className="ec-studio-network__status"
+					>
+						{ notInstrumentedReason ||
+							__(
+								'Not instrumented yet — this dimension can’t be measured here.',
+								'extrachill-studio'
+							) }
+					</InlineStatus>
+				);
+			case 'empty':
+				return (
+					<p className="ec-studio-network__placeholder">
+						{ emptyMessage ||
+							__(
+								'No data for this window yet.',
+								'extrachill-studio'
+							) }
+					</p>
+				);
+			case 'ready':
+			default:
+				return (
+					<>
+						{ headline ? (
+							<div className="ec-studio-network__headline">
+								{ headline }
+							</div>
+						) : null }
+						{ children }
+					</>
+				);
+		}
+	};
+
+	return (
+		<Panel className="ec-studio-panel ec-studio-network__card" compact>
+			<PanelHeader title={ title } description={ description } />
+			<div className="ec-studio-network__card-body">{ renderBody() }</div>
+		</Panel>
+	);
+};
+
+export default ChartCard;

--- a/src/blocks/studio/tabs/network/chart-loader.ts
+++ b/src/blocks/studio/tabs/network/chart-loader.ts
@@ -1,0 +1,43 @@
+/**
+ * Lazy Chart.js loader.
+ *
+ * Chart.js is externalized onto the shared `extrachill-analytics-chart` handle
+ * (see ../../../../../webpack.config.js), so `import('chart.js')` resolves to
+ * the `window.ExtraChillChart` global rather than bundling a second copy. We
+ * still dynamic-`import()` it here so webpack emits the chart wiring as a
+ * code-split chunk that loads only when the Network tab actually mounts a chart
+ * — keeping it out of Studio's main view chunk and off every non-Network page.
+ *
+ * The single in-flight promise is memoized so concurrent charts share one load.
+ */
+import type { Chart as ChartType, ChartConfiguration } from 'chart.js';
+
+type ChartCtor = typeof ChartType;
+
+let chartPromise: Promise< ChartCtor > | null = null;
+
+/**
+ * Resolve the Chart.js constructor, loading the externalized module on first
+ * use. Resolves to the auto-registered Chart class from the shared handle.
+ */
+export const loadChart = (): Promise< ChartCtor > => {
+	if ( ! chartPromise ) {
+		chartPromise = import( 'chart.js' ).then( ( mod ) => {
+			// The shared handle exposes the namespace with both `Chart` and
+			// `default` pointing at the auto-registered constructor.
+			const ctor =
+				( mod as { Chart?: ChartCtor; default?: ChartCtor } ).Chart ??
+				( mod as { default?: ChartCtor } ).default;
+			if ( ! ctor ) {
+				throw new Error(
+					'Chart.js constructor unavailable on the shared analytics handle.'
+				);
+			}
+			return ctor;
+		} );
+	}
+
+	return chartPromise;
+};
+
+export type { ChartConfiguration };

--- a/src/blocks/studio/tabs/network/conversion-map-chart.tsx
+++ b/src/blocks/studio/tabs/network/conversion-map-chart.tsx
@@ -1,0 +1,137 @@
+/**
+ * Conversion map — top entry articles and the share of their visitors that
+ * reach a platform surface (events / community / artist).
+ *
+ * Reads GET /extrachill/v1/analytics/conversion-map. Rendered as a ranked table
+ * (DataTable) rather than a chart because the signal is per-article rates with
+ * labels — a table reads better than a bar here and keeps the entry-article
+ * titles legible. The overall reach rate is the headline.
+ */
+import { useEffect, useMemo, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import type { ReactElement } from 'react';
+import {
+	DataTable,
+	StatGroup,
+	StatTile,
+	type DataTableColumn,
+} from '@extrachill/components';
+
+import { studioAnalyticsApi } from '../../app/client';
+import type {
+	ConversionMapResponse,
+	ConversionRow,
+} from '../../types/analytics';
+import { ChartCard, type ChartCardState } from './chart-card';
+
+const pct = ( rate: number ): string => `${ Math.round( rate * 1000 ) / 10 }%`;
+
+interface ArticleTableRow extends Record< string, unknown > {
+	id: number;
+	title: string;
+	entry_sessions: number;
+	reached_any_rate: string;
+}
+
+export const ConversionMapChart = (): ReactElement => {
+	const [ data, setData ] = useState< ConversionMapResponse | null >( null );
+	const [ state, setState ] = useState< ChartCardState >( 'loading' );
+	const [ errorMessage, setErrorMessage ] = useState( '' );
+
+	useEffect( () => {
+		let cancelled = false;
+
+		studioAnalyticsApi
+			.getConversionMap( {
+				days: 28,
+				top_articles: 10,
+				min_entry_sessions: 1,
+			} )
+			.then( ( response ) => {
+				if ( cancelled ) {
+					return;
+				}
+				setData( response );
+				const hasArticles = ( response.by_article?.length ?? 0 ) > 0;
+				setState( hasArticles ? 'ready' : 'empty' );
+			} )
+			.catch( ( error: unknown ) => {
+				if ( cancelled ) {
+					return;
+				}
+				setErrorMessage( ( error as Error )?.message || '' );
+				setState( 'error' );
+			} );
+
+		return () => {
+			cancelled = true;
+		};
+	}, [] );
+
+	const rows = useMemo< ArticleTableRow[] >( () => {
+		const articles = data?.by_article ?? [];
+		return articles.map( ( row: ConversionRow, index ) => ( {
+			id: row.post_id ?? index,
+			title: row.title || __( '(untitled)', 'extrachill-studio' ),
+			entry_sessions: row.entry_sessions,
+			reached_any_rate: pct( row.reached_any_rate ),
+		} ) );
+	}, [ data ] );
+
+	const columns: DataTableColumn< ArticleTableRow >[] = [
+		{ key: 'title', label: __( 'Entry article', 'extrachill-studio' ) },
+		{
+			key: 'entry_sessions',
+			label: __( 'Sessions', 'extrachill-studio' ),
+			width: '90px',
+		},
+		{
+			key: 'reached_any_rate',
+			label: __( 'Reached platform', 'extrachill-studio' ),
+			width: '140px',
+		},
+	];
+
+	const headline = data ? (
+		<StatGroup>
+			<StatTile
+				value={ pct( data.overall.reached_any_rate ) }
+				label={ __( 'Overall reach to platform', 'extrachill-studio' ) }
+			/>
+			<StatTile
+				value={ data.overall.entry_sessions.toLocaleString() }
+				label={ __( 'Editorial entry sessions', 'extrachill-studio' ) }
+				tone="muted"
+			/>
+		</StatGroup>
+	) : null;
+
+	return (
+		<ChartCard
+			title={ __( 'Top content → platform', 'extrachill-studio' ) }
+			description={ __(
+				'Visitors who entered on an article and reached events, community, or artist — last 28 days.',
+				'extrachill-studio'
+			) }
+			state={ state }
+			errorMessage={ errorMessage }
+			emptyMessage={ __(
+				'No editorial-entry sessions recorded in this window yet.',
+				'extrachill-studio'
+			) }
+			headline={ headline }
+		>
+			<DataTable< ArticleTableRow >
+				columns={ columns }
+				data={ rows }
+				rowKey="id"
+				emptyMessage={ __(
+					'No ranked entry articles yet.',
+					'extrachill-studio'
+				) }
+			/>
+		</ChartCard>
+	);
+};
+
+export default ConversionMapChart;

--- a/src/blocks/studio/tabs/network/index.tsx
+++ b/src/blocks/studio/tabs/network/index.tsx
@@ -1,0 +1,88 @@
+/**
+ * Network pane — the team-facing platform-analytics dashboard.
+ *
+ * Renders four charts from the now-live analytics REST routes:
+ *   1. Sessions over time (GA4 date_stats)        — admin-only for now, degrades
+ *   2. Surface growth     (get-surface-growth)     — first-party, whole team
+ *   3. Retention          (get-retention-stats)    — first-party, whole team
+ *   4. Top content → platform (get-conversion-map) — first-party, whole team
+ *
+ * The three first-party (extrachill-analytics) charts work for the entire team
+ * today; the GA4 sessions chart gracefully degrades to an "admins / coming soon"
+ * placeholder until the read-only analytics cap + Extra Chill team grant land.
+ *
+ * While this pane is mounted it broadcasts `surface: 'network'` into the shared
+ * client-context registry at a higher priority than the tab-level `studio`
+ * surface, so Roadie's chat knows the team member is looking at network
+ * analytics — mirroring how the Compose pane layers its richer draft context on
+ * top of the generic tab broadcast.
+ */
+import { useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import type { ReactElement } from 'react';
+import {
+	getOrCreateClientContextRegistry,
+	registerClientContextProvider,
+} from '@extrachill/chat';
+
+import type { StudioPaneProps } from '../../types/studio';
+import { ConversionMapChart } from './conversion-map-chart';
+import { RetentionChart } from './retention-chart';
+import { SessionsChart } from './sessions-chart';
+import { SurfaceGrowthChart } from './surface-growth-chart';
+
+const CLIENT_CONTEXT_PROVIDER_ID = 'extrachill-studio.network';
+
+/**
+ * Resolve the current site host from the context site URL (GA query scope).
+ * @param siteUrl
+ */
+const resolveHost = ( siteUrl: string ): string => {
+	try {
+		return new URL( siteUrl ).host;
+	} catch {
+		return '';
+	}
+};
+
+const NetworkPane = ( { context }: StudioPaneProps ): ReactElement => {
+	const host = resolveHost( context.siteUrl );
+
+	// Broadcast `surface: 'network'` to Roadie while this pane is active.
+	useEffect( () => {
+		const unregister = registerClientContextProvider( {
+			id: CLIENT_CONTEXT_PROVIDER_ID,
+			priority: 50,
+			getContext: () => ( {
+				kind: 'studio-pane',
+				surface: 'network',
+				description:
+					'Team analytics dashboard: traffic, surface growth, retention, and editorial→platform conversion.',
+			} ),
+		} );
+		getOrCreateClientContextRegistry().notify();
+
+		return () => {
+			unregister();
+		};
+	}, [] );
+
+	return (
+		<div className="ec-studio-pane ec-studio-pane--network">
+			<p className="ec-studio-network__intro">
+				{ __(
+					'Platform health at a glance — first-party traffic, growth, retention, and conversion across the network.',
+					'extrachill-studio'
+				) }
+			</p>
+			<div className="ec-studio-network__grid">
+				<SessionsChart host={ host } />
+				<SurfaceGrowthChart />
+				<RetentionChart />
+				<ConversionMapChart />
+			</div>
+		</div>
+	);
+};
+
+export default NetworkPane;

--- a/src/blocks/studio/tabs/network/retention-chart.tsx
+++ b/src/blocks/studio/tabs/network/retention-chart.tsx
@@ -1,0 +1,169 @@
+/**
+ * Retention chart — weekly-cohort retention curve + headline return rate.
+ *
+ * Reads GET /extrachill/v1/analytics/retention. The headline is the overall
+ * return rate (share of visitors active on >= 2 distinct days). The chart plots
+ * per-cohort week-1 / week-2 retention so a flattening or climbing curve is
+ * visible over the cohort series.
+ */
+import { useEffect, useMemo, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import type { ReactElement } from 'react';
+import { StatGroup, StatTile } from '@extrachill/components';
+
+import { studioAnalyticsApi } from '../../app/client';
+import type { RetentionResponse } from '../../types/analytics';
+import { ChartCard, type ChartCardState } from './chart-card';
+import { ChartCanvas } from './chart-canvas';
+import type { ChartConfiguration } from './chart-loader';
+
+const pct = ( rate: number ): string => `${ Math.round( rate * 1000 ) / 10 }%`;
+
+export const RetentionChart = (): ReactElement => {
+	const [ data, setData ] = useState< RetentionResponse | null >( null );
+	const [ state, setState ] = useState< ChartCardState >( 'loading' );
+	const [ errorMessage, setErrorMessage ] = useState( '' );
+
+	useEffect( () => {
+		let cancelled = false;
+
+		studioAnalyticsApi
+			.getRetention( { days: 28, cohort_weeks: 8 } )
+			.then( ( response ) => {
+				if ( cancelled ) {
+					return;
+				}
+				setData( response );
+				// A real return-rate read with zero visitors is "empty" (no
+				// traffic accumulated yet), not an error.
+				const hasVisitors =
+					( response.return_rate?.total_visitors ?? 0 ) > 0;
+				setState( hasVisitors ? 'ready' : 'empty' );
+			} )
+			.catch( ( error: unknown ) => {
+				if ( cancelled ) {
+					return;
+				}
+				setErrorMessage( ( error as Error )?.message || '' );
+				setState( 'error' );
+			} );
+
+		return () => {
+			cancelled = true;
+		};
+	}, [] );
+
+	const configuration = useMemo< ChartConfiguration | null >( () => {
+		const cohorts = data?.cohort_retention?.cohorts ?? [];
+		if ( cohorts.length === 0 ) {
+			return null;
+		}
+
+		return {
+			type: 'line',
+			data: {
+				labels: cohorts.map( ( c ) => c.cohort_week ),
+				datasets: [
+					{
+						label: __( 'Week 1 retention', 'extrachill-studio' ),
+						data: cohorts.map(
+							( c ) => Math.round( c.retention_w1 * 1000 ) / 10
+						),
+						borderColor: 'rgba(60, 132, 206, 1)',
+						backgroundColor: 'rgba(60, 132, 206, 0.2)',
+						tension: 0.3,
+					},
+					{
+						label: __( 'Week 2 retention', 'extrachill-studio' ),
+						data: cohorts.map(
+							( c ) => Math.round( c.retention_w2 * 1000 ) / 10
+						),
+						borderColor: 'rgba(206, 96, 60, 1)',
+						backgroundColor: 'rgba(206, 96, 60, 0.2)',
+						tension: 0.3,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: false,
+				scales: {
+					y: {
+						beginAtZero: true,
+						title: {
+							display: true,
+							text: __(
+								'% of cohort retained',
+								'extrachill-studio'
+							),
+						},
+					},
+				},
+			},
+		};
+	}, [ data ] );
+
+	const headline = data ? (
+		<StatGroup>
+			<StatTile
+				value={ pct( data.return_rate.rate ) }
+				label={ __( 'Return rate', 'extrachill-studio' ) }
+			/>
+			<StatTile
+				value={ data.return_rate.returning_visitors.toLocaleString() }
+				label={ __( 'Returning visitors', 'extrachill-studio' ) }
+				tone="muted"
+			/>
+			<StatTile
+				value={ pct( data.cross_site_return.rate ) }
+				label={ __( 'Cross-site return', 'extrachill-studio' ) }
+				tone="muted"
+			/>
+		</StatGroup>
+	) : null;
+
+	const hasCohorts = ( data?.cohort_retention?.cohorts?.length ?? 0 ) > 0;
+
+	// When the return rate is real but there isn't enough weekly-cohort history
+	// to draw a curve, show a footnote instead of an empty chart area.
+	const cohortFallback =
+		! configuration && ! hasCohorts ? (
+			<p className="ec-studio-network__footnote">
+				{ __(
+					'Not enough cohort history yet to chart a retention curve.',
+					'extrachill-studio'
+				) }
+			</p>
+		) : null;
+
+	return (
+		<ChartCard
+			title={ __( 'Retention', 'extrachill-studio' ) }
+			description={ __(
+				'First-party visitor return rate and per-cohort retention, last 28 days.',
+				'extrachill-studio'
+			) }
+			state={ state }
+			errorMessage={ errorMessage }
+			emptyMessage={ __(
+				'No identified visitors in this window yet.',
+				'extrachill-studio'
+			) }
+			headline={ headline }
+		>
+			{ configuration ? (
+				<ChartCanvas
+					configuration={ configuration }
+					ariaLabel={ __(
+						'Weekly cohort retention line chart',
+						'extrachill-studio'
+					) }
+				/>
+			) : (
+				cohortFallback
+			) }
+		</ChartCard>
+	);
+};
+
+export default RetentionChart;

--- a/src/blocks/studio/tabs/network/sessions-chart.tsx
+++ b/src/blocks/studio/tabs/network/sessions-chart.tsx
@@ -1,0 +1,182 @@
+/**
+ * Sessions-over-time chart — GA4 daily sessions line.
+ *
+ * Reads POST /datamachine/v1/analytics/ga (action: date_stats). This is the ONE
+ * Network-tab chart backed by Data Machine Business's generic GA4 route, which
+ * is NOT team-accessible yet: it depends on a DM read-only analytics cap plus an
+ * Extra Chill `user_has_cap` grant still in flight (see the permission-model
+ * comment on extrachill-studio#104). Until that lands, the whole team can read
+ * the three first-party (ECA) charts, but GA4 is admin-only.
+ *
+ * So this component GRACEFULLY DEGRADES: a 401/403 (or 404 if the route is
+ * absent on this install) renders an "available to admins / coming soon"
+ * placeholder rather than an error. Only an unexpected failure surfaces as an
+ * error. This keeps the tab fully useful for the team today while the GA4
+ * permission wiring catches up.
+ */
+import { useEffect, useMemo, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import type { ReactElement } from 'react';
+
+import { studioAnalyticsApi } from '../../app/client';
+import type { GaDateStatsResponse } from '../../types/analytics';
+import { ChartCard, type ChartCardState } from './chart-card';
+import { ChartCanvas } from './chart-canvas';
+import type { ChartConfiguration } from './chart-loader';
+
+interface SessionsChartProps {
+	/** Current site host (e.g. extrachill.com) used to scope the GA query. */
+	host: string;
+}
+
+/** Extra state: GA4 not authorized for this user (the expected degrade path). */
+type SessionsState = ChartCardState | 'unauthorized';
+
+const toDate = ( daysAgo: number ): string => {
+	const d = new Date();
+	d.setUTCDate( d.getUTCDate() - daysAgo );
+	return d.toISOString().slice( 0, 10 );
+};
+
+/**
+ * HTTP statuses that mean "not allowed yet", i.e. degrade rather than error.
+ * @param error
+ */
+const isUnauthorizedError = ( error: unknown ): boolean => {
+	const status = ( error as { data?: { status?: number } } )?.data?.status;
+	const code = ( error as { code?: string } )?.code;
+	if ( status === 401 || status === 403 || status === 404 ) {
+		return true;
+	}
+	// apiFetch surfaces REST auth failures with these codes; route-absent
+	// installs surface rest_no_route. All are "not available to you yet".
+	return (
+		code === 'rest_forbidden' ||
+		code === 'rest_cookie_invalid_nonce' ||
+		code === 'rest_no_route'
+	);
+};
+
+export const SessionsChart = ( { host }: SessionsChartProps ): ReactElement => {
+	const [ data, setData ] = useState< GaDateStatsResponse | null >( null );
+	const [ state, setState ] = useState< SessionsState >( 'loading' );
+	const [ errorMessage, setErrorMessage ] = useState( '' );
+
+	useEffect( () => {
+		let cancelled = false;
+
+		studioAnalyticsApi
+			.getGaDateStats( {
+				hostname: host,
+				start_date: toDate( 28 ),
+				end_date: toDate( 1 ),
+				limit: 40,
+			} )
+			.then( ( response ) => {
+				if ( cancelled ) {
+					return;
+				}
+				if ( ! response || response.success === false ) {
+					// A structured non-success (e.g. GA unconfigured) is a
+					// coverage gap, not a hard error — treat as not-instrumented.
+					setState( 'notInstrumented' );
+					return;
+				}
+				setData( response );
+				const rows = response.results ?? [];
+				setState( rows.length > 0 ? 'ready' : 'empty' );
+			} )
+			.catch( ( error: unknown ) => {
+				if ( cancelled ) {
+					return;
+				}
+				if ( isUnauthorizedError( error ) ) {
+					setState( 'unauthorized' );
+					return;
+				}
+				setErrorMessage( ( error as Error )?.message || '' );
+				setState( 'error' );
+			} );
+
+		return () => {
+			cancelled = true;
+		};
+	}, [ host ] );
+
+	const configuration = useMemo< ChartConfiguration | null >( () => {
+		const rows = data?.results ?? [];
+		if ( rows.length === 0 ) {
+			return null;
+		}
+
+		return {
+			type: 'line',
+			data: {
+				labels: rows.map( ( r ) => String( r.date ?? '' ) ),
+				datasets: [
+					{
+						label: __( 'Sessions', 'extrachill-studio' ),
+						data: rows.map( ( r ) => Number( r.sessions ?? 0 ) ),
+						borderColor: 'rgba(60, 132, 206, 1)',
+						backgroundColor: 'rgba(60, 132, 206, 0.2)',
+						fill: true,
+						tension: 0.3,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: false,
+				plugins: { legend: { display: false } },
+				scales: { y: { beginAtZero: true } },
+			},
+		};
+	}, [ data ] );
+
+	// The graceful-degrade placeholder: GA4 is admin-only until the read-only
+	// cap + team grant land. Render an informational note, never an error.
+	if ( state === 'unauthorized' ) {
+		return (
+			<ChartCard
+				title={ __( 'Sessions over time', 'extrachill-studio' ) }
+				description={ __(
+					'GA4 daily sessions for this site.',
+					'extrachill-studio'
+				) }
+				state="notInstrumented"
+				notInstrumentedReason={ __(
+					'Sessions chart is available to admins for now — team access is coming soon once the read-only analytics permission ships.',
+					'extrachill-studio'
+				) }
+			/>
+		);
+	}
+
+	return (
+		<ChartCard
+			title={ __( 'Sessions over time', 'extrachill-studio' ) }
+			description={ __(
+				'GA4 daily sessions for this site, last 28 days.',
+				'extrachill-studio'
+			) }
+			state={ state }
+			errorMessage={ errorMessage }
+			emptyMessage={ __(
+				'No GA4 sessions returned for this window.',
+				'extrachill-studio'
+			) }
+		>
+			{ configuration ? (
+				<ChartCanvas
+					configuration={ configuration }
+					ariaLabel={ __(
+						'Daily sessions line chart',
+						'extrachill-studio'
+					) }
+				/>
+			) : null }
+		</ChartCard>
+	);
+};
+
+export default SessionsChart;

--- a/src/blocks/studio/tabs/network/surface-growth-chart.tsx
+++ b/src/blocks/studio/tabs/network/surface-growth-chart.tsx
@@ -1,0 +1,160 @@
+/**
+ * Surface growth chart — ranked horizontal bar of supply growth per surface.
+ *
+ * Reads GET /extrachill/v1/analytics/surface-growth. The cross-surface axis is
+ * supply pct-per-week (every live surface can produce it deterministically);
+ * demand (GA-derived) degrades to a coverage gap when GA is unavailable, so we
+ * rank on supply and surface the GA availability as a footnote rather than
+ * fabricating demand bars.
+ */
+import { useEffect, useMemo, useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import type { ReactElement } from 'react';
+
+import { studioAnalyticsApi } from '../../app/client';
+import type { SurfaceGrowthResponse } from '../../types/analytics';
+import { ChartCard, type ChartCardState } from './chart-card';
+import { ChartCanvas } from './chart-canvas';
+import type { ChartConfiguration } from './chart-loader';
+
+const BAR_COLOR = 'rgba(60, 132, 206, 0.75)';
+const BAR_BORDER = 'rgba(60, 132, 206, 1)';
+
+export const SurfaceGrowthChart = (): ReactElement => {
+	const [ data, setData ] = useState< SurfaceGrowthResponse | null >( null );
+	const [ state, setState ] = useState< ChartCardState >( 'loading' );
+	const [ errorMessage, setErrorMessage ] = useState( '' );
+
+	useEffect( () => {
+		let cancelled = false;
+
+		studioAnalyticsApi
+			.getSurfaceGrowth( { weeks: 4 } )
+			.then( ( response ) => {
+				if ( cancelled ) {
+					return;
+				}
+				setData( response );
+				const ranked = response.supply_ranking?.ranked ?? [];
+				setState( ranked.length > 0 ? 'ready' : 'empty' );
+			} )
+			.catch( ( error: unknown ) => {
+				if ( cancelled ) {
+					return;
+				}
+				setErrorMessage( ( error as Error )?.message || '' );
+				setState( 'error' );
+			} );
+
+		return () => {
+			cancelled = true;
+		};
+	}, [] );
+
+	const configuration = useMemo< ChartConfiguration | null >( () => {
+		const ranked = data?.supply_ranking?.ranked ?? [];
+		if ( ranked.length === 0 ) {
+			return null;
+		}
+
+		return {
+			type: 'bar',
+			data: {
+				labels: ranked.map( ( row ) => row.label ),
+				datasets: [
+					{
+						label: __(
+							'Supply growth (% / week)',
+							'extrachill-studio'
+						),
+						data: ranked.map( ( row ) => row.pct_per_week ),
+						backgroundColor: BAR_COLOR,
+						borderColor: BAR_BORDER,
+						borderWidth: 1,
+					},
+				],
+			},
+			options: {
+				indexAxis: 'y',
+				responsive: true,
+				maintainAspectRatio: false,
+				plugins: { legend: { display: false } },
+				scales: {
+					x: {
+						title: {
+							display: true,
+							text: __(
+								'% new inventory per week',
+								'extrachill-studio'
+							),
+						},
+					},
+				},
+			},
+		};
+	}, [ data ] );
+
+	const description = data
+		? sprintf(
+				/* translators: %d: number of weeks in the growth window. */
+				__(
+					'New published inventory per surface, last %d weeks. Ranked by supply growth.',
+					'extrachill-studio'
+				),
+				data.weeks
+		  )
+		: __(
+				'New published inventory per surface, ranked by supply growth.',
+				'extrachill-studio'
+		  );
+
+	const fastest = data?.fastest_growing;
+	const headline =
+		fastest && fastest.surface
+			? sprintf(
+					/* translators: 1: surface label, 2: percent per week. */
+					__(
+						'Fastest growing: %1$s (+%2$s%% / wk)',
+						'extrachill-studio'
+					),
+					fastest.label ?? fastest.surface,
+					String( fastest.pct_per_week ?? 0 )
+			  )
+			: null;
+
+	return (
+		<ChartCard
+			title={ __( 'Surface growth', 'extrachill-studio' ) }
+			description={ description }
+			state={ state }
+			errorMessage={ errorMessage }
+			emptyMessage={ __(
+				'No surface produced a comparable growth figure yet.',
+				'extrachill-studio'
+			) }
+			headline={ headline }
+		>
+			{ configuration ? (
+				<>
+					<ChartCanvas
+						configuration={ configuration }
+						ariaLabel={ __(
+							'Surface growth ranked bar chart',
+							'extrachill-studio'
+						) }
+					/>
+					{ data && ! data.ga_available ? (
+						<p className="ec-studio-network__footnote">
+							{ __(
+								'Demand (GA sessions) not instrumented on this install — ranking is supply-based.',
+								'extrachill-studio'
+							) }
+						</p>
+					) : null }
+				</>
+			) : null }
+		</ChartCard>
+	);
+};
+
+export default SurfaceGrowthChart;

--- a/src/blocks/studio/types/analytics.ts
+++ b/src/blocks/studio/types/analytics.ts
@@ -1,0 +1,214 @@
+/**
+ * Typed response shapes for the Network tab analytics REST routes.
+ *
+ * These mirror the ability outputs wrapped by extrachill-api's
+ * `extrachill/v1/analytics/*` routes (extrachill-analytics abilities) and the
+ * Data Machine Business GA4 route. They are intentionally partial — the Studio
+ * Network tab reads only the fields it renders, and treats the rest as opaque.
+ *
+ * The analytics layer uses a `not_instrumented` coverage-gap convention: a
+ * dimension that cannot currently be measured returns `{ measured: false,
+ * not_instrumented: true, reason }` rather than a misleading zero. The
+ * `NotInstrumented` type captures that marker so chart components can render a
+ * "not instrumented" state instead of a false zero.
+ */
+
+/** Coverage-gap marker — a dimension that cannot currently be measured. */
+export interface NotInstrumented {
+	measured: false;
+	not_instrumented: true;
+	reason: string;
+}
+
+/**
+ * Narrow a measured-or-gap union to the coverage-gap marker.
+ * @param value
+ */
+export const isNotInstrumented = ( value: unknown ): value is NotInstrumented =>
+	typeof value === 'object' &&
+	value !== null &&
+	( value as { not_instrumented?: unknown } ).not_instrumented === true;
+
+/* ── GET /extrachill/v1/analytics/summary ── */
+
+export interface AnalyticsSummaryEventType {
+	event_type: string;
+	count: number;
+	daily_avg: number;
+}
+
+export interface AnalyticsSummaryResponse {
+	event_types: AnalyticsSummaryEventType[];
+	total: number;
+	days: number;
+	period: string;
+	since: string;
+	as_of: string;
+}
+
+/* ── GET /extrachill/v1/analytics/surface-growth ── */
+
+export interface SurfaceSupplyMeasured {
+	measured: true;
+	new_in_window: number;
+	prior_total: number;
+	per_week: number;
+	pct_per_week: number | null;
+	unit: string;
+	definition: string;
+}
+
+export type SurfaceSupply = SurfaceSupplyMeasured | NotInstrumented;
+
+export interface SurfaceDemandMeasured {
+	measured: true;
+	basis: string;
+	organic_share: number;
+	current_sessions: number;
+	previous_sessions: number;
+	current_organic: number;
+	previous_organic: number;
+	slope_pct: number | null;
+	pct_per_week: number | null;
+	is_new_traffic: boolean;
+	definition: string;
+}
+
+export type SurfaceDemand = SurfaceDemandMeasured | NotInstrumented;
+
+export interface SurfaceGrowthSurface {
+	surface: string;
+	label: string;
+	blog_id: number;
+	host: string;
+	supply: SurfaceSupply;
+	demand: SurfaceDemand;
+	growth_pct_per_week: number | null;
+}
+
+export interface SurfaceGrowthRankedEntry {
+	surface: string;
+	label: string;
+	pct_per_week: number;
+}
+
+export interface SurfaceGrowthRanking {
+	ranked: SurfaceGrowthRankedEntry[];
+	unranked: Array< { surface: string; reason: string } >;
+}
+
+export interface SurfaceGrowthResponse {
+	surfaces: SurfaceGrowthSurface[];
+	supply_ranking: SurfaceGrowthRanking;
+	demand_ranking: SurfaceGrowthRanking;
+	fastest_growing: {
+		surface: string | null;
+		label?: string;
+		axis?: string;
+		pct_per_week?: number;
+		reason?: string;
+	};
+	weeks: number;
+	days: number;
+	ga_available: boolean;
+	as_of: string;
+	note: string;
+}
+
+/* ── GET /extrachill/v1/analytics/retention ── */
+
+export interface RetentionCohort {
+	cohort_week: string;
+	cohort_size: number;
+	returned_w1: number;
+	returned_w2: number;
+	retention_w1: number;
+	retention_w2: number;
+}
+
+export interface RetentionResponse {
+	return_rate: {
+		total_visitors: number;
+		returning_visitors: number;
+		rate: number;
+		definition: string;
+	};
+	cohort_retention: {
+		cohorts: RetentionCohort[];
+		weeks: number;
+		definition: string;
+	};
+	cross_site_return: {
+		total_visitors: number;
+		cross_site_visitors: number;
+		rate: number;
+		definition: string;
+	};
+	session_depth: {
+		avg_pageviews_per_visitor_day: number;
+		max_pageviews_per_visitor_day: number;
+		definition: string;
+	};
+	days: number;
+	blog_id: number;
+	period: string;
+	as_of: string;
+	note: string;
+}
+
+/* ── GET /extrachill/v1/analytics/conversion-map ── */
+
+export interface ConversionRow {
+	entry_sessions: number;
+	reached_any: number;
+	reached_any_rate: number;
+	same_session: {
+		events: number;
+		community: number;
+		artist: number;
+		any: number;
+	};
+	return: {
+		events: number;
+		community: number;
+		artist: number;
+		any: number;
+	};
+	returned_rate: number;
+	reached_any_same_count: number;
+	reached_any_return_count: number;
+	returned_count: number;
+	/** Present on per-article rows. */
+	post_id?: number;
+	title?: string;
+	slug?: string;
+	/** Present on per-category rows. */
+	term_id?: number;
+	category?: string;
+}
+
+export interface ConversionMapResponse {
+	overall: ConversionRow;
+	by_article: ConversionRow[];
+	by_category: ConversionRow[];
+	entry_blog_id: number;
+	days: number;
+	period: string;
+	as_of: string;
+	note: string;
+}
+
+/* ── POST /datamachine/v1/analytics/ga (action: date_stats) ── */
+
+export interface GaDateStatsRow {
+	date?: string;
+	sessions?: number;
+	[ key: string ]: unknown;
+}
+
+export interface GaDateStatsResponse {
+	success: boolean;
+	results?: GaDateStatsRow[];
+	error?: string;
+	[ key: string ]: unknown;
+}

--- a/src/blocks/studio/view.ts
+++ b/src/blocks/studio/view.ts
@@ -7,6 +7,7 @@ import { mountComponent } from './app/mount';
 import { getStudioTabs } from './app/tabs';
 import type { StudioContext, StudioPaneProps } from './types/studio';
 import ComposePane from './tabs/compose';
+import NetworkPane from './tabs/network';
 import QrCodesPane from './tabs/qr-codes';
 import SocialsPane from './tabs/socials';
 import TranscribePane from './tabs/transcribe';
@@ -15,6 +16,7 @@ const ROOT_SELECTOR = '[data-ec-studio-root]';
 
 const STUDIO_PANES: Record< string, ComponentType< StudioPaneProps > > = {
 	compose: ComposePane,
+	network: NetworkPane,
 	'qr-codes': QrCodesPane,
 	socials: SocialsPane,
 	transcribe: TranscribePane,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,84 @@
+/**
+ * Webpack configuration for extrachill-studio.
+ *
+ * Extends the @wordpress/scripts default config to externalize Chart.js v4
+ * onto the shared, network-activated `extrachill-analytics-chart` script
+ * handle (registered by extrachill-analytics, see extrachill-analytics#93/#96).
+ *
+ * Why externalize instead of bundling:
+ *   extrachill-analytics is network-activated, so exactly ONE copy of Chart.js
+ *   v4 is guaranteed present on every site as `window.ExtraChillChart`. Mapping
+ *   our `chart.js` import to that global (the same way `react` maps to
+ *   `window.React` and `@wordpress/element` to `window.wp.element`) keeps a
+ *   second Chart.js copy out of the Studio bundle entirely. The default
+ *   DependencyExtractionWebpackPlugin also records the resolved handle into the
+ *   generated `*.asset.php` dependency array, so the block's view script
+ *   declares `extrachill-analytics-chart` as a dependency and WordPress loads
+ *   the shared asset before our view code runs — no manual enqueue wiring.
+ *
+ * The import is consumed lazily (dynamic `import()`) from the Network tab only,
+ * so the chart code path is a code-split chunk that loads when a team member
+ * opens the tab rather than on every Studio page load.
+ */
+const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
+const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
+
+/**
+ * The shared Chart.js script handle registered network-wide by
+ * extrachill-analytics. Consumers map their `chart.js` import to the
+ * `ExtraChillChart` global exposed by that handle.
+ */
+const CHART_HANDLE = 'extrachill-analytics-chart';
+const CHART_GLOBAL = 'ExtraChillChart';
+
+/**
+ * Resolve a webpack request to its external global. Returns undefined for
+ * anything we don't externalize so the default WordPress mapping still applies.
+ *
+ * @param {string} request The module request being resolved.
+ * @return {string|undefined} The global variable name, or undefined.
+ */
+const requestToExternal = ( request ) => {
+	if ( request === 'chart.js' || request === 'chart.js/auto' ) {
+		return CHART_GLOBAL;
+	}
+
+	return undefined;
+};
+
+/**
+ * Resolve a webpack request to the WordPress script handle that provides it.
+ * Returning the handle here makes it land in the generated `*.asset.php`
+ * dependency array so WordPress enqueues the shared asset for us.
+ *
+ * @param {string} request The module request being resolved.
+ * @return {string|undefined} The script handle, or undefined.
+ */
+const requestToHandle = ( request ) => {
+	if ( request === 'chart.js' || request === 'chart.js/auto' ) {
+		return CHART_HANDLE;
+	}
+
+	return undefined;
+};
+
+// Replace the default DependencyExtractionWebpackPlugin instance with one that
+// also knows how to map `chart.js` -> the shared analytics handle. The default
+// plugin's built-in WordPress/React mappings are preserved by delegating to
+// `defaultRequestToExternal` / `defaultRequestToHandle` for everything else.
+const plugins = defaultConfig.plugins.map( ( plugin ) => {
+	if ( plugin.constructor.name !== 'DependencyExtractionWebpackPlugin' ) {
+		return plugin;
+	}
+
+	return new DependencyExtractionWebpackPlugin( {
+		injectPolyfill: false,
+		requestToExternal,
+		requestToHandle,
+	} );
+} );
+
+module.exports = {
+	...defaultConfig,
+	plugins,
+};


### PR DESCRIPTION
## Summary

Adds a **Network** tab to the Studio SPA that renders platform-health charts from the now-live analytics REST routes. Visible to **all** team members (no extra feature gate) — the server only emits Studio markup to team/admins, so the tab and its team-readable analytics are inherently private.

Closes #104.

## Charts

Each chart is its own component with **loading / empty / error / not-instrumented** states, and respects the `not_instrumented` coverage-gap convention (renders the gap reason rather than a misleading zero).

1. **Surface growth** (`GET /extrachill/v1/analytics/surface-growth`) — ranked horizontal bar of per-surface supply growth, headline = fastest-growing surface. Ranks on supply (every live surface can produce it); when GA demand is unavailable it footnotes that rather than fabricating bars.
2. **Retention** (`GET /extrachill/v1/analytics/retention`) — weekly-cohort retention line (week-1 / week-2) plus headline return-rate / returning-visitors / cross-site-return stat tiles.
3. **Top content → platform** (`GET /extrachill/v1/analytics/conversion-map`) — ranked `DataTable` of entry articles and their reach-to-platform rate, headline = overall reach.
4. **Sessions over time** (`POST /datamachine/v1/analytics/ga`, action `date_stats`) — GA4 daily-sessions line chart. **First-party (1–3) work for the whole team today;** this one is the GA4 path.

## GA4 graceful-degrade decision

The GA route is **not team-accessible yet** — it depends on a read-only Data Machine analytics cap (data-machine#2806) plus an Extra Chill `user_has_cap` grant still in flight (see the permission-model correction comment on #104). Per layer purity, that grant lives in Extra Chill code, not DM-business.

So the sessions chart **gracefully degrades**: a `401` / `403` (or `404` if the route is absent on this install, or a `rest_no_route` / `rest_forbidden` code) renders an **"available to admins / coming soon"** placeholder instead of an error. A structured non-success (e.g. GA unconfigured) renders as not-instrumented. Only an unexpected failure surfaces as an error. The three first-party charts are the core deliverable and are fully functional for the whole team now; the GA4 chart lights up for everyone once the cap + grant land — no further Studio change required.

## Chart.js as a webpack external (not bundled)

Chart.js v4 is consumed via the shared, network-activated **`extrachill-analytics-chart`** handle (registered by extrachill-analytics#96, exposing `window.ExtraChillChart`):

- New `webpack.config.js` externalizes `chart.js` / `chart.js/auto` → `ExtraChillChart` (same mechanism as `react` → `window.React`), via a configured `DependencyExtractionWebpackPlugin` (`requestToExternal` + `requestToHandle`). The default WordPress/React mappings are preserved.
- `requestToHandle` records `extrachill-analytics-chart` into the generated `view.asset.php` dependency array, so WordPress enqueues the shared asset before the view script runs — no manual enqueue wiring.
- The chart code path is **dynamic-`import()`ed** (`chart-loader.ts`) so it stays out of the main view module graph.

**Verified:** `build/blocks/studio/view.js` contains only `external "ExtraChillChart"` — no Chart.js library internals (`BarController`, `_adapters`, `registerables`) are bundled anywhere in `build/`. `view.asset.php` deps now include `extrachill-analytics-chart`.

> Note on lazy-loading vs. the static asset dependency: declaring the handle in `asset.php` (as the issue's "block's script dependencies" instruction specifies) means WordPress loads the shared handle on any Studio page, not strictly on tab-open. The handle is `register`ed (not unconditionally enqueued) and is a single shared network asset, so this is the idiomatic WP wiring; the chart *component* code path remains dynamic-imported. If strictly-on-open loading is preferred later, we can drop the static dep and load the handle on demand.

## No new JS API client

Per #84 (three coexisting clients already), **no 4th client** — a `studioAnalyticsApi` module added to `app/client.ts` mirrors the existing `studioSocialsApi` raw-`apiFetch` style. `apiFetch` injects the REST nonce globally. Response shapes typed in `types/analytics.ts`.

## Roadie context

`NetworkPane` registers a higher-priority client-context provider broadcasting `surface: 'network'` while active (mirroring the Compose pane's richer-context layering on top of the generic tab broadcast).

## Verification

- `npm run build` — compiles successfully; Chart.js externalized, not bundled (checked).
- `npm run typecheck` (`tsc --noEmit`) — clean.
- `wp-scripts lint-js` on all new files (`tabs/network/*`, `types/analytics.ts`) — clean. Pre-existing prettier/jsdoc debt in already-failing files (`view.ts`, `app/tabs.ts`, `app/client.ts`) is untouched-in-kind (matches the file's established style; tracked by #66/#84) — no new issue types added in changed files.
- `wp-scripts lint-style` — new CSS adds **zero** new errors (6 pre-existing → 6).
- No PHP changed.