### PR TITLE
feat: editor-facing review queue for Studio blog submissions

### DIFF
--- a/extrachill-studio.php
+++ b/extrachill-studio.php
@@ -35,6 +35,7 @@ require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/breadcrumbs.php';
 require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/social-drafts.php';
 require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/compose-editor.php';
 require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/compose/rest.php';
+require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/review-queue.php';
 require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/abilities/resolve-instagram-media.php';
 require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/abilities/run-giveaway.php';
 require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/abilities/sweatpants-token.php';

--- a/inc/review-queue.php
+++ b/inc/review-queue.php
@@ -1,0 +1,272 @@
+<?php
+/**
+ * Studio Submission Review Queue — editor-facing pending-submission list.
+ *
+ * Compose blog submissions are BORN ON MAIN (blog 1) and land there as
+ * `pending` under the writer's authorship (see inc/compose/rest.php and
+ * Extra-Chill/extrachill-studio#106/#107). Until now nothing surfaced those
+ * pending submissions to an editor: a post that no one noticed was
+ * functionally lost — the failure that filed #109 (a real submission sat
+ * unnoticed on main because someone had to go looking for it).
+ *
+ * This page closes the editorial loop. It registers a wp-admin screen on the
+ * Studio subsite (blog 12) — where team editors already work — and queries
+ * MAIN for pending posts carrying the Studio-submission provenance marker
+ * (`_ec_studio_submission`, stamped by the compose proxy). Each row links
+ * straight to the review/edit/preview surfaces on main so an editor can pick
+ * the submission up and publish it.
+ *
+ * Why a Studio-subsite admin page (not a page ON main):
+ *   - This plugin is active only on Studio (blog 12); it is not present on
+ *     main, so it cannot register an admin menu there. The DATA is main-side,
+ *     so the page queries main via switch_to_blog + WP_Query. This mirrors the
+ *     cross-site pattern the compose proxy already uses.
+ *
+ * Distinct from #42 (SOCIALS submissions): that queue is for social drafts;
+ * this one is strictly the BLOG compose editorial queue, keyed on a different
+ * marker. The two do not collide.
+ *
+ * @package    ExtraChillStudio
+ * @subpackage ReviewQueue
+ * @since      0.20.1
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Capability required to view the review queue.
+ *
+ * Gated to editors (and above): reviewing/publishing other people's
+ * submissions is an editorial action, so plain contributors — who can submit
+ * but not review — are excluded. `edit_others_posts` is the core capability
+ * that distinguishes editors from authors/contributors.
+ */
+const EC_STUDIO_REVIEW_QUEUE_CAP = 'edit_others_posts';
+
+/**
+ * Admin page slug for the review queue.
+ */
+const EC_STUDIO_REVIEW_QUEUE_SLUG = 'ec-studio-review-queue';
+
+/**
+ * Register the review-queue admin page under the Posts menu.
+ *
+ * Placed under Posts (edit.php) rather than a dedicated top-level menu: it is
+ * a small editorial list that belongs next to the post lists an editor
+ * already uses, and it avoids adding menu chrome for a single screen.
+ *
+ * @since 0.20.1
+ *
+ * @return void
+ */
+function ec_studio_review_queue_register_page(): void {
+	add_submenu_page(
+		'edit.php',
+		__( 'Studio Submissions', 'extrachill-studio' ),
+		__( 'Studio Submissions', 'extrachill-studio' ),
+		EC_STUDIO_REVIEW_QUEUE_CAP,
+		EC_STUDIO_REVIEW_QUEUE_SLUG,
+		'ec_studio_review_queue_render_page'
+	);
+}
+add_action( 'admin_menu', 'ec_studio_review_queue_register_page' );
+
+/**
+ * Resolve main extrachill.com's blog id.
+ *
+ * @since 0.20.1
+ *
+ * @return int Main blog id, or 0 when unresolved.
+ */
+function ec_studio_review_queue_main_blog_id(): int {
+	if ( ! function_exists( 'ec_get_blog_id' ) ) {
+		return 0;
+	}
+
+	return (int) ec_get_blog_id( 'main' );
+}
+
+/**
+ * Fetch pending Studio submissions from main extrachill.com.
+ *
+ * Runs a WP_Query inside `switch_to_blog( main )` for posts that:
+ *   - have post_status `pending`, and
+ *   - carry the `_ec_studio_submission` provenance meta (EXISTS) — the marker
+ *     the compose proxy stamps on every born-on-main submission.
+ *
+ * Each returned row is a plain array of the fields the table renders, resolved
+ * WHILE STILL in main's context (author display name, edit/preview URLs) so the
+ * caller never has to switch blogs again. This keeps all cross-site work in one
+ * switch/restore pair.
+ *
+ * @since 0.20.1
+ *
+ * @param int $main_blog_id Resolved main blog id.
+ * @return array<int, array<string, mixed>> Rows for the review table.
+ */
+function ec_studio_review_queue_fetch_submissions( int $main_blog_id ): array {
+	if ( $main_blog_id <= 0 ) {
+		return array();
+	}
+
+	$rows = array();
+
+	switch_to_blog( $main_blog_id );
+	try {
+		$query = new \WP_Query(
+			array(
+				'post_type'      => 'post',
+				'post_status'    => 'pending',
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_meta_query -- Editorial queue: a bounded, editor-only admin screen keyed on the provenance marker. This is the intended query.
+				'meta_query'     => array(
+					array(
+						'key'     => '_ec_studio_submission',
+						'compare' => 'EXISTS',
+					),
+				),
+				'orderby'        => 'modified',
+				'order'          => 'DESC',
+				'posts_per_page' => 100,
+				'no_found_rows'  => true,
+			)
+		);
+
+		foreach ( $query->posts as $post ) {
+			if ( ! $post instanceof \WP_Post ) {
+				$post = get_post( $post );
+			}
+			if ( ! $post instanceof \WP_Post ) {
+				continue;
+			}
+
+			$submission = get_post_meta( $post->ID, '_ec_studio_submission', true );
+
+			$submitted_at = is_array( $submission ) && ! empty( $submission['submitted_at'] )
+				? (string) $submission['submitted_at']
+				: '';
+
+			$author_id   = (int) $post->post_author;
+			$author_name = $author_id > 0 ? (string) get_the_author_meta( 'display_name', $author_id ) : '';
+
+			$title = (string) get_the_title( $post );
+
+			$rows[] = array(
+				'id'           => (int) $post->ID,
+				'title'        => '' !== $title ? $title : __( '(no title)', 'extrachill-studio' ),
+				'author'       => '' !== $author_name ? $author_name : __( 'Unknown', 'extrachill-studio' ),
+				'submitted_at' => $submitted_at,
+				'modified_gmt' => (string) $post->post_modified_gmt,
+				'edit_url'     => (string) get_edit_post_link( $post->ID, 'raw' ),
+				'preview_url'  => (string) get_preview_post_link( $post ),
+			);
+		}
+	} finally {
+		restore_current_blog();
+	}
+
+	return $rows;
+}
+
+/**
+ * Format an ISO-8601 / MySQL datetime for display in the site's timezone.
+ *
+ * @since 0.20.1
+ *
+ * Returns a raw (unescaped) string; callers must escape at output.
+ *
+ * @param string $value Datetime string (ISO-8601 UTC or MySQL GMT).
+ * @return string Human-readable local datetime, or an em dash when empty.
+ */
+function ec_studio_review_queue_format_datetime( string $value ): string {
+	$value = trim( $value );
+	if ( '' === $value ) {
+		return '—';
+	}
+
+	$timestamp = strtotime( $value );
+	if ( false === $timestamp ) {
+		return $value;
+	}
+
+	$format = (string) get_option( 'date_format' ) . ' ' . (string) get_option( 'time_format' );
+
+	return (string) wp_date( $format, $timestamp );
+}
+
+/**
+ * Render the review-queue admin page.
+ *
+ * @since 0.20.1
+ *
+ * @return void
+ */
+function ec_studio_review_queue_render_page(): void {
+	if ( ! current_user_can( EC_STUDIO_REVIEW_QUEUE_CAP ) ) {
+		wp_die( esc_html__( 'You do not have permission to view Studio submissions.', 'extrachill-studio' ) );
+	}
+
+	$main_blog_id = ec_studio_review_queue_main_blog_id();
+
+	echo '<div class="wrap">';
+	echo '<h1>' . esc_html__( 'Studio Submissions', 'extrachill-studio' ) . '</h1>';
+	echo '<p class="description">' . esc_html__( 'Blog posts submitted for review through the Studio Compose tool. These live on the main site as pending drafts — open one to review, edit, and publish it.', 'extrachill-studio' ) . '</p>';
+
+	if ( $main_blog_id <= 0 ) {
+		echo '<div class="notice notice-error"><p>' . esc_html__( 'Could not resolve the main site. The Extra Chill multisite helpers may be unavailable.', 'extrachill-studio' ) . '</p></div>';
+		echo '</div>';
+		return;
+	}
+
+	$rows = ec_studio_review_queue_fetch_submissions( $main_blog_id );
+
+	if ( empty( $rows ) ) {
+		echo '<div class="notice notice-info inline"><p>' . esc_html__( 'No Studio submissions are waiting for review right now.', 'extrachill-studio' ) . '</p></div>';
+		echo '</div>';
+		return;
+	}
+
+	echo '<table class="wp-list-table widefat fixed striped">';
+	echo '<thead><tr>';
+	echo '<th scope="col">' . esc_html__( 'Title', 'extrachill-studio' ) . '</th>';
+	echo '<th scope="col">' . esc_html__( 'Author', 'extrachill-studio' ) . '</th>';
+	echo '<th scope="col">' . esc_html__( 'Submitted', 'extrachill-studio' ) . '</th>';
+	echo '<th scope="col">' . esc_html__( 'Actions', 'extrachill-studio' ) . '</th>';
+	echo '</tr></thead>';
+	echo '<tbody>';
+
+	foreach ( $rows as $row ) {
+		$edit_url    = (string) $row['edit_url'];
+		$preview_url = (string) $row['preview_url'];
+		$submitted   = '' !== (string) $row['submitted_at'] ? (string) $row['submitted_at'] : (string) $row['modified_gmt'];
+
+		echo '<tr>';
+
+		echo '<td><strong>';
+		if ( '' !== $edit_url ) {
+			echo '<a href="' . esc_url( $edit_url ) . '">' . esc_html( (string) $row['title'] ) . '</a>';
+		} else {
+			echo esc_html( (string) $row['title'] );
+		}
+		echo '</strong></td>';
+
+		echo '<td>' . esc_html( (string) $row['author'] ) . '</td>';
+
+		echo '<td>' . esc_html( ec_studio_review_queue_format_datetime( $submitted ) ) . '</td>';
+
+		echo '<td>';
+		$actions = array();
+		if ( '' !== $edit_url ) {
+			$actions[] = '<a href="' . esc_url( $edit_url ) . '">' . esc_html__( 'Review &amp; edit', 'extrachill-studio' ) . '</a>';
+		}
+		if ( '' !== $preview_url ) {
+			$actions[] = '<a href="' . esc_url( $preview_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Preview', 'extrachill-studio' ) . '</a>';
+		}
+		echo wp_kses_post( implode( ' | ', $actions ) );
+		echo '</td>';
+
+		echo '</tr>';
+	}
+
+	echo '</tbody></table>';
+	echo '</div>';
+}


### PR DESCRIPTION
## Summary

Compose blog submissions are born on MAIN (blog 1) and land there as `pending` under the writer's authorship, but nothing surfaced them to an editor — a submission no one noticed was functionally lost (the failure that filed #109: a real submission sat unnoticed on main). This adds the editorial pickup surface.

## Where the queue lives

A wp-admin screen on the **Studio subsite** (blog 12) — **Posts → Studio Submissions** (`inc/review-queue.php`). It queries MAIN via `switch_to_blog( main ) + WP_Query`, resolving author name / edit URL / preview URL inside main's context and restoring the blog afterward (verified: fetch runs on blog 1, restores to blog 12).

**Why a Studio-subsite page and not a page ON main:** this plugin is active only on Studio (blog 12) — confirmed via `plugin list` on both sites — so it cannot register an admin menu on main. The data is main-side, so the page queries main cross-site, mirroring the pattern the Compose proxy already uses. This is the issue's stated fallback ("query main via switch_to_blog"). A frontend Studio tab would need a whole new REST route + React tab for the same list; the PHP admin page is the cheaper, self-contained path and puts the queue next to the post lists editors already use.

## The meta_query key

`meta_query` on `_ec_studio_submission` (`compare => EXISTS`), filtered to `post_status = pending`, ordered by `modified DESC`. That marker is stamped on every born-on-main submission by the Compose proxy (`ec_studio_compose_stamp_origin_meta`, PR #107). The row's `submitted_at` reads from the marker payload; it falls back to `post_modified_gmt` for any pre-marker post.

Columns: **Title** (links to review/edit on main), **Author**, **Submitted** (site-timezone formatted), **Actions** (Review & edit, Preview).

## Capability gate

`edit_others_posts` — reviewing/publishing someone else's submission is an editorial action, so plain contributors (who can submit but not review) are excluded. Re-checked in the render callback via `current_user_can`.

## Notification

**Deferred** as a follow-up (the issue marks it optional / nice-to-have). The required deliverable is the list; a submission-arrival email/DM can be added later behind the same marker without touching this surface.

## Distinct from #42

#42 is the SOCIALS submission queue (social drafts); this is strictly the BLOG compose editorial queue, keyed on `_ec_studio_submission`. No collision.

## Verification

- `php -l` clean on both changed files.
- `homeboy lint extrachill-studio`: **zero findings in `inc/review-queue.php`**. All remaining lint failures are in pre-existing files tracked by #66 (transcription/callback.php, compose/rest.php, etc.), untouched here.
- Ran the fetch on the live Studio site against my worktree file: resolves main=1, returns the current (empty) pending set, and correctly restores to blog 12. No pending Studio submissions exist right now because the marker landed with #107 and the one real prior submission predates it — the queue is forward-looking and will show Steve-Hughes-style pending submissions the moment one is stamped.
- No JS touched (no typecheck/build needed).

Closes #109