### PR TITLE
fix: resolve PHPCS errors blocking release

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -1,6 +1,7 @@
 {
   "id": "extrachill-studio",
   "changelog_target": "docs/CHANGELOG.md",
+  "validation_dependencies": ["data-machine", "extrachill-analytics"],
   "extensions": {
     "wordpress": {}
   },

--- a/inc/abilities/run-giveaway.php
+++ b/inc/abilities/run-giveaway.php
@@ -88,10 +88,10 @@ function ec_studio_pick_giveaway_winners( array $entries, int $count ): array {
 	// Shuffle using random_int() for crypto-secure selection.
 	$indices = range( 0, $total - 1 );
 	for ( $i = $total - 1; $i > 0; $i-- ) {
-		$j              = random_int( 0, $i );
-		$tmp            = $indices[ $i ];
-		$indices[ $i ]  = $indices[ $j ];
-		$indices[ $j ]  = $tmp;
+		$j             = random_int( 0, $i );
+		$tmp           = $indices[ $i ];
+		$indices[ $i ] = $indices[ $j ];
+		$indices[ $j ] = $tmp;
 	}
 
 	$winners = array();
@@ -247,7 +247,10 @@ function ec_studio_execute_run_giveaway( array $input ): array|\WP_Error {
 		return new \WP_Error(
 			'no_valid_entries',
 			sprintf( 'No valid entries after filtering. %d comments, %d filtered out.', $stats['total_comments'], $stats['filtered_out'] ),
-			array( 'status' => 404, 'stats' => $stats )
+			array(
+				'status' => 404,
+				'stats'  => $stats,
+			)
 		);
 	}
 
@@ -263,14 +266,14 @@ function ec_studio_execute_run_giveaway( array $input ): array|\WP_Error {
 		$message  = str_replace( '{username}', $username, $message_tpl );
 
 		$winner_data = array(
-			'rank'            => $index + 1,
-			'username'        => $username,
-			'comment_id'      => $winner['id'] ?? '',
-			'comment_text'    => $winner['text'] ?? '',
-			'mentions'        => $winner['mentions'] ?? array(),
-			'announced'       => false,
-			'reply_id'        => null,
-			'announce_error'  => null,
+			'rank'           => $index + 1,
+			'username'       => $username,
+			'comment_id'     => $winner['id'] ?? '',
+			'comment_text'   => $winner['text'] ?? '',
+			'mentions'       => $winner['mentions'] ?? array(),
+			'announced'      => false,
+			'reply_id'       => null,
+			'announce_error' => null,
 		);
 
 		if ( $announce && $reply_ability && ! empty( $winner['id'] ) ) {

--- a/inc/abilities/sweatpants-token.php
+++ b/inc/abilities/sweatpants-token.php
@@ -125,9 +125,9 @@ function ec_studio_register_sweatpants_token_ability(): void {
 				'output_schema'       => array(
 					'type'       => 'object',
 					'properties' => array(
-						'token'           => array( 'type' => 'string' ),
-						'expires_at'      => array( 'type' => 'integer' ),
-						'scope'           => array( 'type' => 'string' ),
+						'token'            => array( 'type' => 'string' ),
+						'expires_at'       => array( 'type' => 'integer' ),
+						'scope'            => array( 'type' => 'string' ),
 						// Callback handoff fields — populated only when the
 						// requested scope includes `callback:write`. The React
 						// tab passes these straight through to sweatpants in
@@ -143,9 +143,9 @@ function ec_studio_register_sweatpants_token_ability(): void {
 						// for a stolen browser-side copy beyond what the team
 						// member could already do, (c) it's per-deployment
 						// rotatable.
-						'callback_url'    => array( 'type' => array( 'string', 'null' ) ),
-						'callback_secret' => array( 'type' => array( 'string', 'null' ) ),
-						'callback_issuer' => array( 'type' => array( 'string', 'null' ) ),
+						'callback_url'     => array( 'type' => array( 'string', 'null' ) ),
+						'callback_secret'  => array( 'type' => array( 'string', 'null' ) ),
+						'callback_issuer'  => array( 'type' => array( 'string', 'null' ) ),
 						'callback_user_id' => array( 'type' => array( 'integer', 'null' ) ),
 					),
 				),
@@ -265,10 +265,10 @@ function ec_studio_execute_sweatpants_token( array $input ): array|\WP_Error {
 	// back to /wp-json/extrachill/v1/transcribe/callback when the job
 	// finishes. See inc/transcription/callback.php for the receiver.
 	if ( in_array( 'callback:write', $requested_scopes, true ) ) {
-		$callback_url = function_exists( 'rest_url' )
+		$callback_url                 = function_exists( 'rest_url' )
 			? rest_url( 'extrachill/v1/transcribe/callback' )
 			: '';
-		$response['callback_url']     = $callback_url ?: null;
+		$response['callback_url']     = $callback_url ? $callback_url : null;
 		$response['callback_secret']  = $secret;
 		$response['callback_issuer']  = EC_STUDIO_SWEATPANTS_TOKEN_ISSUER;
 		$response['callback_user_id'] = $user_id;

--- a/inc/compose-editor.php
+++ b/inc/compose-editor.php
@@ -52,7 +52,7 @@ function extrachill_studio_compose_main_max_upload_size(): int {
  * @return array
  */
 function register_compose_context( array $contexts ): array {
-	$contexts['studio'] = [
+	$contexts['studio'] = array(
 		'type'         => 'studio',
 		'textarea'     => '#ec-studio-compose-content',
 		'container'    => '.ec-studio-compose-editor',
@@ -75,7 +75,7 @@ function register_compose_context( array $contexts ): array {
 		'editor_setup' => function ( $engine ) {
 			// Add .gutenberg-support body class so BE's scoped toolbar/component
 			// dark mode styles in style-index.min.css apply.
-			add_filter( 'body_class', [ $engine, 'body_class' ] );
+			add_filter( 'body_class', array( $engine, 'body_class' ) );
 
 			// The IBE renders inline (shouldIframe=false), not in an iframe.
 			// Theme root.css variables are available on the host page, but
@@ -83,7 +83,7 @@ function register_compose_context( array $contexts ): array {
 			// proper sizing.
 			add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_editor_inline_styles', 50 );
 		},
-	];
+	);
 
 	return $contexts;
 }
@@ -189,9 +189,9 @@ function configure_compose_editor( array $settings ): array {
 	// rendered sidebar into Studio's dedicated compose sidebar slot.
 	$settings['blocksEverywhere']['sidebar']['inserter'] = true;
 	$settings['blocksEverywhere']['sidebar']['detached'] = array(
-		'target'    => '.ec-studio-compose-sidebar__slot',
-		'className' => 'ec-studio-compose-sidebar__content',
-		'persistent' => true,
+		'target'      => '.ec-studio-compose-sidebar__slot',
+		'className'   => 'ec-studio-compose-sidebar__content',
+		'persistent'  => true,
 		'defaultView' => 'inserter',
 	);
 
@@ -244,13 +244,13 @@ function configure_compose_editor( array $settings ): array {
 	// in style.css under html.is-fullscreen-mode and hides Studio chrome
 	// that sits outside the editor skeleton (title input, toolbar, save
 	// actions, detached sidebar). See Phase 1 scoping in MEMORY.md.
-	$settings['blocksEverywhere']['moreMenu']                                = array(
+	$settings['blocksEverywhere']['moreMenu']                             = array(
 		'fullscreen' => true,
 	);
-	$settings['blocksEverywhere']['defaultPreferences']                      = isset( $settings['blocksEverywhere']['defaultPreferences'] ) && is_array( $settings['blocksEverywhere']['defaultPreferences'] )
+	$settings['blocksEverywhere']['defaultPreferences']                   = isset( $settings['blocksEverywhere']['defaultPreferences'] ) && is_array( $settings['blocksEverywhere']['defaultPreferences'] )
 		? $settings['blocksEverywhere']['defaultPreferences']
 		: array();
-	$settings['blocksEverywhere']['defaultPreferences']['fullscreenMode']    = false;
+	$settings['blocksEverywhere']['defaultPreferences']['fullscreenMode'] = false;
 
 	return $settings;
 }

--- a/inc/compose/rest.php
+++ b/inc/compose/rest.php
@@ -881,7 +881,7 @@ function ec_studio_compose_whitelist_post_params( $raw ): array {
 		if ( ! isset( $raw[ $field ] ) ) {
 			continue;
 		}
-		$ids = array_values(
+		$ids              = array_values(
 			array_unique(
 				array_filter(
 					array_map( 'absint', (array) $raw[ $field ] )
@@ -1194,6 +1194,7 @@ function ec_studio_compose_upload_media( \WP_REST_Request $request ) {
 	}
 
 	$files = $request->get_file_params();
+	// phpcs:ignore WordPress.Security.NonceVerification.Missing -- REST cookie nonce already validated by the auth layer; file params are validated below.
 	if ( empty( $files['file'] ) && isset( $_FILES['file'] ) ) {
 		$files['file'] = $_FILES['file']; // phpcs:ignore WordPress.Security.NonceVerification.Missing -- REST cookie nonce already validated by the auth layer; file params are validated below.
 	}

--- a/inc/social-drafts.php
+++ b/inc/social-drafts.php
@@ -64,7 +64,7 @@ function register_social_meta() {
 				'schema' => array(
 					'type'  => 'array',
 					'items' => array(
-						'type' => 'object',
+						'type'       => 'object',
 						'properties' => array(
 							'url' => array( 'type' => 'string' ),
 						),
@@ -198,11 +198,16 @@ function on_publish_crosspost( string $new_status, string $old_status, \WP_Post 
 		return;
 	}
 
-	$images       = get_post_meta( $post->ID, META_IMAGES, true ) ?: array();
-	$aspect_ratio = get_post_meta( $post->ID, META_ASPECT_RATIO, true ) ?: '4:5';
-	$media_kind   = get_post_meta( $post->ID, META_MEDIA_KIND, true ) ?: 'image';
-	$video_url    = get_post_meta( $post->ID, META_VIDEO_URL, true ) ?: '';
-	$cover_url    = get_post_meta( $post->ID, META_COVER_URL, true ) ?: '';
+	$images       = get_post_meta( $post->ID, META_IMAGES, true );
+	$images       = $images ? $images : array();
+	$aspect_ratio = get_post_meta( $post->ID, META_ASPECT_RATIO, true );
+	$aspect_ratio = $aspect_ratio ? $aspect_ratio : '4:5';
+	$media_kind   = get_post_meta( $post->ID, META_MEDIA_KIND, true );
+	$media_kind   = $media_kind ? $media_kind : 'image';
+	$video_url    = get_post_meta( $post->ID, META_VIDEO_URL, true );
+	$video_url    = $video_url ? $video_url : '';
+	$cover_url    = get_post_meta( $post->ID, META_COVER_URL, true );
+	$cover_url    = $cover_url ? $cover_url : '';
 
 	// Schedule async cross-post via DM Task System.
 	$job_id = \DataMachine\Engine\Tasks\TaskScheduler::schedule(
@@ -246,7 +251,8 @@ add_action( 'transition_post_status', __NAMESPACE__ . '\\on_publish_crosspost', 
  * @param array $results Array of result entries.
  */
 function log_publish_result( int $post_id, array $results ) {
-	$existing = get_post_meta( $post_id, META_PUBLISH_LOG, true ) ?: array();
+	$existing = get_post_meta( $post_id, META_PUBLISH_LOG, true );
+	$existing = $existing ? $existing : array();
 	$merged   = array_merge( $existing, $results );
 	update_post_meta( $post_id, META_PUBLISH_LOG, $merged );
 }
@@ -288,7 +294,7 @@ function render_admin_columns( string $column, int $post_id ) {
 			} ) );
 			$total   = count( $log );
 			/* translators: 1: success count 2: total count */
-			printf( esc_html__( '%1$d / %2$d posted', 'extrachill-studio' ), $success, $total );
+			echo esc_html( sprintf( __( '%1$d / %2$d posted', 'extrachill-studio' ), (int) $success, (int) $total ) );
 		} else {
 			$platforms = get_post_meta( $post_id, META_PLATFORMS, true );
 			if ( ! empty( $platforms ) ) {


### PR DESCRIPTION
## Summary

Clears the **13 pre-existing PHPCS errors** that fail the `homeboy release` lint gate for extrachill-studio, so already-merged work can ship. All errors were in first-party `inc/` code — the linter's scan scope is correct (homeboy's bundled `phpcs.xml.dist` already excludes `vendor/`, `node_modules/`, `build/`, `dist/`, `tests/`), so there were **no PHPCS false positives** to exclude. No behavior changes.

**Result:** `PHPCS SUMMARY: 0 errors, 1 warnings` (the remaining warning is an unused `$request` param — a warning, not a blocking error).

## Auto-fixed via `phpcbf` (pure formatting, zero logic change)

- `inc/compose-editor.php` — short-array `[]` → `array()` (`Universal.Arrays.DisallowShortArraySyntax`) + double-arrow/assignment alignment.
- `inc/abilities/run-giveaway.php` — associative-array multi-line formatting (`WordPress.Arrays.ArrayDeclarationSpacing`) + alignment.
- `inc/abilities/sweatpants-token.php` — double-arrow alignment.
- `inc/social-drafts.php` / `inc/compose/rest.php` — alignment.

Verified the auto-fix diffs are whitespace/syntax-only (e.g. the crypto shuffle in `run-giveaway.php` is byte-identical logic, just re-aligned).

## Hand-fixed (careful, behavior-preserving)

- **Short ternaries** (`Universal.Operators.DisallowShortTernary`) — `inc/social-drafts.php` (6) and `inc/abilities/sweatpants-token.php` (1). Expanded `$x = get_post_meta(...) ?: $default;` into `$x = get_post_meta(...); $x = $x ? $x : $default;` so the meta call is still evaluated exactly once (no double-call, identical fallback semantics).
- **Unescaped output** (`WordPress.Security.EscapeOutput`) — `inc/social-drafts.php:291`. `printf( esc_html__( '%1\$d / %2\$d posted' ), $success, $total )` escaped the format string but not the args; rewritten as `echo esc_html( sprintf( __( ... ), (int) $success, (int) $total ) )`.
- **Misplaced nonce ignore** (`WordPress.Security.NonceVerification.Missing`) — `inc/compose/rest.php`. The existing `phpcs:ignore` sat on the `$_FILES` assignment line, but the sniff flags the `isset( $_FILES['file'] )` guard on the line above. Added the ignore to the guard line too. This is a REST endpoint whose nonce is validated by the REST cookie-auth layer via `permission_callback` — a legitimate ignore, not a suppressed real bug.

## phpcs.xml scope changes

None needed — homeboy's bundled ruleset already excludes all vendored/generated/test directories, and every flagged error was genuine first-party debt.

## PHPStan gate still blocks release — separate, pre-existing, filed upstream

`homeboy lint` also runs **PHPStan (level 7)**, which reports **28 errors** that are **pre-existing** (present on `main` before this branch — confirmed by stashing my changes and re-linting) and **out of scope for a PHPCS task**. They are **false positives**: extrachill-studio references symbols owned by sibling plugins that PHPStan's bootstrap doesn't load — `DataMachine\Engine\AI\System\Tasks\SystemTask` + its `failJob()`/`completeJob()` methods (data-machine), and the `EC_ANALYTICS_EVENT_STUDIO_*` constants (extrachill-analytics).

- This commit adds `"validation_dependencies": ["data-machine", "extrachill-analytics"]` to `homeboy.json` (the same field `extrachill-api` uses to pull in `data-machine`) — the correct in-repo declaration of the dependency.
- **However, the current homeboy version does not honor `validation_dependencies` from a worktree checkout**, so PHPStan still can't see those symbols and the 28 errors persist. Filed as **Extra-Chill/homeboy-extensions#2144** with full repro.

Until homeboy honors that field (or the release is run with `--skip-checks=lint`, an operator call), the PHPStan gate remains a blocker independent of this PHPCS work. This PR fully resolves the PHPCS half of the gate and declares the intended dependencies.

## Constraints honored

No merge, no release, no deploy. No CHANGELOG or version edits. Conventional commits.