### PR TITLE
fix: remove bespoke compose-tab full-width breakout

### DIFF
--- a/inc/compose-editor.php
+++ b/inc/compose-editor.php
@@ -3,8 +3,8 @@
  * Compose Editor — Blocks Everywhere integration for Studio.
  *
  * Registers a Studio context via the blocks_everywhere_contexts filter
- * so the isolated block editor loads on the Studio homepage for team
- * members. The editor mounts inside the Compose tab of the Studio React app.
+ * so Blocks Everywhere loads on the Studio homepage for team members.
+ * The editor mounts inside the Compose tab of the Studio React app.
  *
  * @package ExtraChillStudio
  * @since   0.2.0
@@ -77,7 +77,7 @@ function register_compose_context( array $contexts ): array {
 			// dark mode styles in style-index.min.css apply.
 			add_filter( 'body_class', [ $engine, 'body_class' ] );
 
-			// The IBE renders inline (shouldIframe=false), not in an iframe.
+			// BE renders inline (shouldIframe=false), not in an iframe.
 			// Theme root.css variables are available on the host page, but
 			// the editor wrapper needs explicit mapping for dark mode and
 			// proper sizing.
@@ -92,20 +92,14 @@ add_filter( 'blocks_everywhere_contexts', __NAMESPACE__ . '\\register_compose_co
 /**
  * Enqueue inline styles for the compose editor.
  *
- * The IBE renders inline (shouldIframe=false), so host-page CSS
+ * BE renders inline (shouldIframe=false), so host-page CSS
  * variables from root.css are available. We add editor-specific
  * styles for proper sizing, dark mode background, and WP component
  * variable mapping inside .editor-styles-wrapper.
  */
 function enqueue_editor_inline_styles() {
 	$css = <<<'CSS'
-/* Studio compose editor — inline editor theming.
-   The parent .ec-studio-compose-editor (style.css) provides the outer
-   border and radius. The iso-editor sits flush inside it. */
-.ec-studio-compose-editor .iso-editor {
-	min-height: 400px;
-}
-
+/* Studio compose editor — inline editor theming. */
 .ec-studio-compose-editor .editor-styles-wrapper {
 	background-color: var(--background-color);
 	color: var(--text-color);
@@ -137,22 +131,9 @@ function enqueue_editor_inline_styles() {
 	color: var(--muted-text);
 }
 
-/* Toolbar theming */
-.ec-studio-compose-editor .interface-interface-skeleton__header {
-	background-color: var(--card-background);
-	border-bottom: 1px solid var(--border-color);
-}
-
 /* Placeholder styling */
 .ec-studio-compose-editor .block-editor-default-block-appender__content {
 	color: var(--muted-text);
-}
-
-/* Footer */
-.ec-studio-compose-editor .interface-interface-skeleton__footer {
-	background-color: var(--card-background);
-	border-top: 1px solid var(--border-color);
-	font-size: var(--font-size-sm);
 }
 CSS;
 
@@ -237,20 +218,6 @@ function configure_compose_editor( array $settings ): array {
 	//      in main's context so the client-side check matches the server-side
 	//      enforcement in the compose media proxy route.
 	$settings['maxUploadFileSize'] = (int) extrachill_studio_compose_main_max_upload_size();
-
-	// Expose IBE's More Menu so writers can toggle fullscreen mode and
-	// keyboard shortcuts. Default to non-fullscreen on boot — users opt in
-	// via the menu (or Ctrl/Cmd+Shift+Alt+F). Fullscreen-state CSS lives
-	// in style.css under html.is-fullscreen-mode and hides Studio chrome
-	// that sits outside the editor skeleton (title input, toolbar, save
-	// actions, detached sidebar). See Phase 1 scoping in MEMORY.md.
-	$settings['blocksEverywhere']['moreMenu']                                = array(
-		'fullscreen' => true,
-	);
-	$settings['blocksEverywhere']['defaultPreferences']                      = isset( $settings['blocksEverywhere']['defaultPreferences'] ) && is_array( $settings['blocksEverywhere']['defaultPreferences'] )
-		? $settings['blocksEverywhere']['defaultPreferences']
-		: array();
-	$settings['blocksEverywhere']['defaultPreferences']['fullscreenMode']    = false;
 
 	return $settings;
 }

--- a/src/blocks/studio/style.css
+++ b/src/blocks/studio/style.css
@@ -582,23 +582,6 @@
 	align-items: start;
 }
 
-/* Compose pane — full-width breakout (edge-to-edge with comfortable gutters).
- * Mirrors the theme `.full-width-breakout` primitive but uses the transform-
- * free `calc(50% - 50vw)` centering technique instead of transform:
- * translateX(-50%). A transform on this ancestor would establish a containing
- * block for the IBE fullscreen overlay's `position: fixed` (.iso-editor /
- * .interface-interface-skeleton pinned inset:0 below), breaking the fullscreen
- * writing mode. The margin-based breakout gives the same edge-to-edge layout
- * without that side effect. Scoped to the compose tab only. */
-.ec-studio-pane--compose {
-	width: 100vw;
-	max-width: 100vw;
-	margin-left: calc(50% - 50vw);
-	padding-left: max(var(--spacing-lg), env(safe-area-inset-left));
-	padding-right: max(var(--spacing-lg), env(safe-area-inset-right));
-	box-sizing: border-box;
-}
-
 .ec-studio-panel--editor {
 	display: flex;
 	flex-direction: column;
@@ -854,13 +837,6 @@
 @media (max-width: 768px) {
 	.ec-studio-pane__grid--compose {
 		grid-template-columns: 1fr;
-	}
-
-	/* Tighten the full-width breakout gutters on small screens (matches the
-	 * theme .full-width-breakout mobile padding). */
-	.ec-studio-pane--compose {
-		padding-left: max(0.75em, env(safe-area-inset-left));
-		padding-right: max(0.75em, env(safe-area-inset-right));
 	}
 }
 

--- a/src/blocks/studio/style.css
+++ b/src/blocks/studio/style.css
@@ -840,55 +840,6 @@
 	}
 }
 
-/* ── Compose tab — fullscreen mode ──
- * IBE's fullscreen toggle (More Menu → "Fullscreen mode") sets
- * html.is-fullscreen-mode and pins .interface-interface-skeleton fixed
- * to the viewport. Anything outside .iso-editor (Studio chrome: title
- * input, toolbar, save actions, detached sidebar slot) becomes visually
- * irrelevant in that state and would either bleed through or just sit
- * uselessly underneath. Hide them so fullscreen reads as a clean
- * content-only writing mode. Users exit via the same More Menu or the
- * Ctrl/Cmd+Shift+Alt+F shortcut to regain access to title and submit.
- */
-html.is-fullscreen-mode .ec-studio-compose-toolbar,
-html.is-fullscreen-mode .ec-studio-compose-title,
-html.is-fullscreen-mode .ec-studio-composer__actions,
-html.is-fullscreen-mode .ec-studio-panel--compose-sidebar {
-	display: none;
-}
-
-/* The compose editor panel needs to release its border + grid position
- * so the fullscreen skeleton can take over the viewport cleanly. */
-html.is-fullscreen-mode .ec-studio-compose-editor {
-	border: 0;
-	min-height: 0;
-}
-
-html.is-fullscreen-mode .ec-studio-compose-editor .iso-editor {
-	position: fixed;
-	inset: 0;
-	z-index: 99999;
-	min-height: 100vh;
-	width: 100vw;
-	background: var(--background-color);
-}
-
-html.is-fullscreen-mode .ec-studio-compose-editor .edit-post-layout.interface-interface-skeleton {
-	position: fixed;
-	inset: 0;
-	top: 0;
-	left: 0;
-	width: 100vw;
-	height: 100vh;
-}
-
-html.is-fullscreen-mode .ec-studio-compose-editor .interface-interface-skeleton__body,
-html.is-fullscreen-mode .ec-studio-compose-editor .interface-interface-skeleton__editor,
-html.is-fullscreen-mode .ec-studio-compose-editor .interface-interface-skeleton__content {
-	min-height: 0;
-	height: 100%;
-}
-
 /* ── Transcribe tab ── */
 .ec-studio-pane--transcribe {
 	gap: var(--spacing-md);


### PR DESCRIPTION
## Summary
- Removes the hand-rolled `.ec-studio-pane--compose` full-width breakout that shipped in #119.
- Two problems with it: (1) it **reinvented the theme's existing `.full-width-breakout` primitive** instead of using it, and (2) it special-cased **one tab** edge-to-edge, which was never the intent — the ask was to *un-scrunch* the editor, not bulldoze the compose tab to full-bleed.
- **Also strips dead Isolated Block Editor (IBE) code** that Blocks Everywhere no longer renders. See the new section below.

## Why this is the right shape
Studio renders through `BlockShellInner maxWidth="wide"` (view.ts). With the components 1080px cap removed (v0.9.1), the **whole shell** already matches page width across **every** tab uniformly. No per-tab width hack is needed or wanted.

## Kept
The compose un-scrunch fix stays intact: `ec-card-grid` removed from the wrapper (the #116 regression) + `minmax(0, 3fr) minmax(0, 1fr)` editor/sidebar split.

## Reverted
- `.ec-studio-pane--compose { width:100vw; margin-left:calc(50% - 50vw); ... }` block
- Its mobile-gutter counterpart in the 768px media query

## Dead IBE code removal (added to this branch)
Blocks Everywhere removed the Isolated Block Editor. It now renders a flat `.blocks-everywhere-editor` tree and emits **zero** `is-fullscreen-mode` / `.iso-editor` / `.interface-interface-skeleton` / `.edit-post-layout` DOM. Studio was carrying code shaped exclusively for that now-nonexistent DOM — all of it inert. Deleted, not rewritten (fullscreen is a BE-owned feature; Studio isn't enabling it):

**`src/blocks/studio/style.css`**
- Deleted the entire `/* ── Compose tab — fullscreen mode ── */` section: every `html.is-fullscreen-mode ...` rule that hid Studio chrome and pinned `.iso-editor` / `.edit-post-layout.interface-interface-skeleton` / `.interface-interface-skeleton__{body,editor,content}` fixed to the viewport. Dead selectors targeting dead DOM.

**`inc/compose-editor.php`**
- Removed `.ec-studio-compose-editor .iso-editor { min-height: 400px }` (+ its "iso-editor sits flush inside it" comment) and `.ec-studio-compose-editor .interface-interface-skeleton__{header,footer}` from the inline-style heredoc — they theme DOM that no longer renders.
- Removed the stale `moreMenu` / `fullscreenMode` editor settings. `moreMenu` was set to `array('fullscreen' => true)` but current BE expects a **boolean**, so it was already wrong/inert; `defaultPreferences` existed **only** to carry `fullscreenMode`, which BE no longer reads — both removed.
- Reworded the remaining `IBE / isolated block editor` comments to reference Blocks Everywhere.

## Verified
- `php -l inc/compose-editor.php` — clean.
- `npm run build` — compiles, regenerates `build/blocks/studio/*`.
- `grep -rn "iso-editor\|is-fullscreen-mode\|interface-interface-skeleton\|edit-post-layout\|fullscreenMode" src/ inc/ build/` — **empty** after the change.