### PR TITLE
fix: unscrunch Studio compose editor and use full page width

### DIFF
--- a/src/blocks/studio/style.css
+++ b/src/blocks/studio/style.css
@@ -566,10 +566,37 @@
 	}
 }
 
-/* Compose tab — block editor */
+/* Compose tab — block editor.
+ * Deliberately NOT using the shared .ec-card-grid utility: the compose layout
+ * wants a fixed editor+sidebar split, not an auto-fit card grid. Previously
+ * both .ec-card-grid (repeat(auto-fit,minmax(...))) and this 2-column rule
+ * fought over grid-template-columns on the same element (regression from #116),
+ * which scrunched the editor and ballooned the sidebar. ec-card-grid also
+ * supplied display:grid + gap, so those are declared explicitly here now that
+ * the class is gone from the compose wrapper. minmax(0, ...) lets the editor
+ * column shrink its content instead of overflowing on wide code blocks. */
 .ec-studio-pane__grid--compose {
-	grid-template-columns: 2fr 1fr;
+	display: grid;
+	grid-template-columns: minmax(0, 3fr) minmax(0, 1fr);
+	gap: var(--spacing-lg);
 	align-items: start;
+}
+
+/* Compose pane — full-width breakout (edge-to-edge with comfortable gutters).
+ * Mirrors the theme `.full-width-breakout` primitive but uses the transform-
+ * free `calc(50% - 50vw)` centering technique instead of transform:
+ * translateX(-50%). A transform on this ancestor would establish a containing
+ * block for the IBE fullscreen overlay's `position: fixed` (.iso-editor /
+ * .interface-interface-skeleton pinned inset:0 below), breaking the fullscreen
+ * writing mode. The margin-based breakout gives the same edge-to-edge layout
+ * without that side effect. Scoped to the compose tab only. */
+.ec-studio-pane--compose {
+	width: 100vw;
+	max-width: 100vw;
+	margin-left: calc(50% - 50vw);
+	padding-left: max(var(--spacing-lg), env(safe-area-inset-left));
+	padding-right: max(var(--spacing-lg), env(safe-area-inset-right));
+	box-sizing: border-box;
 }
 
 .ec-studio-panel--editor {
@@ -827,6 +854,13 @@
 @media (max-width: 768px) {
 	.ec-studio-pane__grid--compose {
 		grid-template-columns: 1fr;
+	}
+
+	/* Tighten the full-width breakout gutters on small screens (matches the
+	 * theme .full-width-breakout mobile padding). */
+	.ec-studio-pane--compose {
+		padding-left: max(0.75em, env(safe-area-inset-left));
+		padding-right: max(0.75em, env(safe-area-inset-right));
 	}
 }
 

--- a/src/blocks/studio/tabs/compose/index.ts
+++ b/src/blocks/studio/tabs/compose/index.ts
@@ -1117,7 +1117,7 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 		{ className: 'ec-studio-pane ec-studio-pane--compose' },
 		h(
 			'div',
-			{ className: 'ec-card-grid ec-studio-pane__grid ec-studio-pane__grid--compose' },
+			{ className: 'ec-studio-pane__grid ec-studio-pane__grid--compose' },
 			h(
 				PanelView,
 				{ className: 'ec-studio-panel ec-studio-panel--editor', compact: true },


### PR DESCRIPTION
## Root cause

PR #116 (`e43f797`, "adopt shared Grid/.ec-card-grid primitive") added the class `ec-card-grid` to the Compose grid wrapper in `src/blocks/studio/tabs/compose/index.ts`. That element **also** carried an explicit two-column split in `style.css`:

```css
.ec-studio-pane__grid--compose { grid-template-columns: 2fr 1fr; align-items: start; }
```

`.ec-card-grid` (from `@extrachill/components`) declares a competing `grid-template-columns: repeat(auto-fit, minmax(min(100%, var(--ec-card-grid-min, 240px)), 1fr))`. Both are single-class selectors (equal specificity), so the two declarations fight over `grid-template-columns` on the same element depending on bundled source order — the auto-fit card grid interferes with the intended editor+sidebar split, **scrunching the editor and ballooning the sidebar**.

### Timing note

- `#108` (review gate) and `#116` (this regression) both landed **Jul 3**.
- The validated "easy enough to use" Studio session (Steve Hughes, Jinjer recap + 65-photo gallery) was **Jul 2** — *before* both. So no one has actually composed through the degraded UI yet.

## What changed (layout/CSS only)

**1. Removed `ec-card-grid` from the compose wrapper** (`compose/index.ts:1120`):
```diff
- { className: 'ec-card-grid ec-studio-pane__grid ec-studio-pane__grid--compose' },
+ { className: 'ec-studio-pane__grid ec-studio-pane__grid--compose' },
```
The compose pane wants a deliberate 2-column editor+sidebar split, not an auto-fit card grid. Only the compose wrapper is touched — the giveaway stats grid (`giveaway/index.ts:455`) legitimately keeps `ec-card-grid`.

**2. Restored `display:grid` + `gap` and widened the editor** (`style.css`). Since `ec-card-grid` was the source of `display:grid` and `gap` for this element, those are now declared explicitly on `.ec-studio-pane__grid--compose`. The editor share is widened from `2fr 1fr` → `minmax(0, 3fr) minmax(0, 1fr)`:
```css
.ec-studio-pane__grid--compose {
    display: grid;
    grid-template-columns: minmax(0, 3fr) minmax(0, 1fr);
    gap: var(--spacing-lg);
    align-items: start;
}
```
The `minmax(0, ...)` lets the editor column actually shrink its content (wide code blocks, preformatted blocks) instead of overflowing the track — a latent issue with bare `fr`.

**3. Full-width breakout, scoped to the compose pane only** (`.ec-studio-pane--compose`). The Studio renders inside the theme's `.extrachill-content` container (~1200px gutter), wasting edge real estate. This makes the editor+sidebar span the viewport with comfortable gutters.

### Why I did **not** reuse the theme `full-width-breakout` class

The theme primitive uses `transform: translateX(-50%)`. The IBE fullscreen mode (see `style.css` "Compose tab — fullscreen mode") pins `.iso-editor` / `.interface-interface-skeleton` to `position: fixed; inset: 0`. **A `transform` on `.ec-studio-pane--compose` would establish a containing block for those fixed descendants**, repositioning the fullscreen overlay relative to the pane instead of the viewport and breaking the fullscreen writing mode (it would no longer stay pinned to the viewport / cover it fully).

Instead I replicated the breakout with the **transform-free** `margin-left: calc(50% - 50vw)` centering technique — same edge-to-edge result, same safe-area gutter logic, no containing-block side effect. Documented inline in `style.css`.

```css
.ec-studio-pane--compose {
    width: 100vw;
    max-width: 100vw;
    margin-left: calc(50% - 50vw);
    padding-left: max(var(--spacing-lg), env(safe-area-inset-left));
    padding-right: max(var(--spacing-lg), env(safe-area-inset-right));
    box-sizing: border-box;
}
```

## Mobile

The existing `@media (max-width: 768px)` and `(max-width: 480px)` rules target `.ec-studio-pane__grid--compose` by name and collapse it to `1fr` — still working (now backed by the explicit `display:grid`). Added a matching mobile gutter tightening on `.ec-studio-pane--compose` at `max-width:768px` (mirrors the theme primitive's own mobile padding). The breakout degrades gracefully on mobile via the safe-area padding.

## Untouched (deliberately)

The **review sidebar fields** — featured image picker, category/artist/venue/location term pickers, and the review-readiness submit gate (#108) — are **completely untouched**. This PR is layout/CSS only.

## Verification

- `npm run typecheck` — clean.
- `npm run build` — compiles successfully, CSS emitted (16.4 KiB).
- I cannot see the rendered page (no browser), so the visual result is reasoned from the CSS cascade.

## Risk / uncertainty (untestable without a browser)

- The `100vw` width carries the standard scrollbar-gutter characteristic (same as the theme `.full-width-breakout` primitive already in production on archive pages); if any horizontal scroll appears it would match the existing primitive's behavior.
- The `3fr / 1fr` ratio (~75/25) gives the sidebar roughly 350px on a ~1400px viewport — should comfortably fit the existing field components, but the exact fit should be eyeballed on staging.