### PR TITLE
fix: make Studio Network tab a legible two-column dashboard

### DIFF
--- a/src/blocks/studio/style.css
+++ b/src/blocks/studio/style.css
@@ -1032,15 +1032,33 @@ html.is-fullscreen-mode .ec-studio-compose-editor .interface-interface-skeleton_
 	line-height: 1.6;
 }
 
+/*
+ * Two-column-max dashboard grid. The previous `minmax(320px, 1fr)` let the
+ * grid pack 3–4 charts per row on wide screens, squeezing each Chart.js
+ * canvas / DataTable into a cramped ~320px column that read as "a bunch of
+ * tiny cards." A 480px floor guarantees at most two columns on typical
+ * screens so every chart gets legible width, and it collapses to a single
+ * column when two legible cards no longer fit.
+ */
 .ec-studio-network__grid {
 	display: grid;
-	grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-	gap: var(--spacing-md);
+	grid-template-columns: repeat(auto-fit, minmax(min(100%, 480px), 1fr));
+	gap: var(--spacing-lg);
 	min-width: 0;
 }
 
 .ec-studio-network__card {
 	min-width: 0;
+}
+
+/*
+ * The conversion-map card is a ranked DATA TABLE (entry article → platform
+ * reach), which reads best across the full dashboard width rather than
+ * shoulder-to-shoulder with a chart. Span it across both columns on
+ * multi-column layouts; it naturally occupies the single column otherwise.
+ */
+.ec-studio-network__card--wide {
+	grid-column: 1 / -1;
 }
 
 .ec-studio-network__card-body {

--- a/src/blocks/studio/tabs/network/chart-card.tsx
+++ b/src/blocks/studio/tabs/network/chart-card.tsx
@@ -36,6 +36,8 @@ interface ChartCardProps {
 	emptyMessage?: string;
 	/** Optional headline figure rendered above the body in the ready state. */
 	headline?: ReactNode;
+	/** Extra class names for the card panel (e.g. a full-width span modifier). */
+	className?: string;
 	/** The chart / table — rendered only in the ready state. */
 	children?: ReactNode;
 }
@@ -48,6 +50,7 @@ export const ChartCard = ( {
 	notInstrumentedReason,
 	emptyMessage,
 	headline,
+	className,
 	children,
 }: ChartCardProps ): ReactElement => {
 	const renderBody = (): ReactNode => {
@@ -112,8 +115,16 @@ export const ChartCard = ( {
 		}
 	};
 
+	const panelClassName = [
+		'ec-studio-panel',
+		'ec-studio-network__card',
+		className,
+	]
+		.filter( Boolean )
+		.join( ' ' );
+
 	return (
-		<Panel className="ec-studio-panel ec-studio-network__card" compact>
+		<Panel className={ panelClassName } compact>
 			<PanelHeader title={ title } description={ description } />
 			<div className="ec-studio-network__card-body">{ renderBody() }</div>
 		</Panel>

--- a/src/blocks/studio/tabs/network/conversion-map-chart.tsx
+++ b/src/blocks/studio/tabs/network/conversion-map-chart.tsx
@@ -113,6 +113,7 @@ export const ConversionMapChart = (): ReactElement => {
 				'Visitors who entered on an article and reached events, community, or artist — last 28 days.',
 				'extrachill-studio'
 			) }
+			className="ec-studio-network__card--wide"
 			state={ state }
 			errorMessage={ errorMessage }
 			emptyMessage={ __(


### PR DESCRIPTION
## Summary
The Studio **Network** analytics tab showed "a bunch of tiny cards in a grid" that wasn't very useful. The root cause was purely **layout, not data** — the four chart cards were packed into a `repeat(auto-fit, minmax(320px, 1fr))` grid, so on wide screens they rendered as 3–4 cramped ~320px columns. Each Chart.js canvas (sessions, surface growth, retention) and the conversion DataTable needs far more horizontal room to be legible.

I confirmed the backend is healthy and returns real **network-wide** data (the analytics events table is a single shared `c8c_extrachill_analytics_events` table, and the routes already query network-wide):
- Retention: 5.36% return rate over 12,699 visitors, 3 cohorts
- Surface growth: 5 ranked surfaces, `ga_available: true`
- Conversion: 10 ranked entry articles

## Changes
- **Grid floor 320px → 480px** (`minmax(min(100%, 480px), 1fr)`) so the dashboard renders at most two legible columns on typical screens and collapses cleanly to one — no more cramped 3–4-across tiles.
- **Conversion-map card spans full width.** It's a ranked table (entry article → platform reach) that reads best across the whole dashboard rather than shoulder-to-shoulder with a chart. Added an optional `className` prop to `ChartCard` and a `.ec-studio-network__card--wide` span modifier.
- Bumped the inter-card gap to `--spacing-lg` for a less cramped feel.

No analytics logic, routes, or data scoping touched — CSS + one presentational prop.

## Verification
- `npm run typecheck` ✅
- `npm run build` ✅ (built `view.js` + copied `style.css` contain the new grid + wide rule)