### PR TITLE
feat: detect silent Compose strandings on the Studio subsite

### DIFF
--- a/extrachill-studio.php
+++ b/extrachill-studio.php
@@ -35,6 +35,7 @@ require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/breadcrumbs.php';
 require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/social-drafts.php';
 require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/compose-editor.php';
 require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/compose/rest.php';
+require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/compose/strand-detector.php';
 require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/review-queue.php';
 require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/abilities/resolve-instagram-media.php';
 require_once EXTRACHILL_STUDIO_PLUGIN_DIR . 'inc/abilities/run-giveaway.php';

--- a/inc/compose/rest.php
+++ b/inc/compose/rest.php
@@ -294,6 +294,13 @@ function ec_studio_compose_block_stranded_local_writes( $result, $server, $reque
 		return $result;
 	}
 
+	// Make the rejection observable. A single blocked request is a caught
+	// stranding (good), but a RECURRING pattern means the client-side rewrite
+	// is systematically failing — that must be visible to an operator, not
+	// silently absorbed per-request. Record it on a persistent counter (with
+	// last-seen context) and emit a gated error_log line. See #110.
+	ec_studio_compose_record_guard_rejection( $method, $route );
+
 	return new \WP_Error(
 		'ec_studio_compose_stranded_local_write',
 		__( 'This post must be created on the main site, but the request was routed to Studio. Nothing was saved. Please reload the Compose tab and try again — if it keeps happening, contact an admin.', 'extrachill-studio' ),
@@ -301,6 +308,69 @@ function ec_studio_compose_block_stranded_local_writes( $result, $server, $reque
 	);
 }
 add_filter( 'rest_pre_dispatch', 'ec_studio_compose_block_stranded_local_writes', 10, 3 );
+
+/**
+ * Option key holding an observability record of guard rejections.
+ *
+ * Shape: {
+ *   count        int     Total rejections since first seen.
+ *   first_seen   string  ISO-8601 UTC of the first rejection.
+ *   last_seen    string  ISO-8601 UTC of the most recent rejection.
+ *   last_user_id int     User whose write was most recently blocked.
+ *   last_method  string  HTTP method of the most recent blocked write.
+ *   last_route   string  Core route of the most recent blocked write.
+ * }
+ */
+const EC_STUDIO_COMPOSE_GUARD_REJECTIONS_OPTION = 'ec_studio_compose_guard_rejections';
+
+/**
+ * Record a stranded-local-write guard rejection for observability.
+ *
+ * The #107 guard rejects a compose-marked local write per-request, which stops
+ * the stranding but says nothing to an operator. A one-off is expected noise;
+ * a recurring count is a real, actionable signal that the born-on-main routing
+ * is systematically missing. This persists a small running record (autoloaded
+ * option, updated in place) and emits a gated error_log line so the failure is
+ * surfaced in logs and can be read back by the CLI report (see #110).
+ *
+ * @since 0.20.1
+ *
+ * @param string $method HTTP method of the blocked write.
+ * @param string $route  Core route the blocked write targeted.
+ * @return void
+ */
+function ec_studio_compose_record_guard_rejection( string $method, string $route ): void {
+	$now     = gmdate( 'c' );
+	$user_id = (int) get_current_user_id();
+
+	$record = get_option( EC_STUDIO_COMPOSE_GUARD_REJECTIONS_OPTION, array() );
+	if ( ! is_array( $record ) ) {
+		$record = array();
+	}
+
+	$record = array(
+		'count'        => isset( $record['count'] ) ? ( (int) $record['count'] + 1 ) : 1,
+		'first_seen'   => ! empty( $record['first_seen'] ) ? (string) $record['first_seen'] : $now,
+		'last_seen'    => $now,
+		'last_user_id' => $user_id,
+		'last_method'  => $method,
+		'last_route'   => $route,
+	);
+
+	update_option( EC_STUDIO_COMPOSE_GUARD_REJECTIONS_OPTION, $record, true );
+
+	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+		error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Gated observability log for a proven routing miss (#110).
+			sprintf(
+				'[extrachill-studio] Compose born-on-main guard rejected a stranded local write (count=%d): %s %s by user %d. The client-side rewrite is missing — investigate if this recurs.',
+				(int) $record['count'],
+				$method,
+				$route,
+				$user_id
+			)
+		);
+	}
+}
 
 /**
  * Permission check for the compose proxy routes.

--- a/inc/compose/strand-detector-cli.php
+++ b/inc/compose/strand-detector-cli.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * WP-CLI command for the stranded-submission detector (#110).
+ *
+ * Registers `wp extrachill-studio detect-strandings`, which scans the Studio
+ * subsite (blog 12) for `post` entries that look like stranded editorial
+ * content and prints them, plus the #107 guard-rejection counter.
+ *
+ * @package    ExtraChillStudio
+ * @subpackage Compose
+ * @since      0.20.1
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'WP_CLI' ) ) {
+	return;
+}
+
+/**
+ * Detect editorial submissions stranded on the Studio subsite.
+ *
+ * @since 0.20.1
+ */
+class EC_Studio_Strand_Detector_CLI {
+
+	/**
+	 * Scan the Studio subsite for candidate stranded editorial submissions.
+	 *
+	 * Editorial blog posts are meant to be born on main (blog 1); a `post` on
+	 * the Studio subsite (blog 12) with substantial content/images by a team
+	 * member — and no social-draft meta — is a candidate stranding. Running
+	 * this against blog 12 would have surfaced the Steve Hughes submission
+	 * (post 88) instead of it being found by accident.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--min-content-len=<chars>]
+	 * : Minimum body-text length (characters) to treat a post as substantial.
+	 * ---
+	 * default: 200
+	 * ---
+	 *
+	 * [--limit=<count>]
+	 * : Maximum number of Studio-subsite posts to inspect.
+	 * ---
+	 * default: 500
+	 * ---
+	 *
+	 * [--format=<format>]
+	 * : Render format for the candidate list.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - csv
+	 *   - json
+	 *   - yaml
+	 *   - count
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Report candidate strandings on the Studio subsite.
+	 *     $ wp extrachill-studio detect-strandings --url=studio.extrachill.com
+	 *
+	 *     # Machine-readable output for a scheduled check.
+	 *     $ wp extrachill-studio detect-strandings --url=studio.extrachill.com --format=json
+	 *
+	 * @when after_wp_load
+	 *
+	 * @param array $args       Positional args (unused).
+	 * @param array $assoc_args Associative args.
+	 * @return void
+	 */
+	public function __invoke( $args, $assoc_args ) {
+		$this->assert_on_studio_subsite();
+
+		$min_len = isset( $assoc_args['min-content-len'] ) ? (int) $assoc_args['min-content-len'] : EC_STUDIO_STRAND_MIN_CONTENT_LEN;
+		$limit   = isset( $assoc_args['limit'] ) ? (int) $assoc_args['limit'] : 500;
+		$format  = isset( $assoc_args['format'] ) ? (string) $assoc_args['format'] : 'table';
+
+		$candidates = ec_studio_detect_strandings(
+			array(
+				'min_content_len' => $min_len,
+				'limit'           => $limit,
+			)
+		);
+
+		// Surface the guard-rejection counter first — a recurring count is a
+		// live routing miss, distinct from posts already stranded on disk.
+		$this->report_guard_rejections( $format );
+
+		if ( empty( $candidates ) ) {
+			if ( in_array( $format, array( 'json', 'csv', 'yaml' ), true ) ) {
+				\WP_CLI\Utils\format_items( $format, array(), array( 'id', 'title', 'author', 'author_id', 'date', 'status', 'reason' ) );
+			} elseif ( 'count' === $format ) {
+				\WP_CLI::line( '0' );
+			} else {
+				\WP_CLI::success( 'No candidate strandings found on the Studio subsite.' );
+			}
+			return;
+		}
+
+		\WP_CLI\Utils\format_items(
+			$format,
+			$candidates,
+			array( 'id', 'title', 'author', 'author_id', 'date', 'status', 'reason' )
+		);
+
+		if ( ! in_array( $format, array( 'json', 'csv', 'yaml', 'count' ), true ) ) {
+			\WP_CLI::warning(
+				sprintf(
+					'%d candidate stranding(s) found on the Studio subsite. Each is a `post` that looks like editorial content but is not on main — review and, if confirmed, recover via the extrachill-multisite migration primitive.',
+					count( $candidates )
+				)
+			);
+		}
+	}
+
+	/**
+	 * Fail fast unless we're running against the Studio subsite.
+	 *
+	 * The detector only makes sense on blog 12; running it on main would scan
+	 * legitimate editorial posts and flag everything. When the multisite helper
+	 * is available we assert the current blog IS the Studio subsite.
+	 *
+	 * @return void
+	 */
+	private function assert_on_studio_subsite() {
+		if ( ! function_exists( 'ec_get_blog_id' ) ) {
+			// Can't resolve — warn but proceed, so the command still works on a
+			// single-site/dev install.
+			\WP_CLI::warning( 'extrachill-multisite not available; cannot confirm this is the Studio subsite. Proceeding against the current site.' );
+			return;
+		}
+
+		$studio_blog_id  = (int) ec_get_blog_id( 'studio' );
+		$current_blog_id = (int) get_current_blog_id();
+
+		if ( $studio_blog_id > 0 && $current_blog_id !== $studio_blog_id ) {
+			\WP_CLI::error(
+				sprintf(
+					'This scan must run against the Studio subsite (blog %d), but the current site is blog %d. Re-run with --url=studio.extrachill.com',
+					$studio_blog_id,
+					$current_blog_id
+				)
+			);
+		}
+	}
+
+	/**
+	 * Print the #107 guard-rejection observability record.
+	 *
+	 * @param string $format Active output format (suppressed for machine formats).
+	 * @return void
+	 */
+	private function report_guard_rejections( string $format ) {
+		// Keep machine-readable output clean — the candidate list is the payload.
+		if ( in_array( $format, array( 'json', 'csv', 'yaml', 'count' ), true ) ) {
+			return;
+		}
+
+		$record = ec_studio_get_guard_rejection_record();
+
+		if ( empty( $record ) || empty( $record['count'] ) ) {
+			\WP_CLI::log( 'Guard rejections (born-on-main #107): none recorded — no compose-marked local write has been blocked.' );
+			return;
+		}
+
+		\WP_CLI::log(
+			sprintf(
+				'Guard rejections (born-on-main #107): %d blocked. First %s, last %s (user %d, %s %s). A recurring count means the client-side rewrite is systematically missing — investigate.',
+				(int) $record['count'],
+				isset( $record['first_seen'] ) ? (string) $record['first_seen'] : '?',
+				isset( $record['last_seen'] ) ? (string) $record['last_seen'] : '?',
+				isset( $record['last_user_id'] ) ? (int) $record['last_user_id'] : 0,
+				isset( $record['last_method'] ) ? (string) $record['last_method'] : '?',
+				isset( $record['last_route'] ) ? (string) $record['last_route'] : '?'
+			)
+		);
+	}
+}
+
+WP_CLI::add_command( 'extrachill-studio detect-strandings', 'EC_Studio_Strand_Detector_CLI' );

--- a/inc/compose/strand-detector.php
+++ b/inc/compose/strand-detector.php
@@ -1,0 +1,300 @@
+<?php
+/**
+ * Stranded-submission detector — the observability half of born-on-main (#110).
+ *
+ * Studio lives on the Studio subsite (blog 12); editorial blog posts are meant
+ * to be BORN ON MAIN (blog 1) via the compose proxy. #106/#107 hardened
+ * *prevention* (per-request markers + a server 409 guard). This file adds
+ * *detection*: a scan of the Studio subsite for `post` entries that look like
+ * stranded editorial content — a real article that should have landed on main
+ * but didn't — so a stranding is caught in hours by a report, not by chance
+ * weeks later (as the Steve Hughes submission, post 88, was).
+ *
+ * Two observability surfaces live in the compose layer:
+ *   - This scan (WP-CLI `wp extrachill-studio detect-strandings`), which
+ *     inspects blog 12 for candidate strandings.
+ *   - The #107 guard's rejection counter (see rest.php), which records when a
+ *     compose-marked local write is blocked so a recurring routing miss is
+ *     visible. This command also prints that counter.
+ *
+ * WHAT COUNTS AS A CANDIDATE STRANDING
+ * ------------------------------------
+ * A blog-12 `post` (post_type=post) that:
+ *   - is NOT a social draft (social drafts legitimately live on blog 12 and
+ *     carry `_studio_social_*` meta — see inc/social-drafts.php); AND
+ *   - looks like real editorial content: substantial body text OR an attached
+ *     image / featured image; AND
+ *   - is authored by an Extra Chill team member (the people who use compose).
+ *
+ * These are heuristics, deliberately tuned to flag rather than to be certain —
+ * the output is a candidate list for a human/agent to eyeball, not an
+ * auto-remediation. Recovery (migrating a stranded post back to main) is the
+ * separate extrachill-multisite#85/#86 primitive.
+ *
+ * @package    ExtraChillStudio
+ * @subpackage Compose
+ * @since      0.20.1
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Minimum rendered-text length (characters) for a post body to be considered
+ * "substantial" editorial content. Short blog-12 posts with no media are far
+ * more likely to be scratch/social scaffolding than a stranded article.
+ */
+const EC_STUDIO_STRAND_MIN_CONTENT_LEN = 200;
+
+/**
+ * Scan the Studio subsite for candidate stranded editorial submissions.
+ *
+ * Returns a list of blog-12 posts that look like editorial content authored by
+ * a team member and are NOT social drafts. Runs in the CURRENT blog context
+ * (the caller is responsible for being on / switching to the Studio subsite),
+ * so it is reusable outside WP-CLI too.
+ *
+ * @since 0.20.1
+ *
+ * @param array $args {
+ *     Optional. Scan tuning.
+ *
+ *     @type int $min_content_len Minimum content length to treat as substantial.
+ *                                Default EC_STUDIO_STRAND_MIN_CONTENT_LEN.
+ *     @type int $limit           Max posts to inspect. Default 500.
+ * }
+ * @return array<int, array<string, mixed>> Candidate strandings; each entry has
+ *                                           id, title, author, author_id, date,
+ *                                           status, reason.
+ */
+function ec_studio_detect_strandings( array $args = array() ): array {
+	$min_len = isset( $args['min_content_len'] ) ? max( 0, (int) $args['min_content_len'] ) : EC_STUDIO_STRAND_MIN_CONTENT_LEN;
+	$limit   = isset( $args['limit'] ) ? max( 1, (int) $args['limit'] ) : 500;
+
+	$query = new \WP_Query(
+		array(
+			'post_type'              => 'post',
+			// Any lifecycle state — a stranding can be draft, pending, or even
+			// published-on-the-wrong-site.
+			'post_status'            => array( 'draft', 'pending', 'publish', 'future', 'private' ),
+			'posts_per_page'         => $limit,
+			'orderby'                => 'date',
+			'order'                  => 'DESC',
+			'no_found_rows'          => true,
+			'ignore_sticky_posts'    => true,
+			'update_post_term_cache' => false,
+			// Exclude social drafts at the query layer: a post carrying the
+			// platforms meta is a legitimate blog-12 social draft, never a
+			// stranded editorial article.
+			'meta_query'             => array(
+				array(
+					'key'     => \ExtraChillStudio\META_PLATFORMS,
+					'compare' => 'NOT EXISTS',
+				),
+			),
+		)
+	);
+
+	$candidates = array();
+
+	foreach ( $query->posts as $post_ref ) {
+		$post = get_post( $post_ref );
+		if ( ! $post instanceof \WP_Post ) {
+			continue;
+		}
+
+		// Belt-and-suspenders: skip anything still carrying ANY social-draft
+		// marker, even if the platforms meta was cleared but others remain.
+		if ( ec_studio_post_looks_like_social_draft( (int) $post->ID ) ) {
+			continue;
+		}
+
+		$author_id = (int) $post->post_author;
+		if ( ! ec_studio_author_is_team_member( $author_id ) ) {
+			continue;
+		}
+
+		$reason = ec_studio_strand_content_reason( $post, $min_len );
+		if ( '' === $reason ) {
+			continue;
+		}
+
+		$author = get_userdata( $author_id );
+		$title  = get_the_title( $post );
+
+		$candidates[] = array(
+			'id'        => (int) $post->ID,
+			'title'     => '' !== $title ? $title : '(no title)',
+			'author'    => $author ? $author->user_login : (string) $author_id,
+			'author_id' => $author_id,
+			'date'      => (string) $post->post_date_gmt,
+			'status'    => (string) $post->post_status,
+			'reason'    => $reason,
+		);
+	}
+
+	return $candidates;
+}
+
+/**
+ * Whether a Studio-subsite post is a legitimate social draft.
+ *
+ * Social drafts live on blog 12 by design (see inc/social-drafts.php) and are
+ * identified by their `_studio_social_*` meta. Distinguishing them from a
+ * stranded editorial `post` is the crux of the whole detector.
+ *
+ * CRITICAL: this must test the meta *row's existence in the database*, NOT the
+ * value `get_post_meta()` returns. social-drafts.php registers these keys with
+ * `register_post_meta` DEFAULTS (`_studio_social_media_kind` => 'image',
+ * `_studio_social_aspect_ratio` => '4:5'), so `get_post_meta()` returns those
+ * non-empty defaults for EVERY `post` — including editorial ones that have no
+ * social meta row at all. A naive `! empty( get_post_meta(...) )` check would
+ * therefore treat every stranded article as a social draft and hide it (this
+ * is exactly what would have re-buried post 88). So we:
+ *   1. gate on `metadata_exists()` (real DB row), and
+ *   2. require a MEANINGFUL social signal — an actually-selected platform, a
+ *      non-empty caption, or attached social images — not just a defaulted key.
+ *
+ * @since 0.20.1
+ *
+ * @param int $post_id Post ID on the current (Studio) blog.
+ * @return bool True when the post is a genuine social draft.
+ */
+function ec_studio_post_looks_like_social_draft( int $post_id ): bool {
+	// A selected platform is the definitive social-draft marker.
+	if ( metadata_exists( 'post', $post_id, \ExtraChillStudio\META_PLATFORMS ) ) {
+		$platforms = get_post_meta( $post_id, \ExtraChillStudio\META_PLATFORMS, true );
+		if ( is_array( $platforms ) && ! empty( $platforms ) ) {
+			return true;
+		}
+	}
+
+	// A non-empty caption stored on disk is a social-draft signal.
+	if ( metadata_exists( 'post', $post_id, \ExtraChillStudio\META_CAPTION ) ) {
+		$caption = get_post_meta( $post_id, \ExtraChillStudio\META_CAPTION, true );
+		if ( '' !== trim( (string) $caption ) ) {
+			return true;
+		}
+	}
+
+	// Attached social images stored on disk are a social-draft signal.
+	if ( metadata_exists( 'post', $post_id, \ExtraChillStudio\META_IMAGES ) ) {
+		$images = get_post_meta( $post_id, \ExtraChillStudio\META_IMAGES, true );
+		if ( is_array( $images ) && ! empty( $images ) ) {
+			return true;
+		}
+	}
+
+	// A scheduled/cross-posted job id is a social-draft signal.
+	if ( metadata_exists( 'post', $post_id, \ExtraChillStudio\META_JOB_ID ) ) {
+		$job_id = (int) get_post_meta( $post_id, \ExtraChillStudio\META_JOB_ID, true );
+		if ( $job_id > 0 ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Whether a user id holds the Extra Chill team role.
+ *
+ * Team members are the only people who use the compose pane, so a stranded
+ * editorial post is authored by one of them. Delegates to the canonical
+ * `ec_is_team_member( $user_id )` (extrachill-users) when available.
+ *
+ * @since 0.20.1
+ *
+ * @param int $user_id Author user id.
+ * @return bool True when the author is a team member.
+ */
+function ec_studio_author_is_team_member( int $user_id ): bool {
+	if ( $user_id <= 0 ) {
+		return false;
+	}
+
+	if ( function_exists( 'ec_is_team_member' ) ) {
+		return (bool) ec_is_team_member( $user_id );
+	}
+
+	// Fallback when extrachill-users isn't loaded: a user with edit_posts on a
+	// blog-12 editorial post is close enough to flag for review.
+	return user_can( $user_id, 'edit_posts' );
+}
+
+/**
+ * Explain why a post looks like substantial editorial content, or '' if not.
+ *
+ * A stranded article is one that carries real editorial weight — a body of
+ * text and/or images — as opposed to an empty scratch post. Returns a short
+ * human-readable reason for the report, or an empty string when the post is
+ * too thin to flag.
+ *
+ * @since 0.20.1
+ *
+ * @param \WP_Post $post    Post on the current (Studio) blog.
+ * @param int      $min_len Minimum rendered-text length to treat as substantial.
+ * @return string Reason string, or '' when the post is not a candidate.
+ */
+function ec_studio_strand_content_reason( \WP_Post $post, int $min_len ): string {
+	$reasons = array();
+
+	// Substantial body text (strip blocks/shortcodes/tags before measuring).
+	$plain = trim( wp_strip_all_tags( strip_shortcodes( (string) $post->post_content ) ) );
+	$len   = function_exists( 'mb_strlen' ) ? mb_strlen( $plain ) : strlen( $plain );
+	if ( $len >= $min_len ) {
+		$reasons[] = sprintf( '%d chars of body text', $len );
+	}
+
+	// A featured image is a strong editorial signal.
+	if ( has_post_thumbnail( $post ) ) {
+		$reasons[] = 'has featured image';
+	}
+
+	// Attached images (inserted media owned by the post) are another signal.
+	$attachments = get_children(
+		array(
+			'post_parent'    => $post->ID,
+			'post_type'      => 'attachment',
+			'post_mime_type' => 'image',
+			'numberposts'    => 1,
+			'fields'         => 'ids',
+		)
+	);
+	if ( ! empty( $attachments ) ) {
+		$reasons[] = 'has attached image(s)';
+	}
+
+	return implode( '; ', $reasons );
+}
+
+/**
+ * Read the persisted guard-rejection observability record.
+ *
+ * Surfaced alongside the scan so an operator sees both signals in one place:
+ * candidate strandings already on disk AND whether the #107 guard has been
+ * actively blocking compose-marked local writes (a recurring count means the
+ * client-side rewrite is systematically missing).
+ *
+ * @since 0.20.1
+ *
+ * @return array<string, mixed> The rejection record, or an empty array when
+ *                              nothing has ever been blocked.
+ */
+function ec_studio_get_guard_rejection_record(): array {
+	if ( ! defined( 'EC_STUDIO_COMPOSE_GUARD_REJECTIONS_OPTION' ) ) {
+		return array();
+	}
+
+	$record = get_option( EC_STUDIO_COMPOSE_GUARD_REJECTIONS_OPTION, array() );
+
+	return is_array( $record ) ? $record : array();
+}
+
+/*
+ * ---------------------------------------------------------------------------
+ * WP-CLI surface.
+ * ---------------------------------------------------------------------------
+ */
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	require_once __DIR__ . '/strand-detector-cli.php';
+}


### PR DESCRIPTION
## Summary

The observability half of the born-on-main guarantee (#110). #106/#107 hardened *prevention* (per-request markers + a server 409 guard). This adds *detection*: a submission that still strands on the Studio subsite (blog 12) must be caught in hours by a report — not by chance weeks later, the way the Steve Hughes submission (post 88) was.

## What the detector checks

`wp extrachill-studio detect-strandings` (run with `--url=studio.extrachill.com`) scans blog 12 for `post` entries that look like **stranded editorial content**:

- `post_type=post` on the Studio subsite, in any lifecycle state (draft/pending/publish/future/private);
- **substantial** — ≥200 chars of body text (tunable via `--min-content-len`) **and/or** a featured image **and/or** an attached image;
- authored by an **Extra Chill team member** (`ec_is_team_member( $author_id )` — the people who use Compose);
- **not** a social draft.

Output columns: `id`, `title`, `author`, `author_id`, `date`, `status`, `reason` (e.g. *"1230 chars of body text; has featured image"*). Supports `--format=table|csv|json|yaml|count` for use in a scheduled check. The command asserts it is running on the Studio subsite (via `ec_get_blog_id('studio')`) so it can never flag legitimate main-site editorial posts.

## How it excludes legitimate social drafts (the crux)

Social drafts legitimately live on blog 12 and carry `_studio_social_*` meta (`inc/social-drafts.php`). The subtle trap: those keys are registered with `register_post_meta` **defaults** (`_studio_social_media_kind` => `'image'`, `_studio_social_aspect_ratio` => `'4:5'`), so `get_post_meta()` returns non-empty values for **every** `post` — including editorial ones with no social meta row at all. A naive `! empty( get_post_meta(...) )` check would classify every stranded article as a social draft and **re-bury the exact post this is meant to surface**.

So the exclusion:
1. gates on `metadata_exists( 'post', $id, $key )` — a real DB row, not a defaulted value; and
2. requires a **meaningful** social signal — an actually-selected platform, a non-empty caption, attached social images, or a cross-post job id.

## Guard-rejection logging

The #107 `rest_pre_dispatch` guard now records every rejection to a persistent option (`ec_studio_compose_guard_rejections`: `count` + `first_seen`/`last_seen` + last `user_id`/`method`/`route`) and emits a `WP_DEBUG`-gated `error_log` line. A one-off block is a caught stranding (good); a **recurring count** means the client-side rewrite is systematically missing — now visible instead of silently absorbed per-request. The CLI report prints this counter first.

## Verification

- `php -l` clean on all changed/new PHP.
- `homeboy lint extrachill-studio`: **zero findings** on the new `strand-detector.php` / `strand-detector-cli.php` and on the guard-rejection block added to `rest.php`. (Pre-existing findings in other files are #66, untouched.)
- Ran the detector logic against the live blog 12: it surfaces **exactly** the Steve Hughes stranding — `88 | Jinjer north american tour 2026 … | stevehughes | pending | 1230 chars; featured img` — and correctly excludes the two legitimate social drafts (posts 13 and 6). Running this detector against blog 12 would have caught the stranding by report instead of by accident.

Recovery of a confirmed stranding (migrating it back to main) remains the separate extrachill-multisite#85/#86 primitive; this PR is detection only.

Closes #110