### PR TITLE
fix: make Studio compose born-on-main robust against silent local writes (#106)

### DIFF
--- a/inc/compose/rest.php
+++ b/inc/compose/rest.php
@@ -174,6 +174,97 @@ function ec_studio_compose_register_routes(): void {
 add_action( 'rest_api_init', 'ec_studio_compose_register_routes' );
 
 /**
+ * Header the compose editor attaches to every write it originates, so the
+ * apiFetch middleware rewrites it onto the compose proxy (→ main). Its
+ * presence on a LOCAL core `/wp/v2/posts|media` write means the client-side
+ * rewrite missed — see {@link ec_studio_compose_block_stranded_local_writes}.
+ * Kept in sync with COMPOSE_MARKER_HEADER in cross-site-middleware.ts.
+ */
+const EC_STUDIO_COMPOSE_MARKER_HEADER = 'X-EC-Studio-Compose';
+
+/**
+ * Server-side backstop: never let a compose-originated write land on the
+ * Studio subsite.
+ *
+ * Born-on-main was previously enforced ONLY in the browser (a racy apiFetch
+ * middleware). When the rewrite missed, the write hit Studio-local
+ * `/wp/v2/posts|media` and silently created the post/attachment on blog 12 —
+ * exactly the stranded submission of #106, undetectable because nothing on the
+ * server objected.
+ *
+ * This guard closes that hole. The compose editor tags every write it
+ * originates with the `X-EC-Studio-Compose` header. A correctly-rewritten
+ * request reaches the compose PROXY route (`/extrachill/v1/studio/compose/*`)
+ * and is forwarded to main; it never carries this header into a core
+ * `/wp/v2/*` route. So a core `/wp/v2/posts` or `/wp/v2/media` WRITE that
+ * arrives on the Studio subsite CARRYING this marker is a proven routing miss:
+ * we reject it with a clear error the client surfaces, instead of silently
+ * committing to blog 12. A compose write is therefore provably on main or it
+ * fails loudly — it can never silently strand again.
+ *
+ * Scope is deliberately narrow so legitimate Studio-local writes are never
+ * touched:
+ *   - Only runs on the Studio subsite (never on main).
+ *   - Only WRITE methods (POST/PUT/PATCH) to the core posts/media collections
+ *     and single-item routes.
+ *   - Only when the compose marker header is present. Socials' local drafts
+ *     carry the `X-EC-Studio-Local` marker and never the compose one, so they
+ *     pass straight through.
+ *
+ * @since 0.20.1
+ *
+ * @param mixed            $result  Pre-dispatch short-circuit (null to continue).
+ * @param \WP_REST_Server  $server  REST server instance.
+ * @param \WP_REST_Request $request The request being dispatched.
+ * @return mixed Null to continue dispatch, or a WP_Error to reject.
+ */
+function ec_studio_compose_block_stranded_local_writes( $result, $server, $request ) {
+	// Already short-circuited by another handler — don't interfere.
+	if ( null !== $result ) {
+		return $result;
+	}
+
+	// Only guard the Studio subsite. On main these routes are the correct
+	// destination, so the marker (which the proxy strips anyway) is harmless.
+	if ( function_exists( 'ec_get_blog_id' ) ) {
+		$main_blog_id = (int) ec_get_blog_id( 'main' );
+		if ( $main_blog_id > 0 && (int) get_current_blog_id() === $main_blog_id ) {
+			return $result;
+		}
+	}
+
+	// Only writes can strand content; reads are harmless.
+	$method = strtoupper( (string) $request->get_method() );
+	if ( ! in_array( $method, array( 'POST', 'PUT', 'PATCH' ), true ) ) {
+		return $result;
+	}
+
+	// Only a compose-originated request should ever carry this marker.
+	if ( '' === (string) $request->get_header( EC_STUDIO_COMPOSE_MARKER_HEADER ) ) {
+		return $result;
+	}
+
+	// Only the core posts/media routes strand content on blog 12. Match the
+	// collection and single-item routes; the compose proxy routes are a
+	// different namespace and never reach here.
+	$route                  = (string) $request->get_route();
+	$is_core_posts_or_media = (bool) preg_match(
+		'#^/wp/v2/(posts|media)(/\d+)?(/autosaves)?$#',
+		$route
+	);
+	if ( ! $is_core_posts_or_media ) {
+		return $result;
+	}
+
+	return new \WP_Error(
+		'ec_studio_compose_stranded_local_write',
+		__( 'This post must be created on the main site, but the request was routed to Studio. Nothing was saved. Please reload the Compose tab and try again — if it keeps happening, contact an admin.', 'extrachill-studio' ),
+		array( 'status' => 409 )
+	);
+}
+add_filter( 'rest_pre_dispatch', 'ec_studio_compose_block_stranded_local_writes', 10, 3 );
+
+/**
  * Permission check for the compose proxy routes.
  *
  * Mirrors the team-gating used by the compose editor surface itself
@@ -317,6 +408,13 @@ function ec_studio_compose_create_post( \WP_REST_Request $request ) {
 		)
 	);
 
+	// Stamp Studio-submission provenance meta on the main-site post. This is
+	// the detectability half of the born-on-main guarantee (#106): every
+	// compose-created post carries an identifying marker on main, so a
+	// submission that SHOULD be on main but is missing it (stranded on blog 12)
+	// becomes observable instead of silent.
+	ec_studio_compose_stamp_origin_meta( $response, $user_id );
+
 	// On a successful create, emit a draft-created or submitted-for-review
 	// event (extrachill-users#127 shared contract). A brand-new compose post
 	// defaults to draft when status is omitted.
@@ -361,6 +459,12 @@ function ec_studio_compose_update_post( \WP_REST_Request $request ) {
 			'user_id' => $user_id,
 		)
 	);
+
+	// Ensure the submission-provenance meta is present on main. Idempotent:
+	// a compose post created before this marker existed, or one whose create
+	// stamp somehow did not land, is back-filled here on its next compose
+	// write (e.g. Submit-for-Review). See #106.
+	ec_studio_compose_stamp_origin_meta( $response, $user_id );
 
 	// On a successful update, emit submitted-for-review when the writer
 	// transitions the post to pending (extrachill-users#127 shared contract).
@@ -423,6 +527,91 @@ function ec_studio_compose_emit_lifecycle_event( $response, string $status, int 
 			$user_id,
 			array( 'post_id' => $post_id )
 		);
+	}
+}
+
+/**
+ * Post-meta key stamped on a main-site post created via the Studio compose
+ * proxy. Value is an array: { user_id, submitted_at (ISO-8601 UTC), source }.
+ */
+const EC_STUDIO_SUBMISSION_META = '_ec_studio_submission';
+
+/**
+ * Post-meta key recording the blog id the compose write originated from
+ * (always the Studio subsite). Aids detecting a stranded/mis-homed submission.
+ */
+const EC_STUDIO_ORIGIN_BLOG_META = '_ec_studio_origin_blog';
+
+/**
+ * Stamp Studio-submission provenance meta on the MAIN-site post.
+ *
+ * The born-on-main guarantee (#106) needs more than routing — it needs
+ * *provenance* and *detectability*. Every post the compose proxy writes gets
+ * an identifying marker on main so that:
+ *   - editors/tools can query for Studio submissions, and
+ *   - a submission that should be on main but is missing the marker (i.e.
+ *     stranded on the Studio subsite) is observable instead of silent.
+ *
+ * The marker is server-authored provenance, not user input, and is set
+ * directly under `switch_to_blog( main )` via update_post_meta — it does NOT
+ * rely on the main-site post type registering these keys for REST, so it works
+ * regardless of which plugins are active on main. Idempotent: `submitted_at`
+ * is only written once (first stamp wins) so re-stamping on a later update
+ * does not rewrite the original submission time; `source` and origin-blog are
+ * refreshed harmlessly.
+ *
+ * No-op when the cross-site write errored or returned no post id.
+ *
+ * @since 0.20.1
+ *
+ * @param array|\WP_Error $response Cross-site write result.
+ * @param int             $user_id  Acting/subject user id.
+ * @return void
+ */
+function ec_studio_compose_stamp_origin_meta( $response, int $user_id ): void {
+	if ( is_wp_error( $response ) ) {
+		return;
+	}
+
+	// After the WP_Error guard, a successful cross-site write is an array.
+	$post_id = isset( $response['id'] ) ? (int) $response['id'] : 0;
+	if ( $post_id <= 0 ) {
+		return;
+	}
+
+	if ( ! function_exists( 'ec_get_blog_id' ) ) {
+		return;
+	}
+
+	$main_blog_id = (int) ec_get_blog_id( 'main' );
+	if ( $main_blog_id <= 0 ) {
+		return;
+	}
+
+	$origin_blog_id = (int) get_current_blog_id();
+
+	switch_to_blog( $main_blog_id );
+	try {
+		$existing = get_post_meta( $post_id, EC_STUDIO_SUBMISSION_META, true );
+
+		// Preserve the original submitted_at on re-stamp (first stamp wins).
+		$submitted_at = is_array( $existing ) && ! empty( $existing['submitted_at'] )
+			? (string) $existing['submitted_at']
+			: gmdate( 'c' );
+
+		update_post_meta(
+			$post_id,
+			EC_STUDIO_SUBMISSION_META,
+			array(
+				'user_id'      => $user_id,
+				'submitted_at' => $submitted_at,
+				'source'       => 'studio-compose',
+			)
+		);
+
+		update_post_meta( $post_id, EC_STUDIO_ORIGIN_BLOG_META, $origin_blog_id );
+	} finally {
+		restore_current_blog();
 	}
 }
 

--- a/src/blocks/studio/tabs/compose/cross-site-middleware.ts
+++ b/src/blocks/studio/tabs/compose/cross-site-middleware.ts
@@ -20,16 +20,57 @@
  * land in main's media library — not Studio's — avoiding the cross-site
  * attachment migration problem.
  *
- * Scope — this matters: apiFetch is a single global, shared by every Studio
- * tab. The rewrite must apply ONLY while the Compose pane is active, because
- * other tabs legitimately hit the same core routes against the LOCAL Studio
- * site (e.g. the Socials tab POSTs `/wp/v2/posts` to create a Studio-local
- * social draft). So the middleware is registered once but stays INERT until
- * the Compose pane activates it on mount, and deactivates it on unmount. When
- * inactive it passes every request through untouched. Even when active it only
- * rewrites the specific compose routes below; all other traffic (core editor
- * bootstrap preloads, taxonomies, user lookups) passes through so the editor
- * still boots against the local Studio site.
+ * ## Why this is NOT gated by a lifecycle-toggled global (regression #106)
+ *
+ * The original implementation gated the rewrite on a module-level `active`
+ * boolean that the Compose pane flipped `true` on React mount and `false` on
+ * unmount. That was racy: any compose write (autosave, media upload, or the
+ * final Submit-for-Review) that dispatched while the flag was `false` — before
+ * the mount effect ran, or after the unmount cleared it — silently escaped to
+ * Studio-local `/wp/v2/posts|media` and landed on blog 12. With a real
+ * submission (69 uploads + autosaves + a submit) the odds of *something*
+ * firing outside the window were high; a stranded post + 69 attachments on
+ * blog 12 is exactly what happened (#106).
+ *
+ * The gate is now split into two race-free mechanisms, either of which forces
+ * a rewrite:
+ *
+ *   1. **Explicit per-request marker.** The Compose pane tags every request it
+ *      originates (autosave, submit, save-draft, draft load, content refetch)
+ *      with an `X-EC-Studio-Compose` header (see {@link markComposeRequest}).
+ *      A marked request is ALWAYS rewritten — the routing decision is attached
+ *      to the request itself, so there is no timing window at all.
+ *
+ *   2. **Live-instance reference count.** The block editor's OWN internal calls
+ *      (core autosave store writes, `uploadMedia()` uploads) are made by core,
+ *      not the Compose pane, so we cannot mark them at their call site. Instead
+ *      the Compose pane registers a live editor instance for its entire
+ *      lifetime ({@link registerComposeInstance}). While at least one compose
+ *      instance is live, compose-route traffic rewrites by default.
+ *
+ * The routing decision is made by apiFetch middleware at DISPATCH time, not at
+ * completion — so a request that is still in-flight when the pane unmounts was
+ * already rewritten when it was created. The only escape the old boolean had
+ * (a compose write dispatching while the flag read `false`) cannot occur here:
+ * compose writes only originate while an instance is live (refcount ≥ 1), and
+ * the marker forces a rewrite independently of the count.
+ *
+ * ## Preserving Socials' LOCAL writes
+ *
+ * apiFetch is a single global shared by every Studio tab, and the Socials tab
+ * legitimately POSTs `/wp/v2/posts` to the LOCAL Studio site to create a
+ * Studio-local social draft. Because the refcount defaults compose routes to
+ * "rewrite" while a compose instance is live, Socials must OPT OUT explicitly:
+ * it tags its local writes with `X-EC-Studio-Local` (see
+ * {@link markLocalRequest}). A locally-marked request is NEVER rewritten,
+ * regardless of the refcount — so Socials always reaches blog 12 even when the
+ * Compose pane is mounted in a background tab. This is deterministic: the two
+ * markers are mutually exclusive and each is attached at the originating call
+ * site, so no shared mutable timing state decides where a write lands.
+ *
+ * Non-compose routes (core editor bootstrap preloads, taxonomies, user
+ * lookups) are never matched by {@link rewritePath} and always pass through so
+ * the editor still boots against the local Studio site.
  */
 
 import apiFetch from '@wordpress/api-fetch';
@@ -38,14 +79,90 @@ import type { APIFetchMiddleware, APIFetchOptions } from '@wordpress/api-fetch';
 /** Studio-local proxy route prefix that forwards to main. */
 const PROXY_PREFIX = '/extrachill/v1/studio/compose';
 
+/**
+ * Request header a Compose-pane call attaches to force a rewrite to main.
+ * Set via {@link markComposeRequest} on every apiFetch the pane originates.
+ */
+export const COMPOSE_MARKER_HEADER = 'X-EC-Studio-Compose';
+
+/**
+ * Request header a caller attaches to force a LOCAL (Studio blog 12) write,
+ * opting out of the compose rewrite even while a compose instance is live.
+ * Set via {@link markLocalRequest} — used by the Socials tab.
+ */
+export const LOCAL_MARKER_HEADER = 'X-EC-Studio-Local';
+
 /** Whether the middleware has been registered with apiFetch (once per page). */
 let registered = false;
 
 /**
- * Whether rewriting is currently active. Gated to the Compose pane's lifetime
- * so other Studio tabs' core-route calls reach the local Studio site.
+ * Number of live Compose editor instances. While > 0, compose-route traffic
+ * rewrites to main by default (unless the request opts out with the local
+ * marker). A reference count — not a lifecycle boolean — so overlapping
+ * mounts/unmounts (React strict-mode double-invoke, tab churn) can never leave
+ * the gate stuck open or closed.
  */
-let active = false;
+let liveInstances = 0;
+
+/**
+ * Read a header value from apiFetch options case-insensitively.
+ *
+ * @param options apiFetch options.
+ * @param name    Header name to look up.
+ * @return The header value, or undefined when absent.
+ */
+function readHeader( options: APIFetchOptions, name: string ): string | undefined {
+	const headers = options.headers;
+	if ( ! headers || typeof headers !== 'object' ) {
+		return undefined;
+	}
+	const wanted = name.toLowerCase();
+	for ( const key of Object.keys( headers as Record< string, string > ) ) {
+		if ( key.toLowerCase() === wanted ) {
+			return ( headers as Record< string, string > )[ key ];
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Attach the compose marker header to apiFetch options.
+ *
+ * Every request the Compose pane originates should be wrapped with this so it
+ * is ALWAYS rewritten to main, independent of the live-instance count.
+ *
+ * @param options apiFetch options.
+ * @return New options with the compose marker header set.
+ */
+export function markComposeRequest< T extends APIFetchOptions >( options: T ): T {
+	return {
+		...options,
+		headers: {
+			...( options.headers as Record< string, string > | undefined ),
+			[ COMPOSE_MARKER_HEADER ]: '1',
+		},
+	};
+}
+
+/**
+ * Attach the local marker header to apiFetch options.
+ *
+ * Callers that must write to the LOCAL Studio site (blog 12) even while a
+ * Compose instance is live — e.g. the Socials tab creating a social draft —
+ * wrap their options with this so the middleware never rewrites them.
+ *
+ * @param options apiFetch options.
+ * @return New options with the local marker header set.
+ */
+export function markLocalRequest< T extends APIFetchOptions >( options: T ): T {
+	return {
+		...options,
+		headers: {
+			...( options.headers as Record< string, string > | undefined ),
+			[ LOCAL_MARKER_HEADER ]: '1',
+		},
+	};
+}
 
 /**
  * Split an apiFetch path into its route and query-string parts.
@@ -114,11 +231,37 @@ function rewritePath( path: string ): string | null {
 }
 
 /**
+ * Decide whether a given apiFetch request should be rewritten to main.
+ *
+ * Rewrite when EITHER:
+ *   - the request carries the compose marker (pane-originated call), OR
+ *   - at least one Compose instance is live (covers the block editor's own
+ *     internal autosave/upload calls, which we cannot mark at their source).
+ *
+ * Never rewrite when the request carries the local marker — that is an
+ * explicit opt-out (Socials) that must reach blog 12 even while Compose is
+ * mounted. The local marker wins over the live-instance default, so the two
+ * tabs never fight over a shared boolean.
+ *
+ * @param options apiFetch options for the request.
+ * @return True when the request should be rewritten to main.
+ */
+function shouldRewrite( options: APIFetchOptions ): boolean {
+	if ( readHeader( options, LOCAL_MARKER_HEADER ) ) {
+		return false;
+	}
+	if ( readHeader( options, COMPOSE_MARKER_HEADER ) ) {
+		return true;
+	}
+	return liveInstances > 0;
+}
+
+/**
  * Register the cross-site compose apiFetch middleware (idempotent).
  *
  * Registers the rewrite middleware with apiFetch exactly once per page. The
- * middleware is INERT until {@link setComposeCrossSiteActive} turns it on, so
- * registering it has no effect on other tabs' requests.
+ * middleware only rewrites when {@link shouldRewrite} says so, so registering
+ * it has no effect on other tabs' unmarked, no-instance-live requests.
  */
 function registerMiddlewareOnce(): void {
 	if ( registered ) {
@@ -127,7 +270,7 @@ function registerMiddlewareOnce(): void {
 	registered = true;
 
 	const middleware: APIFetchMiddleware = ( options: APIFetchOptions, next ) => {
-		if ( ! active ) {
+		if ( ! shouldRewrite( options ) ) {
 			return next( options );
 		}
 
@@ -146,16 +289,30 @@ function registerMiddlewareOnce(): void {
 }
 
 /**
- * Turn cross-site rewriting on or off.
+ * Register a live Compose editor instance.
  *
- * The Compose pane calls this with `true` on mount and `false` on unmount so
- * the rewrite only applies while the writer is in the Blog tab. Registering
- * the middleware lazily here keeps the whole mechanism dormant until Compose
- * is actually used.
+ * The Compose pane calls this once, synchronously, from its first mount effect
+ * — before the block editor is created and before any compose request can
+ * dispatch — and calls the returned disposer on unmount. While the count is
+ * above zero, the block editor's own internal `/wp/v2/posts|media` calls are
+ * rewritten to main. Reference-counted so overlapping instances (or React
+ * strict-mode's double-invoke) can never leave the gate stuck.
  *
- * @param next Whether rewriting should be active.
+ * Registering the middleware lazily here keeps the whole mechanism dormant
+ * until Compose is actually used.
+ *
+ * @return A disposer that decrements the live-instance count.
  */
-export function setComposeCrossSiteActive( next: boolean ): void {
+export function registerComposeInstance(): () => void {
 	registerMiddlewareOnce();
-	active = next;
+	liveInstances += 1;
+
+	let disposed = false;
+	return () => {
+		if ( disposed ) {
+			return;
+		}
+		disposed = true;
+		liveInstances = Math.max( 0, liveInstances - 1 );
+	};
 }

--- a/src/blocks/studio/tabs/compose/index.ts
+++ b/src/blocks/studio/tabs/compose/index.ts
@@ -9,8 +9,19 @@ import {
 } from '@extrachill/chat';
 import { ActionRow, FieldGroup, InlineStatus, Panel, PanelHeader } from '@extrachill/components';
 import type { StudioPaneProps } from '../../types/studio';
-import { setComposeCrossSiteActive } from './cross-site-middleware';
+import { markComposeRequest, registerComposeInstance } from './cross-site-middleware';
 import { installChatRefreshAdapter } from './refresh-adapter';
+
+/**
+ * apiFetch wrapper that tags a request as Compose-pane-originated so the
+ * cross-site middleware ALWAYS rewrites it to main (blog 1), with no dependence
+ * on the live-instance count and no timing window. Every apiFetch call this
+ * pane makes goes through here so a stray call can never escape to blog 12.
+ * See cross-site-middleware.ts and Extra-Chill/extrachill-studio#106.
+ */
+const composeApiFetch = < T = unknown >(
+	options: import('@wordpress/api-fetch').APIFetchOptions< true >
+): Promise< T > => apiFetch< T >( markComposeRequest( options ) );
 
 const h = createElement as typeof import( 'react' ).createElement;
 const PanelView = Panel as unknown as ( props: any ) => ReactElement;
@@ -206,7 +217,7 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 	const fetchPostContent = useCallback(
 		async ( postId: number ): Promise< string > => {
 			try {
-				const post = await apiFetch< WpPost >( {
+				const post = await composeApiFetch< WpPost >( {
 					path: `/wp/v2/posts/${ postId }?context=edit`,
 				} );
 				return post?.content?.raw || post?.content?.rendered || '';
@@ -324,7 +335,7 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 			// the author filter rather than ship a half-broken query. In practice
 			// @wordpress/data core selector should always resolve for logged-in
 			// users on Studio (gated by team-member capability check server-side).
-			const result = await apiFetch< WpPost[] >( { path } );
+			const result = await composeApiFetch< WpPost[] >( { path } );
 			return Array.isArray( result ) ? result : [];
 		} catch {
 			return [];
@@ -381,13 +392,13 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 				// The /autosaves endpoint returns a revision object (id = revision ID, parent = post ID).
 				// Do NOT overwrite activePostIdRef with the revision ID.
 				if ( postId ) {
-					await apiFetch( {
+					await composeApiFetch( {
 						path: `/wp/v2/posts/${ postId }/autosaves`,
 						method: 'POST',
 						data: { title: currentTitle, content: currentContent },
 					} );
 				} else {
-					const post = await apiFetch< WpPost >( {
+					const post = await composeApiFetch< WpPost >( {
 						path: '/wp/v2/posts',
 						method: 'POST',
 						data: { title: currentTitle, content: currentContent, status: 'draft' },
@@ -435,7 +446,7 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 					.getCurrentUser?.();
 				const currentUserId = currentUser?.id;
 				if ( currentUserId ) {
-					const autosaves = await apiFetch< WpAutosave[] >( {
+					const autosaves = await composeApiFetch< WpAutosave[] >( {
 						path: `/wp/v2/posts/${ post.id }/autosaves?context=edit`,
 					} );
 					const userAutosave = Array.isArray( autosaves )
@@ -537,13 +548,13 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 				// The /autosaves endpoint returns a revision object (id = revision ID, parent = post ID).
 				// Do NOT overwrite activePostIdRef with the revision ID — the parent ID is stable.
 				if ( postId ) {
-					await apiFetch( {
+					await composeApiFetch( {
 						path: `/wp/v2/posts/${ postId }/autosaves`,
 						method: 'POST',
 						data: { title: currentTitle, content: currentContent },
 					} );
 				} else {
-					const post = await apiFetch< WpPost >( {
+					const post = await composeApiFetch< WpPost >( {
 						path: '/wp/v2/posts',
 						method: 'POST',
 						data: { title: currentTitle, content: currentContent, status: 'draft' },
@@ -620,15 +631,17 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 		}, AUTOSAVE_DELAY );
 	}, [ performAutosave ] );
 
-	// Activate cross-site apiFetch rewriting for the lifetime of this pane only.
-	// Declared before the draft-load/editor-mount effect so rewriting is on
-	// before the first /wp/v2/posts fetch fires. Deactivated on unmount so other
-	// Studio tabs (e.g. Socials) keep hitting the local Studio site.
+	// Register a live cross-site compose instance for the lifetime of this pane.
+	// Declared before the draft-load/editor-mount effect so the instance is
+	// live before the first /wp/v2/posts fetch — or the block editor's own
+	// internal autosave/upload calls — can fire. The disposer decrements the
+	// reference count on unmount. This covers the block editor's OWN internal
+	// calls (which we can't mark at their source); the pane's own calls are
+	// additionally tagged via composeApiFetch so they route to main even if the
+	// count were somehow zero. See Extra-Chill/extrachill-studio#106.
 	useEffect( () => {
-		setComposeCrossSiteActive( true );
-		return () => {
-			setComposeCrossSiteActive( false );
-		};
+		const dispose = registerComposeInstance();
+		return dispose;
 	}, [] );
 
 	// Bridge the chat's action-resolved event to BE's refresh-content event for
@@ -847,7 +860,7 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 		try {
 			const path = activePostId ? `/wp/v2/posts/${ activePostId }` : '/wp/v2/posts';
 
-			await apiFetch< WpPost >( {
+			await composeApiFetch< WpPost >( {
 				path,
 				method: 'POST',
 				data: {
@@ -894,7 +907,7 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 
 		try {
 			const path = activePostId ? `/wp/v2/posts/${ activePostId }` : '/wp/v2/posts';
-			const post = await apiFetch< WpPost >( {
+			const post = await composeApiFetch< WpPost >( {
 				path,
 				method: 'POST',
 				data: { title: title.trim(), content, status: 'draft' },

--- a/src/blocks/studio/tabs/socials/publish/index.ts
+++ b/src/blocks/studio/tabs/socials/publish/index.ts
@@ -7,6 +7,7 @@ import apiFetch from '@wordpress/api-fetch';
 import type { NetworkMediaItem, SocialJobPlatformResult, SocialPlatformConfig } from '@extrachill/api-client';
 import { studioClient } from '../../../app/client';
 import MediaPicker from '../media-picker';
+import { markLocalRequest } from '../../compose/cross-site-middleware';
 
 const h = createElement as typeof import( 'react' ).createElement;
 const PanelView = Panel as unknown as ( props: any ) => ReactElement;
@@ -289,7 +290,14 @@ const PlatformPublishPane = ( { slug, label, username, config }: PlatformPublish
 		setStatus( __( 'Submitting for review…', 'extrachill-studio' ) );
 
 		try {
-			const post = await apiFetch< WpPost >( {
+			// This social draft must be born on the LOCAL Studio site (blog 12),
+			// NOT rewritten to main. The compose cross-site middleware is a
+			// single apiFetch-wide global, so an active Compose instance in a
+			// background tab would otherwise capture this /wp/v2/posts write.
+			// Tag it explicitly local so it always reaches blog 12, regardless
+			// of Compose's live-instance count. See
+			// Extra-Chill/extrachill-studio#106.
+			const post = await apiFetch< WpPost >( markLocalRequest( {
 				path: '/wp/v2/posts',
 				method: 'POST',
 				data: {
@@ -303,7 +311,7 @@ const PlatformPublishPane = ( { slug, label, username, config }: PlatformPublish
 						_studio_social_media_kind: images.length > 1 ? 'carousel' : 'image',
 					},
 				},
-			} );
+			} ) );
 
 			setStatus(
 				sprintf( __( 'Draft #%d submitted for review. An admin will approve it before it goes live.', 'extrachill-studio' ), post.id )


### PR DESCRIPTION
## Root cause

Born-on-main for the Studio Compose pane was enforced **entirely in the browser** by an apiFetch middleware (`cross-site-middleware.ts`) gated on a **module-level `active` boolean** the pane flipped `true` on React mount and `false` on unmount. The rewrite from core `/wp/v2/posts|media` onto the `/extrachill/v1/studio/compose/*` proxy (which forwards to main via `ec_cross_site_rest_request('main', …)`) only happened while `active === true`.

That is racy. Any compose write — an **autosave**, a **media upload**, or the final **Submit-for-Review** — that dispatched while the flag read `false` (before the mount effect ran, or after unmount cleared it, or an in-flight request completing during teardown) **silently escaped to Studio-local `/wp/v2/posts|media` → blog 12**. With a real submission (69 uploads + autosaves + a submit) the odds of *something* firing outside the window were high. There was **no server-side backstop** and **no provenance marker**, so a miss was silent and undetectable — exactly the stranded submission of #106 (Steve Hughes: post 88 + 69 attachments on blog 12).

## The three fixes (acceptance criteria)

### 1. Deterministic client routing — no racy global
The `active` boolean is gone. Routing is now decided by two race-free mechanisms, either of which forces a rewrite:

- **Explicit per-request marker.** The compose pane tags **every** request it originates (autosave, submit, save-draft, draft load, content refetch) with an `X-EC-Studio-Compose` header via a `composeApiFetch` wrapper. A marked request is **always** rewritten — the decision travels with the request, so there is no timing window.
- **Live-instance reference count.** The block editor's OWN internal calls (core autosave store writes, `uploadMedia()` uploads) are made by core and can't be marked at their call site, so the pane registers a live editor instance for its entire lifetime (`registerComposeInstance`, set synchronously in the first effect before the editor is even created). While ≥ 1 instance is live, compose-route traffic rewrites by default. It's a reference count, not a lifecycle boolean, so overlapping mounts/strict-mode double-invoke can't leave the gate stuck.

The routing decision is made by apiFetch middleware at **dispatch** time, not completion — so a request still in-flight at unmount was already rewritten when created. The one escape the old boolean had (a compose write dispatching while the flag read `false`) can't occur: compose writes only originate while an instance is live, and the marker forces a rewrite independently of the count.

**Autosave + Submit-for-Review + all media uploads are covered:** the pane's own autosave/submit/save calls carry the marker; the block editor's inline `uploadMedia()` and core autosave calls are covered by the live-instance refcount. The `pagehide` `sendBeacon` unload path already hardcoded the proxy route (unchanged).

### 2. Provenance meta on main
Every compose create/submit stamps identifying meta on the **main-site** post:
- `_ec_studio_submission` = `{ user_id, submitted_at (ISO-8601 UTC, first-stamp-wins), source: 'studio-compose' }`
- `_ec_studio_origin_blog` = originating blog id

Set **server-side** under `switch_to_blog( main )` via `update_post_meta` after a successful cross-site create/update — chosen over passing `meta` in the REST body because it does **not** depend on the main site registering these keys for REST (works regardless of which plugins are active on main), and because it's server-authored provenance, not user input. Idempotent: re-stamping on a later update back-fills a missing marker and preserves the original `submitted_at`. A submission that *should* be on main but is missing the marker (stranded on blog 12) is now **observable** instead of silent.

### 3. Server-side backstop against silent local writes
A new `rest_pre_dispatch` guard (`ec_studio_compose_block_stranded_local_writes`) rejects, with a **409 the client surfaces**, any core `/wp/v2/posts|media` **WRITE** that arrives on the **Studio subsite** carrying the `X-EC-Studio-Compose` marker. A correctly-rewritten request reaches the proxy namespace and never carries the marker into a `/wp/v2/*` route, so such a request is a proven routing miss. A compose write is therefore **provably on main or it fails loudly** — it can never silently strand again. Scope is deliberately narrow (writes only, Studio subsite only, marker present only, core posts/media routes only) so legitimate Studio-local writes are untouched.

### Preserving Socials-local behavior
The Socials tab legitimately POSTs `/wp/v2/posts` to the **local** Studio site (blog 12). Because compose routes now rewrite by default while an instance is live, Socials opts **out** explicitly by tagging its publish call with `X-EC-Studio-Local` (`markLocalRequest`). A locally-marked request is never rewritten and never guarded, so Socials always reaches blog 12 even with Compose mounted in a background tab. The two markers are mutually exclusive and each is attached at the originating call site — no shared mutable state decides where a write lands.

## Race proof
- **Fires at mount:** the live-instance refcount is incremented synchronously in the first `useEffect`, before the editor is created and before any request can dispatch; the pane's own calls also carry the marker. → routed to main.
- **Fires during editing:** marker on pane calls; refcount ≥ 1 for editor-internal calls. → routed to main.
- **Fires at/after unmount:** middleware decided routing at dispatch, so any in-flight request was already rewritten; a genuinely late core call while refcount is 0 that reached blog 12 would be a marker-less core call — but core calls only originate while the instance is live (refcount ≥ 1). If a *compose-marked* call somehow reached blog 12, the server guard rejects it (no silent strand). → routed to main or hard-fails.

## What I rebuilt / verified
- `npm run typecheck` — clean.
- `npm run build` — succeeds; confirmed both marker headers compile into `build/blocks/studio/view.js`. (`build/` is gitignored and produced at release time, so it is not committed.)
- `php -l inc/compose/rest.php` — clean.
- `homeboy lint extrachill-studio --changed-only` — **eslint passes (0)** on the 3 changed TS files; the only remaining phpcs/phpstan findings are **pre-existing** (per #66) — verified each finding line via `git blame` is not from this change. Introduced **zero** new lint findings.

## Out of scope (per #106)
Post 88 and its 69 attachments stranded on blog 12 are **not** migrated here — that data cleanup is the owner's separate operation, explicitly out of scope for this code PR.

Closes #106