### PR TITLE
feat: gate Studio compose submissions on featured image + category (#108)

### DIFF
--- a/inc/compose/rest.php
+++ b/inc/compose/rest.php
@@ -170,6 +170,44 @@ function ec_studio_compose_register_routes(): void {
 			),
 		)
 	);
+
+	/*
+	 * Editorial-taxonomy term pickers. The compose UI reads/searches (GET) and
+	 * creates (POST) terms on MAIN's category/artist/venue/location taxonomies
+	 * so a submission reaches editorial review-ready. `<taxonomy>` is a slug
+	 * from the allow-list in ec_studio_compose_resolve_term_taxonomy(); free
+	 * tags (post_tag) are intentionally NOT proxied (see #108).
+	 */
+	register_rest_route(
+		EC_STUDIO_COMPOSE_NAMESPACE,
+		'/' . EC_STUDIO_COMPOSE_ROUTE . '/terms/(?P<taxonomy>[a-z_]+)',
+		array(
+			array(
+				'methods'             => 'GET',
+				'callback'            => 'ec_studio_compose_list_terms',
+				'permission_callback' => 'ec_studio_compose_permission_check',
+				'args'                => array(
+					'taxonomy' => array(
+						'required'          => true,
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_key',
+					),
+				),
+			),
+			array(
+				'methods'             => 'POST',
+				'callback'            => 'ec_studio_compose_create_term',
+				'permission_callback' => 'ec_studio_compose_permission_check',
+				'args'                => array(
+					'taxonomy' => array(
+						'required'          => true,
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_key',
+					),
+				),
+			),
+		)
+	);
 }
 add_action( 'rest_api_init', 'ec_studio_compose_register_routes' );
 
@@ -698,10 +736,22 @@ function ec_studio_compose_create_autosave( \WP_REST_Request $request ) {
 }
 
 /**
+ * Editorial taxonomies the compose pane is allowed to set on the main post,
+ * keyed by the REST field name main's `/wp/v2/posts` controller expects (each
+ * taxonomy's `rest_base`). Each accepts an array of term IDs.
+ *
+ * Deliberately excludes `post_tag`: Extra Chill does NOT use free-form tags
+ * (see Extra-Chill/extrachill-studio#108). Only the platform taxonomies a
+ * concert recap actually lives on are forwarded.
+ */
+const EC_STUDIO_COMPOSE_TERM_FIELDS = array( 'categories', 'artist', 'venue', 'location' );
+
+/**
  * Sanitize the post params accepted from the compose pane.
  *
  * Whitelists the small set of fields the compose pane sends — title, content,
- * status — so the proxy never forwards arbitrary REST fields cross-site.
+ * status, featured image, and the editorial taxonomies — so the proxy never
+ * forwards arbitrary REST fields cross-site.
  *
  * Title and content are passed through unaltered. Main's `/wp/v2/posts`
  * controller is the single sanitization authority: it sanitizes the title via
@@ -711,10 +761,15 @@ function ec_studio_compose_create_autosave( \WP_REST_Request $request ) {
  * Pre-sanitizing or unslashing here would double-process and corrupt
  * legitimate characters (e.g. backslashes), so we don't.
  *
- * The only field the proxy actively gates is `status`: it is validated against
- * the lifecycle states the compose pane is allowed to set (draft, pending) —
- * a policy gate, not sanitization — so the tool can never push a post straight
- * to publish.
+ * `status` is policy-gated against the lifecycle states the compose pane may
+ * set (draft, pending) so the tool can never push a post straight to publish.
+ *
+ * `featured_media` and the term fields (categories/artist/venue/location) are
+ * coerced to their expected numeric shapes so a malformed client payload can't
+ * reach main's controller as garbage; main's schema still validates that the
+ * IDs resolve to real attachments/terms under the user's own auth. Because
+ * every write is forwarded to main, the featured image and terms land on the
+ * MAIN post (blog 1) — never on the Studio subsite (blog 12).
  *
  * @since 0.16.0
  *
@@ -743,7 +798,166 @@ function ec_studio_compose_whitelist_post_params( $raw ): array {
 		}
 	}
 
+	// Featured image — a single attachment id on main. 0 clears it.
+	if ( isset( $raw['featured_media'] ) ) {
+		$params['featured_media'] = absint( $raw['featured_media'] );
+	}
+
+	/*
+	 * Editorial taxonomies — arrays of term ids on main. An explicit empty
+	 * array is forwarded so the writer can clear a taxonomy.
+	 */
+	foreach ( EC_STUDIO_COMPOSE_TERM_FIELDS as $field ) {
+		if ( ! isset( $raw[ $field ] ) ) {
+			continue;
+		}
+		$ids = array_values(
+			array_unique(
+				array_filter(
+					array_map( 'absint', (array) $raw[ $field ] )
+				)
+			)
+		);
+		$params[ $field ] = $ids;
+	}
+
 	return $params;
+}
+
+/**
+ * Map a compose term-picker taxonomy slug to main's REST base.
+ *
+ * The compose UI addresses taxonomies by their slug (category/artist/venue/
+ * location). Main's `/wp/v2/*` term routes are keyed by each taxonomy's
+ * `rest_base`, which differs for the core category taxonomy (`categories`).
+ * This allow-list is the single gate on which taxonomies the picker can touch
+ * — anything not listed (notably `post_tag`) is rejected, so the tool can
+ * never write free tags (see Extra-Chill/extrachill-studio#108).
+ *
+ * @since 0.21.0
+ *
+ * @param string $taxonomy Taxonomy slug from the route.
+ * @return string|null Main's REST base, or null when not allowed.
+ */
+function ec_studio_compose_resolve_term_taxonomy( string $taxonomy ): ?string {
+	$allowed = array(
+		'category' => 'categories',
+		'artist'   => 'artist',
+		'venue'    => 'venue',
+		'location' => 'location',
+	);
+
+	return $allowed[ $taxonomy ] ?? null;
+}
+
+/**
+ * List / search terms in one of main's editorial taxonomies.
+ *
+ * Proxies `GET /wp/v2/<rest_base>` on main so the compose term pickers read
+ * and autocomplete against MAIN's category/artist/venue/location terms — the
+ * same place the forwarded post write assigns them. Query params (search,
+ * per_page, include, orderby) are forwarded verbatim so the picker can search
+ * and hydrate selected terms by id.
+ *
+ * @since 0.21.0
+ *
+ * @param \WP_REST_Request $request REST request.
+ * @return \WP_REST_Response|\WP_Error
+ */
+function ec_studio_compose_list_terms( \WP_REST_Request $request ) {
+	$guard = ec_studio_compose_require_cross_site();
+	if ( is_wp_error( $guard ) ) {
+		return $guard;
+	}
+
+	$rest_base = ec_studio_compose_resolve_term_taxonomy( (string) $request['taxonomy'] );
+	if ( null === $rest_base ) {
+		return new \WP_Error(
+			'ec_studio_compose_bad_taxonomy',
+			__( 'That taxonomy is not available in Studio.', 'extrachill-studio' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	$user_id = (int) get_current_user_id();
+	$query   = $request->get_query_params();
+	$query   = is_array( $query ) ? $query : array();
+
+	// Sane default page size for a picker; the client may override.
+	if ( ! isset( $query['per_page'] ) ) {
+		$query['per_page'] = 20;
+	}
+
+	$response = ec_cross_site_rest_request(
+		'main',
+		'GET',
+		'/wp/v2/' . $rest_base,
+		array(
+			'query'   => $query,
+			'user_id' => $user_id,
+		)
+	);
+
+	return ec_studio_compose_relay_response( $response );
+}
+
+/**
+ * Create a term in one of main's editorial taxonomies.
+ *
+ * Proxies `POST /wp/v2/<rest_base>` on main so a writer can add a missing
+ * artist/venue/location/category from the compose picker. The term is created
+ * on MAIN (blog 1) under the user's own auth, so main's create-term capability
+ * check applies. Only `name` and (for hierarchical category) `parent` are
+ * forwarded.
+ *
+ * @since 0.21.0
+ *
+ * @param \WP_REST_Request $request REST request.
+ * @return \WP_REST_Response|\WP_Error
+ */
+function ec_studio_compose_create_term( \WP_REST_Request $request ) {
+	$guard = ec_studio_compose_require_cross_site();
+	if ( is_wp_error( $guard ) ) {
+		return $guard;
+	}
+
+	$rest_base = ec_studio_compose_resolve_term_taxonomy( (string) $request['taxonomy'] );
+	if ( null === $rest_base ) {
+		return new \WP_Error(
+			'ec_studio_compose_bad_taxonomy',
+			__( 'That taxonomy is not available in Studio.', 'extrachill-studio' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	$raw  = $request->get_json_params();
+	$name = is_array( $raw ) && isset( $raw['name'] ) ? trim( (string) $raw['name'] ) : '';
+	if ( '' === $name ) {
+		return new \WP_Error(
+			'ec_studio_compose_term_name_required',
+			__( 'Enter a name to create this term.', 'extrachill-studio' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	$body = array( 'name' => $name );
+	if ( 'categories' === $rest_base && is_array( $raw ) && isset( $raw['parent'] ) ) {
+		$body['parent'] = absint( $raw['parent'] );
+	}
+
+	$user_id = (int) get_current_user_id();
+
+	$response = ec_cross_site_rest_request(
+		'main',
+		'POST',
+		'/wp/v2/' . $rest_base,
+		array(
+			'body'    => $body,
+			'user_id' => $user_id,
+		)
+	);
+
+	return ec_studio_compose_relay_response( $response );
 }
 
 /**

--- a/src/blocks/studio/style.css
+++ b/src/blocks/studio/style.css
@@ -669,6 +669,157 @@
 	height: 100%;
 }
 
+/* Review-readiness fields — featured image + editorial taxonomies (#108). */
+.ec-studio-compose-review {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing-md, 16px);
+	margin-bottom: var(--spacing-md, 16px);
+}
+
+.ec-studio-compose-review__field {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing-xs, 4px);
+}
+
+.ec-studio-compose-review__label {
+	font-weight: 600;
+	font-size: var(--font-size-sm, 0.875rem);
+	display: flex;
+	align-items: baseline;
+	gap: var(--spacing-xs, 4px);
+}
+
+.ec-studio-compose-review__required {
+	color: var(--error-color);
+	font-weight: 400;
+	font-size: var(--font-size-xs, 0.75rem);
+}
+
+.ec-studio-compose-review__optional {
+	color: var(--muted-text);
+	font-weight: 400;
+	font-size: var(--font-size-xs, 0.75rem);
+}
+
+.ec-studio-compose-review__error {
+	color: var(--error-color);
+	font-size: var(--font-size-xs, 0.75rem);
+}
+
+.ec-studio-compose-review__hint {
+	font-size: var(--font-size-sm, 0.875rem);
+}
+
+/* Featured image control. */
+.ec-studio-compose-featured__preview {
+	display: block;
+	max-width: 100%;
+	height: auto;
+	border-radius: var(--border-radius-sm, 4px);
+	border: 1px solid var(--border-color);
+}
+
+.ec-studio-compose-featured__empty {
+	padding: var(--spacing-md, 16px);
+	text-align: center;
+	color: var(--muted-text);
+	border: 1px dashed var(--border-color);
+	border-radius: var(--border-radius-sm, 4px);
+	font-size: var(--font-size-sm, 0.875rem);
+}
+
+.ec-studio-compose-featured__actions {
+	display: flex;
+	gap: var(--spacing-sm, 8px);
+	align-items: center;
+	flex-wrap: wrap;
+}
+
+/* The native file input is hidden; its <label> is the styled trigger. */
+.ec-studio-compose-featured__file {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
+}
+
+.ec-studio-compose-featured__button {
+	cursor: pointer;
+}
+
+/* Term picker. */
+.ec-studio-compose-review__chips {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--spacing-xs, 4px);
+}
+
+.ec-studio-compose-review__chip {
+	display: inline-flex;
+	align-items: center;
+	gap: var(--spacing-xs, 4px);
+	padding: 2px var(--spacing-xs, 4px) 2px var(--spacing-sm, 8px);
+	background: var(--card-background);
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius-pill, 999px);
+	font-size: var(--font-size-xs, 0.75rem);
+}
+
+.ec-studio-compose-review__chip-remove {
+	border: 0;
+	background: transparent;
+	cursor: pointer;
+	color: var(--muted-text);
+	font-size: var(--font-size-base, 1rem);
+	line-height: 1;
+	padding: 0 2px;
+}
+
+.ec-studio-compose-review__chip-remove:hover {
+	color: var(--error-color);
+}
+
+.ec-studio-compose-review__search {
+	width: 100%;
+}
+
+.ec-studio-compose-review__results {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	max-height: 180px;
+	overflow-y: auto;
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius-sm, 4px);
+}
+
+.ec-studio-compose-review__result {
+	display: block;
+	width: 100%;
+	text-align: left;
+	padding: var(--spacing-xs, 4px) var(--spacing-sm, 8px);
+	border: 0;
+	background: transparent;
+	cursor: pointer;
+	font-size: var(--font-size-sm, 0.875rem);
+}
+
+.ec-studio-compose-review__result:hover {
+	background: var(--card-background);
+}
+
+.ec-studio-compose-review__create {
+	align-self: flex-start;
+	cursor: pointer;
+}
+
 @media (max-width: 768px) {
 	.ec-studio-pane__grid--compose {
 		grid-template-columns: 1fr;

--- a/src/blocks/studio/tabs/compose/index.ts
+++ b/src/blocks/studio/tabs/compose/index.ts
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { createElement, useEffect, useRef, useState, useCallback } from '@wordpress/element';
 import type { ReactElement, ChangeEvent } from 'react';
 import apiFetch from '@wordpress/api-fetch';
@@ -11,6 +11,8 @@ import { ActionRow, FieldGroup, InlineStatus, Panel, PanelHeader } from '@extrac
 import type { StudioPaneProps } from '../../types/studio';
 import { markComposeRequest, registerComposeInstance } from './cross-site-middleware';
 import { installChatRefreshAdapter } from './refresh-adapter';
+import { COMPOSE_TAXONOMIES, FeaturedImage, TermPicker } from './review-fields';
+import type { WpTerm } from './review-fields';
 
 /**
  * apiFetch wrapper that tags a request as Compose-pane-originated so the
@@ -53,6 +55,11 @@ interface WpPost {
 	date: string;
 	modified: string;
 	modified_gmt?: string;
+	featured_media?: number;
+	categories?: number[];
+	artist?: number[];
+	venue?: number[];
+	location?: number[];
 }
 
 interface WpAutosave {
@@ -111,6 +118,17 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 	const [ drafts, setDrafts ] = useState< WpPost[] >( [] );
 	const [ activePostId, setActivePostId ] = useState< number | null >( null );
 	const [ isLoadingDrafts, setIsLoadingDrafts ] = useState( true );
+
+	// Review-readiness fields (Extra-Chill/extrachill-studio#108). Featured
+	// image + editorial taxonomies, all written to the MAIN post via the
+	// compose proxy. Terms are held as {id,name} so chips render without a
+	// second lookup; only ids are sent on write.
+	const [ featuredMediaId, setFeaturedMediaId ] = useState( 0 );
+	const [ selectedTerms, setSelectedTerms ] = useState< Record< string, WpTerm[] > >( {} );
+	const featuredMediaIdRef = useRef( 0 );
+	const selectedTermsRef = useRef< Record< string, WpTerm[] > >( {} );
+	featuredMediaIdRef.current = featuredMediaId;
+	selectedTermsRef.current = selectedTerms;
 
 	// Autosave tracking refs.
 	const autosaveTimerRef = useRef< ReturnType< typeof setTimeout > | null >( null );
@@ -224,6 +242,65 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 			} catch {
 				return '';
 			}
+		},
+		[]
+	);
+
+	/**
+	 * Build the review-field portion of a post write payload — featured image
+	 * and editorial taxonomies — from the current selections. Keyed by the REST
+	 * field names main's /wp/v2/posts controller expects; the compose proxy
+	 * whitelists exactly these and forwards them to the MAIN post.
+	 */
+	const buildReviewPayload = useCallback( (): Record< string, unknown > => {
+		const payload: Record< string, unknown > = {
+			featured_media: featuredMediaIdRef.current || 0,
+		};
+		for ( const tax of COMPOSE_TAXONOMIES ) {
+			payload[ tax.field ] = ( selectedTermsRef.current[ tax.slug ] || [] ).map( ( t ) => t.id );
+		}
+		return payload;
+	}, [] );
+
+	/**
+	 * Hydrate the review-field selections (featured image + term chips) for a
+	 * post being switched into. Term id arrays on the post are resolved to
+	 * {id,name} via the compose proxy so chips render with labels. Best-effort:
+	 * a failed term lookup leaves that taxonomy empty rather than blocking the
+	 * draft switch.
+	 *
+	 * @param post The post being switched into, or null to reset.
+	 */
+	const hydrateReviewFields = useCallback(
+		async ( post: WpPost | null ): Promise< void > => {
+			if ( ! post ) {
+				setFeaturedMediaId( 0 );
+				setSelectedTerms( {} );
+				return;
+			}
+
+			setFeaturedMediaId( post.featured_media ? Number( post.featured_media ) : 0 );
+
+			const next: Record< string, WpTerm[] > = {};
+			await Promise.all(
+				COMPOSE_TAXONOMIES.map( async ( tax ) => {
+					const ids = ( post[ tax.field as 'categories' | 'artist' | 'venue' | 'location' ] || [] ) as number[];
+					if ( ! Array.isArray( ids ) || ids.length === 0 ) {
+						next[ tax.slug ] = [];
+						return;
+					}
+					try {
+						const include = ids.join( ',' );
+						const terms = await composeApiFetch< WpTerm[] >( {
+							path: `/extrachill/v1/studio/compose/terms/${ tax.slug }?include=${ include }&per_page=100`,
+						} );
+						next[ tax.slug ] = Array.isArray( terms ) ? terms : [];
+					} catch {
+						next[ tax.slug ] = [];
+					}
+				} )
+			);
+			setSelectedTerms( next );
 		},
 		[]
 	);
@@ -471,6 +548,7 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 			contentSnapshotRef.current = content;
 			replaceEditorContent( content );
 			lastSavedPayloadRef.current = JSON.stringify( { title, content } );
+			void hydrateReviewFields( post );
 		} else {
 			activePostIdRef.current = null;
 			titleRef.current = '';
@@ -479,13 +557,14 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 			setTitle( '' );
 			replaceEditorContent( '' );
 			lastSavedPayloadRef.current = '';
+			void hydrateReviewFields( null );
 		}
 
 		setHasUnsavedChanges( false );
 		setError( '' );
 		setStatus( '' );
 		scheduleClientContextUpdate();
-	}, [ flushCurrentDraft, scheduleClientContextUpdate ] );
+	}, [ flushCurrentDraft, scheduleClientContextUpdate, hydrateReviewFields ] );
 
 	const startNew = useCallback( async (): Promise< void > => {
 		await switchToDraft( null );
@@ -707,6 +786,7 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 					title: post.title.raw || post.title.rendered || '',
 					content: post.content.raw || post.content.rendered || '',
 				} );
+				void hydrateReviewFields( post );
 			} else {
 				activePostIdRef.current = null;
 				titleRef.current = '';
@@ -740,7 +820,7 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 		return () => {
 			cancelled = true;
 		};
-	}, [ loadDrafts, scheduleClientContextUpdate ] );
+	}, [ loadDrafts, scheduleClientContextUpdate, hydrateReviewFields ] );
 
 
 
@@ -848,6 +928,20 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 			return;
 		}
 
+		// Review-readiness gate (Extra-Chill/extrachill-studio#108): a
+		// submission must reach an editor with at least a featured image and a
+		// category, so they aren't left dressing a bare title+body by hand.
+		if ( ! featuredMediaIdRef.current ) {
+			setError( __( 'Add a featured image before submitting for review.', 'extrachill-studio' ) );
+			setStatus( '' );
+			return;
+		}
+		if ( ! ( selectedTermsRef.current.category || [] ).length ) {
+			setError( __( 'Choose a category before submitting for review.', 'extrachill-studio' ) );
+			setStatus( '' );
+			return;
+		}
+
 		if ( autosaveTimerRef.current ) {
 			clearTimeout( autosaveTimerRef.current );
 			autosaveTimerRef.current = null;
@@ -867,6 +961,7 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 					title: title.trim(),
 					content,
 					status: 'pending',
+					...buildReviewPayload(),
 				},
 			} );
 
@@ -910,7 +1005,7 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 			const post = await composeApiFetch< WpPost >( {
 				path,
 				method: 'POST',
-				data: { title: title.trim(), content, status: 'draft' },
+				data: { title: title.trim(), content, status: 'draft', ...buildReviewPayload() },
 			} );
 
 			activePostIdRef.current = post.id;
@@ -955,6 +1050,16 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 		}
 	};
 
+	const onFeaturedChange = useCallback( ( id: number ): void => {
+		setFeaturedMediaId( id );
+		setError( '' );
+	}, [] );
+
+	const onTermsChange = useCallback( ( slug: string, terms: WpTerm[] ): void => {
+		setSelectedTerms( ( prev ) => ( { ...prev, [ slug ]: terms } ) );
+		setError( '' );
+	}, [] );
+
 	const onTitleChange = ( e: ChangeEvent< HTMLInputElement > ): void => {
 		editSeqRef.current += 1;
 		titleRef.current = e.target.value;
@@ -991,6 +1096,21 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 			)
 		)
 	);
+
+	// Review-readiness (#108): featured image + at least one category. Drives
+	// the Submit button's disabled state and an inline nudge so the gate is
+	// guided, not a surprise wall at click time.
+	const hasFeatured = featuredMediaId > 0;
+	const hasCategory = ( selectedTerms.category || [] ).length > 0;
+	const reviewReady = hasFeatured && hasCategory;
+
+	const missingReviewFields: string[] = [];
+	if ( ! hasFeatured ) {
+		missingReviewFields.push( __( 'a featured image', 'extrachill-studio' ) );
+	}
+	if ( ! hasCategory ) {
+		missingReviewFields.push( __( 'a category', 'extrachill-studio' ) );
+	}
 
 	return h(
 		'div',
@@ -1052,6 +1172,20 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 				! error && status
 					? h( InlineStatusView, { tone: 'success', className: 'ec-studio-message' }, status )
 					: null,
+				! reviewReady && missingReviewFields.length
+					? h(
+						InlineStatusView,
+						{ tone: 'info', className: 'ec-studio-message ec-studio-compose-review__hint' },
+						sprintf(
+							/* translators: %s: list of missing fields, e.g. "a featured image and a category". */
+							__( 'Add %s to submit for review.', 'extrachill-studio' ),
+							// Join with a localized conjunction. The separator is
+							// built from a trimmed word so no translatable string
+							// carries flanking whitespace.
+							missingReviewFields.join( ` ${ __( 'and', 'extrachill-studio' ) } ` )
+						)
+					)
+					: null,
 				h(
 					ActionRowView,
 					{ className: 'ec-studio-composer__actions' },
@@ -1061,7 +1195,7 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 						type: 'button',
 						className: 'button-1 button-medium',
 						onClick: submitForReview,
-						disabled: isSubmitting || isSwitching || ! editorReady,
+						disabled: isSubmitting || isSwitching || ! editorReady || ! reviewReady,
 					},
 					isSubmitting ? __( 'Submitting…', 'extrachill-studio' ) : __( 'Submit for Review', 'extrachill-studio' )
 				),
@@ -1085,8 +1219,33 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 					PanelView,
 					{ className: 'ec-studio-panel ec-studio-panel--compose-sidebar', compact: true },
 					h( PanelHeader, {
-						description: __( 'Browse blocks and structure without crowding the writing canvas.', 'extrachill-studio' ),
+						description: __( 'Set the featured image and terms so an editor gets a review-ready post.', 'extrachill-studio' ),
 					} ),
+					createElement(
+						'div',
+						{ className: 'ec-studio-compose-review' },
+						h( FeaturedImage, {
+							composeApiFetch,
+							mediaId: featuredMediaId,
+							onChange: onFeaturedChange,
+							disabled: isSubmitting || isSwitching,
+						} ),
+						...COMPOSE_TAXONOMIES.map( ( tax ) =>
+							h( TermPicker, {
+								key: tax.slug,
+								composeApiFetch,
+								taxonomy: tax.slug,
+								label: tax.label,
+								required: tax.required,
+								// Category is single-select (one primary category);
+								// artist/venue/location can carry several.
+								multiple: ! tax.required,
+								selected: selectedTerms[ tax.slug ] || [],
+								onChange: ( terms: WpTerm[] ) => onTermsChange( tax.slug, terms ),
+								disabled: isSubmitting || isSwitching,
+							} )
+						)
+					),
 					createElement( 'div', {
 						className: 'ec-studio-compose-sidebar__slot',
 					} )

--- a/src/blocks/studio/tabs/compose/review-fields.ts
+++ b/src/blocks/studio/tabs/compose/review-fields.ts
@@ -1,0 +1,546 @@
+/**
+ * Compose review-readiness fields — featured image + editorial taxonomies.
+ *
+ * The Compose pane lets a writer draft a post that is BORN ON MAIN (blog 1),
+ * but until Extra-Chill/extrachill-studio#108 it could reach editorial review
+ * with only a title + body — no featured image, no category, no artist/venue/
+ * location — leaving an editor to dress the post by hand with context they
+ * don't have.
+ *
+ * This module adds the pre-submit gate: a small set of controls that read and
+ * write MAIN's featured image and editorial taxonomies through the born-on-main
+ * compose proxy (`/extrachill/v1/studio/compose/*`). Every call is made with
+ * the `composeApiFetch` wrapper the pane injects so the request carries the
+ * compose marker and the server forwards it to main — the featured image and
+ * terms therefore land on the MAIN post, never on the Studio subsite (blog 12).
+ *
+ * Deliberately NO free-tag (`post_tag`) control: Extra Chill does not use
+ * free-form tags. The taxonomies surfaced are category (required), artist,
+ * venue, and location (prompted, optional).
+ */
+
+import { __, sprintf } from '@wordpress/i18n';
+import {
+	createElement,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from '@wordpress/element';
+import type { ReactElement, ChangeEvent } from 'react';
+import type { APIFetchOptions } from '@wordpress/api-fetch';
+
+/** apiFetch wrapper injected by the Compose pane (tags requests for main). */
+export type ComposeApiFetch = < T = unknown >(
+	options: APIFetchOptions< true >
+) => Promise< T >;
+
+const h = createElement;
+
+/** A term as returned by main's `/wp/v2/<rest_base>` REST route. */
+export interface WpTerm {
+	id: number;
+	name: string;
+	parent?: number;
+}
+
+/** An attachment as returned by main's `/wp/v2/media/<id>` route. */
+interface WpMedia {
+	id: number;
+	source_url?: string;
+	alt_text?: string;
+	media_details?: {
+		sizes?: Record< string, { source_url?: string } >;
+	};
+}
+
+/**
+ * Studio compose taxonomy slugs, mapped to the post-write REST field the main
+ * `/wp/v2/posts` controller expects (each taxonomy's rest_base). The category
+ * field is `categories`; the platform taxonomies keep their own slug.
+ */
+export const COMPOSE_TAXONOMIES = [
+	{
+		slug: 'category',
+		field: 'categories',
+		label: __( 'Category', 'extrachill-studio' ),
+		required: true,
+	},
+	{
+		slug: 'artist',
+		field: 'artist',
+		label: __( 'Artist', 'extrachill-studio' ),
+		required: false,
+	},
+	{
+		slug: 'venue',
+		field: 'venue',
+		label: __( 'Venue', 'extrachill-studio' ),
+		required: false,
+	},
+	{
+		slug: 'location',
+		field: 'location',
+		label: __( 'Location', 'extrachill-studio' ),
+		required: false,
+	},
+] as const;
+
+/** Proxy route prefix (forwards to main). Mirrors the PHP compose proxy. */
+const PROXY_TERMS = '/extrachill/v1/studio/compose/terms';
+
+/**
+ * Pull the best available preview URL from a main-site attachment.
+ *
+ * Prefers the `medium` size, then `thumbnail`, then the full source URL, so the
+ * featured-image preview is a reasonable size without a second request.
+ * @param media
+ */
+function pickMediaPreview( media: WpMedia | null ): string {
+	if ( ! media ) {
+		return '';
+	}
+	const sizes = media.media_details?.sizes;
+	return (
+		sizes?.medium?.source_url ||
+		sizes?.thumbnail?.source_url ||
+		media.source_url ||
+		''
+	);
+}
+
+/**
+ * Featured-image control for the Compose pane.
+ *
+ * Uploads a chosen file to MAIN's media library via the compose proxy (the same
+ * `/wp/v2/media` route the inline editor uploads through, rewritten to main),
+ * then reports the resulting attachment id up so it is written to the main post
+ * as `featured_media`. Hydrates a preview for an already-set featured image.
+ * @param props
+ * @param props.composeApiFetch
+ * @param props.mediaId
+ * @param props.onChange
+ * @param props.disabled
+ */
+export function FeaturedImage( props: {
+	composeApiFetch: ComposeApiFetch;
+	mediaId: number;
+	onChange: ( id: number ) => void;
+	disabled?: boolean;
+} ): ReactElement {
+	const { composeApiFetch, mediaId, onChange, disabled } = props;
+	const [ previewUrl, setPreviewUrl ] = useState( '' );
+	const [ isUploading, setIsUploading ] = useState( false );
+	const [ error, setError ] = useState( '' );
+	const fileInputRef = useRef< HTMLInputElement >( null );
+	// Guards a hydrate against a stale response when mediaId changes rapidly
+	// (e.g. draft switch) before the fetch resolves.
+	const hydrateSeqRef = useRef( 0 );
+
+	// Hydrate a preview when a featured image id is present (draft load / set).
+	useEffect( () => {
+		if ( ! mediaId ) {
+			setPreviewUrl( '' );
+			return;
+		}
+		const seq = ++hydrateSeqRef.current;
+		( async (): Promise< void > => {
+			try {
+				const media = await composeApiFetch< WpMedia >( {
+					path: `/wp/v2/media/${ mediaId }`,
+				} );
+				if ( seq === hydrateSeqRef.current ) {
+					setPreviewUrl( pickMediaPreview( media ) );
+				}
+			} catch {
+				if ( seq === hydrateSeqRef.current ) {
+					setPreviewUrl( '' );
+				}
+			}
+		} )();
+	}, [ mediaId, composeApiFetch ] );
+
+	const onFileChange = useCallback(
+		async ( e: ChangeEvent< HTMLInputElement > ): Promise< void > => {
+			const file = e.target.files?.[ 0 ];
+			// Reset the input so re-selecting the same file re-triggers change.
+			if ( fileInputRef.current ) {
+				fileInputRef.current.value = '';
+			}
+			if ( ! file ) {
+				return;
+			}
+
+			setIsUploading( true );
+			setError( '' );
+			try {
+				const form = new window.FormData();
+				form.append( 'file', file );
+				const media = await composeApiFetch< WpMedia >( {
+					path: '/wp/v2/media',
+					method: 'POST',
+					body: form,
+				} );
+				if ( media?.id ) {
+					setPreviewUrl( pickMediaPreview( media ) );
+					onChange( media.id );
+				}
+			} catch ( uploadError ) {
+				setError(
+					( uploadError as Error )?.message ||
+						__(
+							'Featured image upload failed.',
+							'extrachill-studio'
+						)
+				);
+			} finally {
+				setIsUploading( false );
+			}
+		},
+		[ composeApiFetch, onChange ]
+	);
+
+	const inputId = 'ec-studio-compose-featured-input';
+
+	let uploadLabel: string = __( 'Upload image', 'extrachill-studio' );
+	if ( isUploading ) {
+		uploadLabel = __( 'Uploading…', 'extrachill-studio' );
+	} else if ( mediaId ) {
+		uploadLabel = __( 'Replace image', 'extrachill-studio' );
+	}
+
+	return h(
+		'div',
+		{ className: 'ec-studio-compose-review__field' },
+		h(
+			'div',
+			{ className: 'ec-studio-compose-review__label' },
+			__( 'Featured image', 'extrachill-studio' ),
+			h(
+				'span',
+				{ className: 'ec-studio-compose-review__required' },
+				__( '(required)', 'extrachill-studio' )
+			)
+		),
+		previewUrl
+			? h( 'img', {
+					className: 'ec-studio-compose-featured__preview',
+					src: previewUrl,
+					alt: __( 'Featured image preview', 'extrachill-studio' ),
+			  } )
+			: h(
+					'div',
+					{ className: 'ec-studio-compose-featured__empty' },
+					__( 'No featured image yet.', 'extrachill-studio' )
+			  ),
+		h(
+			'div',
+			{ className: 'ec-studio-compose-featured__actions' },
+			h( 'input', {
+				id: inputId,
+				ref: fileInputRef,
+				type: 'file',
+				accept: 'image/jpeg,image/png,image/gif,image/webp',
+				className: 'ec-studio-compose-featured__file',
+				onChange: onFileChange,
+				disabled: disabled || isUploading,
+			} ),
+			h(
+				'label',
+				{
+					htmlFor: inputId,
+					className:
+						'button-1 button-small ec-studio-compose-featured__button',
+				},
+				uploadLabel
+			),
+			mediaId
+				? h(
+						'button',
+						{
+							type: 'button',
+							className: 'button-1 button-small button-secondary',
+							onClick: () => {
+								setPreviewUrl( '' );
+								onChange( 0 );
+							},
+							disabled: disabled || isUploading,
+						},
+						__( 'Remove', 'extrachill-studio' )
+				  )
+				: null
+		),
+		error
+			? h(
+					'div',
+					{ className: 'ec-studio-compose-review__error' },
+					error
+			  )
+			: null
+	);
+}
+
+/**
+ * Single-taxonomy term picker for the Compose pane.
+ *
+ * Reads/searches MAIN's terms through the compose proxy, lets the writer select
+ * one or more existing terms, and add a missing term (create-on-main). Reports
+ * the selected term ids up so they are written to the main post as the
+ * taxonomy's REST field. Category is used as a single-select required field;
+ * artist/venue/location are multi-select and optional.
+ * @param props
+ * @param props.composeApiFetch
+ * @param props.taxonomy
+ * @param props.label
+ * @param props.required
+ * @param props.multiple
+ * @param props.selected
+ * @param props.onChange
+ * @param props.disabled
+ */
+export function TermPicker( props: {
+	composeApiFetch: ComposeApiFetch;
+	taxonomy: string;
+	label: string;
+	required?: boolean;
+	multiple?: boolean;
+	selected: WpTerm[];
+	onChange: ( terms: WpTerm[] ) => void;
+	disabled?: boolean;
+} ): ReactElement {
+	const {
+		composeApiFetch,
+		taxonomy,
+		label,
+		required,
+		multiple,
+		selected,
+		onChange,
+		disabled,
+	} = props;
+	const [ search, setSearch ] = useState( '' );
+	const [ results, setResults ] = useState< WpTerm[] >( [] );
+	const [ isSearching, setIsSearching ] = useState( false );
+	const [ isCreating, setIsCreating ] = useState( false );
+	const [ error, setError ] = useState( '' );
+	const searchTimerRef = useRef< ReturnType< typeof setTimeout > | null >(
+		null
+	);
+	const searchSeqRef = useRef( 0 );
+
+	const runSearch = useCallback(
+		async ( term: string ): Promise< void > => {
+			const seq = ++searchSeqRef.current;
+			setIsSearching( true );
+			try {
+				const query = term.trim()
+					? `?search=${ encodeURIComponent(
+							term.trim()
+					  ) }&per_page=20`
+					: '?per_page=20&orderby=count&order=desc';
+				const found = await composeApiFetch< WpTerm[] >( {
+					path: `${ PROXY_TERMS }/${ taxonomy }${ query }`,
+				} );
+				if ( seq === searchSeqRef.current ) {
+					setResults( Array.isArray( found ) ? found : [] );
+				}
+			} catch {
+				if ( seq === searchSeqRef.current ) {
+					setResults( [] );
+				}
+			} finally {
+				if ( seq === searchSeqRef.current ) {
+					setIsSearching( false );
+				}
+			}
+		},
+		[ composeApiFetch, taxonomy ]
+	);
+
+	const onSearchChange = useCallback(
+		( e: ChangeEvent< HTMLInputElement > ): void => {
+			const value = e.target.value;
+			setSearch( value );
+			setError( '' );
+			if ( searchTimerRef.current ) {
+				clearTimeout( searchTimerRef.current );
+			}
+			searchTimerRef.current = setTimeout( () => {
+				searchTimerRef.current = null;
+				runSearch( value );
+			}, 300 );
+		},
+		[ runSearch ]
+	);
+
+	const selectTerm = useCallback(
+		( term: WpTerm ): void => {
+			if ( selected.some( ( t ) => t.id === term.id ) ) {
+				return;
+			}
+			onChange( multiple ? [ ...selected, term ] : [ term ] );
+			setSearch( '' );
+			setResults( [] );
+		},
+		[ selected, onChange, multiple ]
+	);
+
+	const removeTerm = useCallback(
+		( id: number ): void => {
+			onChange( selected.filter( ( t ) => t.id !== id ) );
+		},
+		[ selected, onChange ]
+	);
+
+	const createTerm = useCallback( async (): Promise< void > => {
+		const name = search.trim();
+		if ( ! name ) {
+			return;
+		}
+		setIsCreating( true );
+		setError( '' );
+		try {
+			const term = await composeApiFetch< WpTerm >( {
+				path: `${ PROXY_TERMS }/${ taxonomy }`,
+				method: 'POST',
+				data: { name },
+			} );
+			if ( term?.id ) {
+				selectTerm( term );
+			}
+		} catch ( createError ) {
+			setError(
+				( createError as Error )?.message ||
+					__( 'Could not create that term.', 'extrachill-studio' )
+			);
+		} finally {
+			setIsCreating( false );
+		}
+	}, [ search, composeApiFetch, taxonomy, selectTerm ] );
+
+	useEffect( () => {
+		return () => {
+			if ( searchTimerRef.current ) {
+				clearTimeout( searchTimerRef.current );
+			}
+		};
+	}, [] );
+
+	// Whether the typed search exactly matches an existing result (so we don't
+	// offer "create" for something that already exists).
+	const exactMatch = results.some(
+		( t ) => t.name.trim().toLowerCase() === search.trim().toLowerCase()
+	);
+	const canCreate = search.trim().length > 0 && ! exactMatch && ! isSearching;
+
+	const createLabel = isCreating
+		? __( 'Adding…', 'extrachill-studio' )
+		: sprintf(
+				/* translators: %s: the term name being created */
+				__( 'Add “%s”', 'extrachill-studio' ),
+				search.trim()
+		  );
+
+	return h(
+		'div',
+		{ className: 'ec-studio-compose-review__field' },
+		h(
+			'div',
+			{ className: 'ec-studio-compose-review__label' },
+			label,
+			required
+				? h(
+						'span',
+						{ className: 'ec-studio-compose-review__required' },
+						__( '(required)', 'extrachill-studio' )
+				  )
+				: h(
+						'span',
+						{ className: 'ec-studio-compose-review__optional' },
+						__( '(optional)', 'extrachill-studio' )
+				  )
+		),
+		selected.length
+			? h(
+					'div',
+					{ className: 'ec-studio-compose-review__chips' },
+					...selected.map( ( term ) =>
+						h(
+							'span',
+							{
+								key: term.id,
+								className: 'ec-studio-compose-review__chip',
+							},
+							term.name,
+							h(
+								'button',
+								{
+									type: 'button',
+									className:
+										'ec-studio-compose-review__chip-remove',
+									'aria-label': __(
+										'Remove',
+										'extrachill-studio'
+									),
+									onClick: () => removeTerm( term.id ),
+									disabled,
+								},
+								'×'
+							)
+						)
+					)
+			  )
+			: null,
+		h( 'input', {
+			type: 'text',
+			className: 'ec-studio-compose-review__search',
+			placeholder: __( 'Search or add…', 'extrachill-studio' ),
+			value: search,
+			onChange: onSearchChange,
+			disabled: disabled || isCreating,
+		} ),
+		results.length
+			? h(
+					'ul',
+					{ className: 'ec-studio-compose-review__results' },
+					...results.map( ( term ) =>
+						h(
+							'li',
+							{ key: term.id },
+							h(
+								'button',
+								{
+									type: 'button',
+									className:
+										'ec-studio-compose-review__result',
+									onClick: () => selectTerm( term ),
+									disabled,
+								},
+								term.name
+							)
+						)
+					)
+			  )
+			: null,
+		canCreate
+			? h(
+					'button',
+					{
+						type: 'button',
+						className:
+							'button-1 button-small ec-studio-compose-review__create',
+						onClick: createTerm,
+						disabled: disabled || isCreating,
+					},
+					createLabel
+			  )
+			: null,
+		error
+			? h(
+					'div',
+					{ className: 'ec-studio-compose-review__error' },
+					error
+			  )
+			: null
+	);
+}


### PR DESCRIPTION
## Summary

The Compose pane let a writer hit **Submit for Review** with only a title + body, so posts reached editorial with **no featured image and no taxonomy** — an editor had to add all of it by hand (filed after Steve Hughes' Jinjer recap arrived bare). This adds a lightweight pre-submit gate so a Studio submission reaches an editor **review-ready**.

## What's gated

| Field | Behavior |
|---|---|
| **Featured image** | **Required** — Submit-for-Review is blocked until set |
| **Category** | **Required** — Submit-for-Review is blocked until set |
| **Artist / Venue / Location** | **Prompted, optional** — visible so writers are nudged, never required |

Submit-for-Review is disabled with an inline nudge (`Add a featured image and a category to submit for review.`) until the minimum set is present, plus a hard guard in the submit handler. Save Draft is never blocked, so a work-in-progress still persists its featured image + terms.

## Everything lands on MAIN, never blog 12

All featured-image and taxonomy writes go through the **born-on-main compose proxy** (`ec_cross_site_rest_request( 'main', ... )`), the same mechanism the compose editor already uses for content and media:

- The whitelist in `inc/compose/rest.php` is extended to forward `featured_media` + the term fields (`categories`, `artist`, `venue`, `location`) to `/wp/v2/posts` on main.
- New proxy routes `GET|POST /extrachill/v1/studio/compose/terms/<taxonomy>` back the pickers — reading/searching and creating terms on main's taxonomies under the writer's own auth.
- The featured-image upload reuses the existing `/wp/v2/media` compose rewrite (marked requests → main), so the attachment is created on blog 1.

So a submission's featured image and terms provably land on the **main post (blog 1)** — never on the Studio subsite (blog 12), preserving the born-on-main guarantee from #75/#106.

## No free tags

Extra Chill does **not** use `post_tag`. The proxy taxonomy allow-list (`ec_studio_compose_resolve_term_taxonomy`) deliberately maps only `category`/`artist`/`venue`/`location`; anything else (notably `post_tag`) is rejected. No free-form tags are added anywhere.

## Files

- `inc/compose/rest.php` — extend post-param whitelist with `featured_media` + term fields; add terms proxy routes + callbacks.
- `src/blocks/studio/tabs/compose/review-fields.ts` *(new)* — `FeaturedImage` + `TermPicker` React controls, all wired through `composeApiFetch` (compose marker → main).
- `src/blocks/studio/tabs/compose/index.ts` — review-field state, hydrate on draft switch, include review payload on save/submit, gate the Submit button.
- `src/blocks/studio/style.css` — styles for the new controls.

## Decisions made autonomously

- **Category is single-select; artist/venue/location are multi-select.** A post has one primary category but can span several artists/venues/locations.
- **Featured image is required (hard block), not a soft warning** — the issue lists it first and it's the most-missed field; a hard gate is the reliable fix.
- **`festival` was left out** of the pickers — it isn't registered on the `post` type's REST schema and the issue scoped the required/prompted set to category + artist/venue/location.

## Verification

- `npm run typecheck` ✅
- `npm run build` ✅ (compiles clean)
- `php -l inc/compose/rest.php` ✅
- phpcs (HomeboyWordPress ruleset) on `inc/compose/rest.php`: no **new** violations (pre-existing multi-line-comment findings per #66 unchanged); `review-fields.ts` is fully eslint-clean; `index.ts` adds no net-new non-prettier lint findings.

Closes #108