### PR TITLE
fix: resolve PHPCS findings blocking release

### DIFF
--- a/inc/abilities/run-giveaway.php
+++ b/inc/abilities/run-giveaway.php
@@ -88,10 +88,10 @@ function ec_studio_pick_giveaway_winners( array $entries, int $count ): array {
 	// Shuffle using random_int() for crypto-secure selection.
 	$indices = range( 0, $total - 1 );
 	for ( $i = $total - 1; $i > 0; $i-- ) {
-		$j              = random_int( 0, $i );
-		$tmp            = $indices[ $i ];
-		$indices[ $i ]  = $indices[ $j ];
-		$indices[ $j ]  = $tmp;
+		$j             = random_int( 0, $i );
+		$tmp           = $indices[ $i ];
+		$indices[ $i ] = $indices[ $j ];
+		$indices[ $j ] = $tmp;
 	}
 
 	$winners = array();
@@ -247,7 +247,10 @@ function ec_studio_execute_run_giveaway( array $input ): array|\WP_Error {
 		return new \WP_Error(
 			'no_valid_entries',
 			sprintf( 'No valid entries after filtering. %d comments, %d filtered out.', $stats['total_comments'], $stats['filtered_out'] ),
-			array( 'status' => 404, 'stats' => $stats )
+			array(
+				'status' => 404,
+				'stats'  => $stats,
+			)
 		);
 	}
 
@@ -263,14 +266,14 @@ function ec_studio_execute_run_giveaway( array $input ): array|\WP_Error {
 		$message  = str_replace( '{username}', $username, $message_tpl );
 
 		$winner_data = array(
-			'rank'            => $index + 1,
-			'username'        => $username,
-			'comment_id'      => $winner['id'] ?? '',
-			'comment_text'    => $winner['text'] ?? '',
-			'mentions'        => $winner['mentions'] ?? array(),
-			'announced'       => false,
-			'reply_id'        => null,
-			'announce_error'  => null,
+			'rank'           => $index + 1,
+			'username'       => $username,
+			'comment_id'     => $winner['id'] ?? '',
+			'comment_text'   => $winner['text'] ?? '',
+			'mentions'       => $winner['mentions'] ?? array(),
+			'announced'      => false,
+			'reply_id'       => null,
+			'announce_error' => null,
 		);
 
 		if ( $announce && $reply_ability && ! empty( $winner['id'] ) ) {

--- a/inc/abilities/sweatpants-token.php
+++ b/inc/abilities/sweatpants-token.php
@@ -268,7 +268,7 @@ function ec_studio_execute_sweatpants_token( array $input ): array|\WP_Error {
 		$callback_url                 = function_exists( 'rest_url' )
 			? rest_url( 'extrachill/v1/transcribe/callback' )
 			: '';
-		$response['callback_url']     = $callback_url ?: null;
+		$response['callback_url']     = $callback_url ? $callback_url : null;
 		$response['callback_secret']  = $secret;
 		$response['callback_issuer']  = EC_STUDIO_SWEATPANTS_TOKEN_ISSUER;
 		$response['callback_user_id'] = $user_id;

--- a/inc/abilities/sweatpants-token.php
+++ b/inc/abilities/sweatpants-token.php
@@ -125,9 +125,9 @@ function ec_studio_register_sweatpants_token_ability(): void {
 				'output_schema'       => array(
 					'type'       => 'object',
 					'properties' => array(
-						'token'           => array( 'type' => 'string' ),
-						'expires_at'      => array( 'type' => 'integer' ),
-						'scope'           => array( 'type' => 'string' ),
+						'token'            => array( 'type' => 'string' ),
+						'expires_at'       => array( 'type' => 'integer' ),
+						'scope'            => array( 'type' => 'string' ),
 						// Callback handoff fields — populated only when the
 						// requested scope includes `callback:write`. The React
 						// tab passes these straight through to sweatpants in
@@ -143,9 +143,9 @@ function ec_studio_register_sweatpants_token_ability(): void {
 						// for a stolen browser-side copy beyond what the team
 						// member could already do, (c) it's per-deployment
 						// rotatable.
-						'callback_url'    => array( 'type' => array( 'string', 'null' ) ),
-						'callback_secret' => array( 'type' => array( 'string', 'null' ) ),
-						'callback_issuer' => array( 'type' => array( 'string', 'null' ) ),
+						'callback_url'     => array( 'type' => array( 'string', 'null' ) ),
+						'callback_secret'  => array( 'type' => array( 'string', 'null' ) ),
+						'callback_issuer'  => array( 'type' => array( 'string', 'null' ) ),
 						'callback_user_id' => array( 'type' => array( 'integer', 'null' ) ),
 					),
 				),
@@ -265,7 +265,7 @@ function ec_studio_execute_sweatpants_token( array $input ): array|\WP_Error {
 	// back to /wp-json/extrachill/v1/transcribe/callback when the job
 	// finishes. See inc/transcription/callback.php for the receiver.
 	if ( in_array( 'callback:write', $requested_scopes, true ) ) {
-		$callback_url = function_exists( 'rest_url' )
+		$callback_url                 = function_exists( 'rest_url' )
 			? rest_url( 'extrachill/v1/transcribe/callback' )
 			: '';
 		$response['callback_url']     = $callback_url ?: null;

--- a/inc/compose-editor.php
+++ b/inc/compose-editor.php
@@ -52,7 +52,7 @@ function extrachill_studio_compose_main_max_upload_size(): int {
  * @return array
  */
 function register_compose_context( array $contexts ): array {
-	$contexts['studio'] = [
+	$contexts['studio'] = array(
 		'type'         => 'studio',
 		'textarea'     => '#ec-studio-compose-content',
 		'container'    => '.ec-studio-compose-editor',
@@ -75,7 +75,7 @@ function register_compose_context( array $contexts ): array {
 		'editor_setup' => function ( $engine ) {
 			// Add .gutenberg-support body class so BE's scoped toolbar/component
 			// dark mode styles in style-index.min.css apply.
-			add_filter( 'body_class', [ $engine, 'body_class' ] );
+			add_filter( 'body_class', array( $engine, 'body_class' ) );
 
 			// BE renders inline (shouldIframe=false), not in an iframe.
 			// Theme root.css variables are available on the host page, but
@@ -83,7 +83,7 @@ function register_compose_context( array $contexts ): array {
 			// proper sizing.
 			add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_editor_inline_styles', 50 );
 		},
-	];
+	);
 
 	return $contexts;
 }
@@ -170,9 +170,9 @@ function configure_compose_editor( array $settings ): array {
 	// rendered sidebar into Studio's dedicated compose sidebar slot.
 	$settings['blocksEverywhere']['sidebar']['inserter'] = true;
 	$settings['blocksEverywhere']['sidebar']['detached'] = array(
-		'target'    => '.ec-studio-compose-sidebar__slot',
-		'className' => 'ec-studio-compose-sidebar__content',
-		'persistent' => true,
+		'target'      => '.ec-studio-compose-sidebar__slot',
+		'className'   => 'ec-studio-compose-sidebar__content',
+		'persistent'  => true,
 		'defaultView' => 'inserter',
 	);
 

--- a/inc/compose/rest.php
+++ b/inc/compose/rest.php
@@ -452,7 +452,7 @@ function ec_studio_compose_relay_response( $response ) {
  * @param \WP_REST_Request $request REST request.
  * @return \WP_REST_Response|\WP_Error
  */
-function ec_studio_compose_list_drafts( \WP_REST_Request $request ) {
+function ec_studio_compose_list_drafts( \WP_REST_Request $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- Required REST callback signature.
 	$guard = ec_studio_compose_require_cross_site();
 	if ( is_wp_error( $guard ) ) {
 		return $guard;
@@ -1193,7 +1193,8 @@ function ec_studio_compose_upload_media( \WP_REST_Request $request ) {
 		);
 	}
 
-	$files = $request->get_file_params();
+	$files = $request->get_file_params(); // phpcs:ignore WordPress.Security.NonceVerification.Missing -- This authenticated REST route has a team-member permission callback; uploaded file fields are validated below.
+	// phpcs:ignore WordPress.Security.NonceVerification.Missing -- This authenticated REST route has a team-member permission callback; uploaded file fields are validated below.
 	if ( empty( $files['file'] ) && isset( $_FILES['file'] ) ) {
 		$files['file'] = $_FILES['file']; // phpcs:ignore WordPress.Security.NonceVerification.Missing -- REST cookie nonce already validated by the auth layer; file params are validated below.
 	}

--- a/inc/compose/rest.php
+++ b/inc/compose/rest.php
@@ -881,7 +881,7 @@ function ec_studio_compose_whitelist_post_params( $raw ): array {
 		if ( ! isset( $raw[ $field ] ) ) {
 			continue;
 		}
-		$ids = array_values(
+		$ids              = array_values(
 			array_unique(
 				array_filter(
 					array_map( 'absint', (array) $raw[ $field ] )

--- a/inc/social-drafts.php
+++ b/inc/social-drafts.php
@@ -198,11 +198,16 @@ function on_publish_crosspost( string $new_status, string $old_status, \WP_Post 
 		return;
 	}
 
-	$images       = get_post_meta( $post->ID, META_IMAGES, true ) ?: array();
-	$aspect_ratio = get_post_meta( $post->ID, META_ASPECT_RATIO, true ) ?: '4:5';
-	$media_kind   = get_post_meta( $post->ID, META_MEDIA_KIND, true ) ?: 'image';
-	$video_url    = get_post_meta( $post->ID, META_VIDEO_URL, true ) ?: '';
-	$cover_url    = get_post_meta( $post->ID, META_COVER_URL, true ) ?: '';
+	$images       = get_post_meta( $post->ID, META_IMAGES, true );
+	$images       = $images ? $images : array();
+	$aspect_ratio = get_post_meta( $post->ID, META_ASPECT_RATIO, true );
+	$aspect_ratio = $aspect_ratio ? $aspect_ratio : '4:5';
+	$media_kind   = get_post_meta( $post->ID, META_MEDIA_KIND, true );
+	$media_kind   = $media_kind ? $media_kind : 'image';
+	$video_url    = get_post_meta( $post->ID, META_VIDEO_URL, true );
+	$video_url    = $video_url ? $video_url : '';
+	$cover_url    = get_post_meta( $post->ID, META_COVER_URL, true );
+	$cover_url    = $cover_url ? $cover_url : '';
 
 	// Schedule async cross-post via DM Task System.
 	$job_id = \DataMachine\Engine\Tasks\TaskScheduler::schedule(
@@ -246,7 +251,8 @@ add_action( 'transition_post_status', __NAMESPACE__ . '\\on_publish_crosspost', 
  * @param array $results Array of result entries.
  */
 function log_publish_result( int $post_id, array $results ) {
-	$existing = get_post_meta( $post_id, META_PUBLISH_LOG, true ) ?: array();
+	$existing = get_post_meta( $post_id, META_PUBLISH_LOG, true );
+	$existing = $existing ? $existing : array();
 	$merged   = array_merge( $existing, $results );
 	update_post_meta( $post_id, META_PUBLISH_LOG, $merged );
 }
@@ -288,7 +294,7 @@ function render_admin_columns( string $column, int $post_id ) {
 			} ) );
 			$total   = count( $log );
 			/* translators: 1: success count 2: total count */
-			printf( esc_html__( '%1$d / %2$d posted', 'extrachill-studio' ), $success, $total );
+			printf( esc_html__( '%1$d / %2$d posted', 'extrachill-studio' ), absint( $success ), absint( $total ) );
 		} else {
 			$platforms = get_post_meta( $post_id, META_PLATFORMS, true );
 			if ( ! empty( $platforms ) ) {

--- a/inc/social-drafts.php
+++ b/inc/social-drafts.php
@@ -64,7 +64,7 @@ function register_social_meta() {
 				'schema' => array(
 					'type'  => 'array',
 					'items' => array(
-						'type' => 'object',
+						'type'       => 'object',
 						'properties' => array(
 							'url' => array( 'type' => 'string' ),
 						),


### PR DESCRIPTION
## Summary
- Reduces the Studio PHPCS baseline from 38 findings to 0, superseding stale closed PR #118.
- Applies PHPCBF formatting in a dedicated commit, then replaces short ternaries and escapes numeric admin-table output without changing behavior.
- Adds narrow, documented suppressions for the required REST callback signature and the authenticated, team-gated REST upload route.

## Verification
- `homeboy review extrachill-studio lint --force-hot --allow-local-hot`: PHPCS passed (0 findings).
- PHP syntax checks passed for all five changed PHP files.
- The full Homeboy gate remains infrastructure-blocked after PHPCS by the shared PHPStan runtime: `PharException: manifest cannot be larger than 100 MB` loading `/home/opencode/.config/homeboy/extensions/wordpress/vendor/phpstan/phpstan/phpstan.phar`.

## PHPCS Ignores
- `Generic.CodeAnalysis.UnusedFunctionParameter.Found`: `$request` remains required by the WordPress REST callback contract although this list endpoint does not read request parameters.
- `WordPress.Security.NonceVerification.Missing` on `get_file_params()` and the `$_FILES` fallback: the route is REST-authenticated and guarded by `ec_studio_compose_permission_check`; the upload fields are then validated before use. These targeted suppressions preserve the existing REST authentication design rather than adding a redundant form nonce.

No behavior was intentionally changed. No changelog or version files were modified.