### PR TITLE
feat: add scoped Network analytics workspace

### DIFF
--- a/src/blocks/studio/render.php
+++ b/src/blocks/studio/render.php
@@ -58,6 +58,36 @@ $site_name   = get_bloginfo( 'name' );
 $site_url    = home_url( '/' );
 $rest_nonce  = wp_create_nonce( 'wp_rest' );
 $socials_api = rest_url( 'datamachine/v1/socials/' );
+$network_sites = array();
+
+if ( is_multisite() ) {
+	$sites = get_sites(
+		array(
+			'public'   => 1,
+			'archived' => 0,
+			'deleted'  => 0,
+			'spam'     => 0,
+			'number'   => 0,
+		)
+	);
+
+	foreach ( $sites as $site ) {
+		$site_id   = (int) $site->blog_id;
+		$network_site_url = get_home_url( $site_id, '/' );
+		$site_host        = wp_parse_url( $network_site_url, PHP_URL_HOST );
+
+		if ( ! is_string( $site_host ) || '' === $site_host ) {
+			continue;
+		}
+
+		$network_sites[] = array(
+			'id'   => $site_id,
+			'name' => (string) get_blog_option( $site_id, 'blogname', $site_host ),
+			'url'  => $network_site_url,
+			'host' => $site_host,
+		);
+	}
+}
 
 /**
  * Filter the social platform slugs shown in Studio's Socials tab.
@@ -101,6 +131,7 @@ $can_brand_socials = function_exists( 'ec_feature_available' )
 	data-description="<?php echo esc_attr( $description ); ?>"
 	data-social-platforms="<?php echo esc_attr( wp_json_encode( $allowed_platforms ) ); ?>"
 	data-can-brand-socials="<?php echo $can_brand_socials ? 'true' : 'false'; ?>"
+	data-network-sites="<?php echo esc_attr( wp_json_encode( $network_sites ) ); ?>"
 >
 	<div class="ec-studio-app__mount" data-ec-studio-app></div>
 </div>

--- a/src/blocks/studio/style.css
+++ b/src/blocks/studio/style.css
@@ -1148,31 +1148,30 @@
 	line-height: 1.6;
 }
 
-/*
- * Two-column-max dashboard grid. A 480px floor guarantees at most two columns
- * on typical screens so every Chart.js canvas / DataTable gets legible width,
- * collapsing to a single column when two legible cards no longer fit. Rendered
- * via the shared <Grid> primitive from @extrachill/components with
- * minColumnWidth="480px" and gap="var(--spacing-lg)" (see tabs/network/index.tsx),
- * which applies the .ec-card-grid utility. This class only carries
- * element-specific overrides.
- */
-.ec-studio-network__grid {
+.ec-studio-network__report {
+	display: grid;
+	gap: var(--spacing-md);
 	min-width: 0;
+}
+
+.ec-studio-network__toolbar {
+	margin-top: var(--spacing-md);
+}
+
+.ec-studio-network__scope {
+	font-size: var(--font-size-sm);
+	color: var(--text-color-muted, #666);
+}
+
+.ec-studio-network__filter {
+	display: inline-flex;
+	align-items: center;
+	gap: var(--spacing-xs);
+	font-size: var(--font-size-sm);
 }
 
 .ec-studio-network__card {
 	min-width: 0;
-}
-
-/*
- * The conversion-map card is a ranked DATA TABLE (entry article → platform
- * reach), which reads best across the full dashboard width rather than
- * shoulder-to-shoulder with a chart. Span it across both columns on
- * multi-column layouts; it naturally occupies the single column otherwise.
- */
-.ec-studio-network__card--wide {
-	grid-column: 1 / -1;
 }
 
 .ec-studio-network__card-body {
@@ -1219,9 +1218,10 @@
 	color: var(--color-error, #b3261e);
 }
 
-@media (max-width: 600px) {
+@media (max-width: 480px) {
 
-	.ec-studio-network__grid {
-		grid-template-columns: 1fr;
+	.ec-studio-network__filter {
+		display: grid;
+		width: 100%;
 	}
 }

--- a/src/blocks/studio/tabs/network/conversion-map-chart.tsx
+++ b/src/blocks/studio/tabs/network/conversion-map-chart.tsx
@@ -33,27 +33,36 @@ interface ArticleTableRow extends Record< string, unknown > {
 	reached_any_rate: string;
 }
 
-export const ConversionMapChart = (): ReactElement => {
+interface ConversionMapChartProps {
+	days: number;
+}
+
+export const ConversionMapChart = ( {
+	days,
+}: ConversionMapChartProps ): ReactElement => {
 	const [ data, setData ] = useState< ConversionMapResponse | null >( null );
 	const [ state, setState ] = useState< ChartCardState >( 'loading' );
 	const [ errorMessage, setErrorMessage ] = useState( '' );
 
 	useEffect( () => {
 		let cancelled = false;
+		setState( 'loading' );
+		setErrorMessage( '' );
 
 		studioAnalyticsApi
 			.getConversionMap( {
-				days: 28,
+				days,
 				top_articles: 10,
-				min_entry_sessions: 1,
+				min_entry_sessions: 5,
 			} )
 			.then( ( response ) => {
 				if ( cancelled ) {
 					return;
 				}
 				setData( response );
-				const hasArticles = ( response.by_article?.length ?? 0 ) > 0;
-				setState( hasArticles ? 'ready' : 'empty' );
+				const hasEntries =
+					( response.overall?.entry_sessions ?? 0 ) > 0;
+				setState( hasEntries ? 'ready' : 'empty' );
 			} )
 			.catch( ( error: unknown ) => {
 				if ( cancelled ) {
@@ -66,7 +75,7 @@ export const ConversionMapChart = (): ReactElement => {
 		return () => {
 			cancelled = true;
 		};
-	}, [] );
+	}, [ days ] );
 
 	const rows = useMemo< ArticleTableRow[] >( () => {
 		const articles = data?.by_article ?? [];
@@ -110,7 +119,7 @@ export const ConversionMapChart = (): ReactElement => {
 		<ChartCard
 			title={ __( 'Top content → platform', 'extrachill-studio' ) }
 			description={ __(
-				'Visitors who entered on an article and reached events, community, or artist — last 28 days.',
+				'Visitors who entered on an article and reached events, community, or artist over the selected range.',
 				'extrachill-studio'
 			) }
 			className="ec-studio-network__card--wide"

--- a/src/blocks/studio/tabs/network/index.tsx
+++ b/src/blocks/studio/tabs/network/index.tsx
@@ -17,14 +17,14 @@
  * analytics — mirroring how the Compose pane layers its richer draft context on
  * top of the generic tab broadcast.
  */
-import { useEffect } from '@wordpress/element';
+import { useEffect, useId, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import type { ReactElement } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import {
 	getOrCreateClientContextRegistry,
 	registerClientContextProvider,
 } from '@extrachill/chat';
-import { Grid } from '@extrachill/components';
+import { ResponsiveTabs, Toolbar } from '@extrachill/components';
 
 import type { StudioPaneProps } from '../../types/studio';
 import { ConversionMapChart } from './conversion-map-chart';
@@ -34,20 +34,29 @@ import { SurfaceGrowthChart } from './surface-growth-chart';
 
 const CLIENT_CONTEXT_PROVIDER_ID = 'extrachill-studio.network';
 
-/**
- * Resolve the current site host from the context site URL (GA query scope).
- * @param siteUrl
- */
-const resolveHost = ( siteUrl: string ): string => {
-	try {
-		return new URL( siteUrl ).host;
-	} catch {
-		return '';
-	}
-};
+const REPORTS = [
+	{ id: 'sessions', label: __( 'Sessions', 'extrachill-studio' ) },
+	{ id: 'growth', label: __( 'Growth', 'extrachill-studio' ) },
+	{ id: 'retention', label: __( 'Retention', 'extrachill-studio' ) },
+	{ id: 'conversion', label: __( 'Conversion', 'extrachill-studio' ) },
+];
+
+const DATE_RANGES = [
+	{ value: 28, label: __( 'Last 4 weeks', 'extrachill-studio' ) },
+	{ value: 84, label: __( 'Last 12 weeks', 'extrachill-studio' ) },
+	{ value: 364, label: __( 'Last 52 weeks', 'extrachill-studio' ) },
+];
 
 const NetworkPane = ( { context }: StudioPaneProps ): ReactElement => {
-	const host = resolveHost( context.siteUrl );
+	const [ activeReport, setActiveReport ] = useState( 'sessions' );
+	const [ days, setDays ] = useState( 28 );
+	const [ selectedBlogId, setSelectedBlogId ] = useState( 0 );
+	const controlId = useId().replace( /:/g, '' );
+	const rangeControlId = `${ controlId }-range`;
+	const siteControlId = `${ controlId }-site`;
+	const selectedSite = context.networkSites.find(
+		( site ) => site.id === selectedBlogId
+	);
 
 	// Broadcast `surface: 'network'` to Roadie while this pane is active.
 	useEffect( () => {
@@ -68,24 +77,149 @@ const NetworkPane = ( { context }: StudioPaneProps ): ReactElement => {
 		};
 	}, [] );
 
+	const supportsSiteScope =
+		activeReport === 'sessions' || activeReport === 'retention';
+	let scopeDescription: string = __(
+		'Scope: entire network',
+		'extrachill-studio'
+	);
+	if ( activeReport === 'growth' ) {
+		scopeDescription = __(
+			'Scope: five measured publishing surfaces',
+			'extrachill-studio'
+		);
+	} else if ( activeReport === 'conversion' ) {
+		scopeDescription = __(
+			'Scope: main blog to Events, Community, and Artist',
+			'extrachill-studio'
+		);
+	} else if ( selectedSite ) {
+		scopeDescription =
+			activeReport === 'retention'
+				? `${ __( 'Scope:', 'extrachill-studio' ) } ${
+						selectedSite.name
+				  } ${ __(
+						'(cross-site return remains network-wide)',
+						'extrachill-studio'
+				  ) }`
+				: `${ __( 'Scope:', 'extrachill-studio' ) } ${
+						selectedSite.name
+				  }`;
+	}
+
+	const controls = (
+		<Toolbar
+			className="ec-studio-network__toolbar"
+			actions={
+				<>
+					<label
+						className="ec-studio-network__filter"
+						htmlFor={ rangeControlId }
+					>
+						<span>{ __( 'Range', 'extrachill-studio' ) }</span>
+						<select
+							id={ rangeControlId }
+							className="ec-toolbar__select"
+							value={ days }
+							onChange={ ( event ) =>
+								setDays( Number( event.currentTarget.value ) )
+							}
+						>
+							{ DATE_RANGES.map( ( range ) => (
+								<option
+									key={ range.value }
+									value={ range.value }
+								>
+									{ range.label }
+								</option>
+							) ) }
+						</select>
+					</label>
+					{ supportsSiteScope ? (
+						<label
+							className="ec-studio-network__filter"
+							htmlFor={ siteControlId }
+						>
+							<span>{ __( 'Site', 'extrachill-studio' ) }</span>
+							<select
+								id={ siteControlId }
+								className="ec-toolbar__select"
+								value={ selectedBlogId }
+								onChange={ ( event ) =>
+									setSelectedBlogId(
+										Number( event.currentTarget.value )
+									)
+								}
+							>
+								<option value={ 0 }>
+									{ __(
+										'Entire network',
+										'extrachill-studio'
+									) }
+								</option>
+								{ context.networkSites.map( ( site ) => (
+									<option key={ site.id } value={ site.id }>
+										{ site.name }
+									</option>
+								) ) }
+							</select>
+						</label>
+					) : null }
+				</>
+			}
+		>
+			<span className="ec-studio-network__scope">
+				{ scopeDescription }
+			</span>
+		</Toolbar>
+	);
+
+	const renderReport = ( reportId: string ): ReactNode => {
+		let report: ReactNode;
+		switch ( reportId ) {
+			case 'growth':
+				report = <SurfaceGrowthChart days={ days } />;
+				break;
+			case 'retention':
+				report = (
+					<RetentionChart days={ days } blogId={ selectedBlogId } />
+				);
+				break;
+			case 'conversion':
+				report = <ConversionMapChart days={ days } />;
+				break;
+			case 'sessions':
+			default:
+				report = (
+					<SessionsChart days={ days } host={ selectedSite?.host } />
+				);
+		}
+
+		return (
+			<div className="ec-studio-network__report">
+				{ controls }
+				{ report }
+			</div>
+		);
+	};
+
 	return (
 		<div className="ec-studio-pane ec-studio-pane--network">
 			<p className="ec-studio-network__intro">
 				{ __(
-					'Platform health at a glance — first-party traffic, growth, retention, and conversion across the network.',
+					'Choose a report, range, and supported site scope. Each view uses the full workspace width.',
 					'extrachill-studio'
 				) }
 			</p>
-			<Grid
-				minColumnWidth="480px"
-				gap="var(--spacing-lg)"
-				className="ec-studio-network__grid"
-			>
-				<SessionsChart host={ host } />
-				<SurfaceGrowthChart />
-				<RetentionChart />
-				<ConversionMapChart />
-			</Grid>
+			<ResponsiveTabs
+				tabs={ REPORTS }
+				active={ activeReport }
+				onChange={ setActiveReport }
+				renderPanel={ renderReport }
+				syncWithHash
+				hashPrefix="network-report-"
+				contextSurface="studio-network"
+			/>
 		</div>
 	);
 };

--- a/src/blocks/studio/tabs/network/retention-chart.tsx
+++ b/src/blocks/studio/tabs/network/retention-chart.tsx
@@ -19,16 +19,30 @@ import type { ChartConfiguration } from './chart-loader';
 
 const pct = ( rate: number ): string => `${ Math.round( rate * 1000 ) / 10 }%`;
 
-export const RetentionChart = (): ReactElement => {
+interface RetentionChartProps {
+	days: number;
+	blogId: number;
+}
+
+export const RetentionChart = ( {
+	days,
+	blogId,
+}: RetentionChartProps ): ReactElement => {
 	const [ data, setData ] = useState< RetentionResponse | null >( null );
 	const [ state, setState ] = useState< ChartCardState >( 'loading' );
 	const [ errorMessage, setErrorMessage ] = useState( '' );
 
 	useEffect( () => {
 		let cancelled = false;
+		setState( 'loading' );
+		setErrorMessage( '' );
 
 		studioAnalyticsApi
-			.getRetention( { days: 28, cohort_weeks: 8 } )
+			.getRetention( {
+				days,
+				blog_id: blogId,
+				cohort_weeks: Math.max( 4, Math.ceil( days / 7 ) ),
+			} )
 			.then( ( response ) => {
 				if ( cancelled ) {
 					return;
@@ -51,7 +65,7 @@ export const RetentionChart = (): ReactElement => {
 		return () => {
 			cancelled = true;
 		};
-	}, [] );
+	}, [ blogId, days ] );
 
 	const configuration = useMemo< ChartConfiguration | null >( () => {
 		const cohorts = data?.cohort_retention?.cohorts ?? [];
@@ -140,7 +154,7 @@ export const RetentionChart = (): ReactElement => {
 		<ChartCard
 			title={ __( 'Retention', 'extrachill-studio' ) }
 			description={ __(
-				'First-party visitor return rate and per-cohort retention, last 28 days.',
+				'First-party return rate for the selected range, with a separate weekly cohort history.',
 				'extrachill-studio'
 			) }
 			state={ state }

--- a/src/blocks/studio/tabs/network/sessions-chart.tsx
+++ b/src/blocks/studio/tabs/network/sessions-chart.tsx
@@ -25,8 +25,9 @@ import { ChartCanvas } from './chart-canvas';
 import type { ChartConfiguration } from './chart-loader';
 
 interface SessionsChartProps {
-	/** Current site host (e.g. extrachill.com) used to scope the GA query. */
-	host: string;
+	/** Empty means the full GA property; otherwise scope to one network host. */
+	host?: string;
+	days: number;
 }
 
 /** Extra state: GA4 not authorized for this user (the expected degrade path). */
@@ -57,20 +58,37 @@ const isUnauthorizedError = ( error: unknown ): boolean => {
 	);
 };
 
-export const SessionsChart = ( { host }: SessionsChartProps ): ReactElement => {
+export const SessionsChart = ( {
+	host = '',
+	days,
+}: SessionsChartProps ): ReactElement => {
 	const [ data, setData ] = useState< GaDateStatsResponse | null >( null );
 	const [ state, setState ] = useState< SessionsState >( 'loading' );
 	const [ errorMessage, setErrorMessage ] = useState( '' );
+	const scopeDescription = host
+		? __( 'GA4 daily sessions for the selected site.', 'extrachill-studio' )
+		: __( 'GA4 daily sessions across the network.', 'extrachill-studio' );
+	const rangeDescription = host
+		? __(
+				'GA4 daily sessions for the selected site, over the selected range.',
+				'extrachill-studio'
+		  )
+		: __(
+				'GA4 daily sessions across the network, over the selected range.',
+				'extrachill-studio'
+		  );
 
 	useEffect( () => {
 		let cancelled = false;
+		setState( 'loading' );
+		setErrorMessage( '' );
 
 		studioAnalyticsApi
 			.getGaDateStats( {
 				hostname: host,
-				start_date: toDate( 28 ),
+				start_date: toDate( days ),
 				end_date: toDate( 1 ),
-				limit: 40,
+				limit: days + 5,
 			} )
 			.then( ( response ) => {
 				if ( cancelled ) {
@@ -101,10 +119,12 @@ export const SessionsChart = ( { host }: SessionsChartProps ): ReactElement => {
 		return () => {
 			cancelled = true;
 		};
-	}, [ host ] );
+	}, [ days, host ] );
 
 	const configuration = useMemo< ChartConfiguration | null >( () => {
-		const rows = data?.results ?? [];
+		const rows = [ ...( data?.results ?? [] ) ].sort( ( a, b ) =>
+			String( a.date ?? '' ).localeCompare( String( b.date ?? '' ) )
+		);
 		if ( rows.length === 0 ) {
 			return null;
 		}
@@ -112,7 +132,12 @@ export const SessionsChart = ( { host }: SessionsChartProps ): ReactElement => {
 		return {
 			type: 'line',
 			data: {
-				labels: rows.map( ( r ) => String( r.date ?? '' ) ),
+				labels: rows.map( ( r ) => {
+					const date = String( r.date ?? '' );
+					return date.length === 8
+						? `${ date.slice( 4, 6 ) }/${ date.slice( 6, 8 ) }`
+						: date;
+				} ),
 				datasets: [
 					{
 						label: __( 'Sessions', 'extrachill-studio' ),
@@ -139,10 +164,7 @@ export const SessionsChart = ( { host }: SessionsChartProps ): ReactElement => {
 		return (
 			<ChartCard
 				title={ __( 'Sessions over time', 'extrachill-studio' ) }
-				description={ __(
-					'GA4 daily sessions for this site.',
-					'extrachill-studio'
-				) }
+				description={ scopeDescription }
 				state="notInstrumented"
 				notInstrumentedReason={ __(
 					'Sessions chart is available to admins for now — team access is coming soon once the read-only analytics permission ships.',
@@ -155,10 +177,7 @@ export const SessionsChart = ( { host }: SessionsChartProps ): ReactElement => {
 	return (
 		<ChartCard
 			title={ __( 'Sessions over time', 'extrachill-studio' ) }
-			description={ __(
-				'GA4 daily sessions for this site, last 28 days.',
-				'extrachill-studio'
-			) }
+			description={ rangeDescription }
 			state={ state }
 			errorMessage={ errorMessage }
 			emptyMessage={ __(

--- a/src/blocks/studio/tabs/network/surface-growth-chart.tsx
+++ b/src/blocks/studio/tabs/network/surface-growth-chart.tsx
@@ -20,16 +20,26 @@ import type { ChartConfiguration } from './chart-loader';
 const BAR_COLOR = 'rgba(60, 132, 206, 0.75)';
 const BAR_BORDER = 'rgba(60, 132, 206, 1)';
 
-export const SurfaceGrowthChart = (): ReactElement => {
+interface SurfaceGrowthChartProps {
+	days: number;
+}
+
+export const SurfaceGrowthChart = ( {
+	days,
+}: SurfaceGrowthChartProps ): ReactElement => {
 	const [ data, setData ] = useState< SurfaceGrowthResponse | null >( null );
 	const [ state, setState ] = useState< ChartCardState >( 'loading' );
 	const [ errorMessage, setErrorMessage ] = useState( '' );
 
 	useEffect( () => {
 		let cancelled = false;
+		setState( 'loading' );
+		setErrorMessage( '' );
 
 		studioAnalyticsApi
-			.getSurfaceGrowth( { weeks: 4 } )
+			.getSurfaceGrowth( {
+				weeks: Math.max( 1, Math.round( days / 7 ) ),
+			} )
 			.then( ( response ) => {
 				if ( cancelled ) {
 					return;
@@ -49,7 +59,7 @@ export const SurfaceGrowthChart = (): ReactElement => {
 		return () => {
 			cancelled = true;
 		};
-	}, [] );
+	}, [ days ] );
 
 	const configuration = useMemo< ChartConfiguration | null >( () => {
 		const ranked = data?.supply_ranking?.ranked ?? [];

--- a/src/blocks/studio/types/studio.ts
+++ b/src/blocks/studio/types/studio.ts
@@ -14,6 +14,14 @@ export interface StudioContext {
 	socialPlatforms: string[];
 	/** Whether the user may access the shared brand social accounts. */
 	canBrandSocials: boolean;
+	networkSites: StudioSite[];
+}
+
+export interface StudioSite {
+	id: number;
+	name: string;
+	url: string;
+	host: string;
 }
 
 export interface StudioTab {

--- a/src/blocks/studio/view.ts
+++ b/src/blocks/studio/view.ts
@@ -1,6 +1,11 @@
 import { createElement, useState } from '@wordpress/element';
 import type { ComponentType, ReactElement } from 'react';
-import { BlockShell, BlockShellHeader, BlockShellInner, ResponsiveTabs } from '@extrachill/components';
+import {
+	BlockShell,
+	BlockShellHeader,
+	BlockShellInner,
+	ResponsiveTabs,
+} from '@extrachill/components';
 import '@extrachill/components/styles/components.scss';
 
 import { mountComponent } from './app/mount';
@@ -30,39 +35,33 @@ const StudioApp = ( { context }: { context: StudioContext } ): ReactElement => {
 		return createElement( ActivePane, { context } );
 	};
 
-	return createElement(
-		BlockShell,
-		{
-			children: createElement(
-				BlockShellInner,
-				{
-					maxWidth: 'wide',
-					children: [
-						createElement( BlockShellHeader, {
-							key: 'header',
-							title: context.headline || 'Studio',
-							description: context.description,
-						} ),
-						createElement( ResponsiveTabs, {
-							key: 'tabs',
-							tabs,
-							active: activeTab,
-							onChange: setActiveTab,
-							renderPanel,
-							showDesktopTabs: true,
-							// Broadcast the active Studio tab into the shared
-							// client-context registry so Roadie's chat knows
-							// which tab the team member is on. Generic — handled
-							// entirely by ResponsiveTabs; Studio just names the
-							// surface. The Compose pane layers its richer
-							// draft-specific context on top at higher priority.
-							contextSurface: 'studio',
-						} ),
-					],
-				}
-			),
-		},
-	);
+	return createElement( BlockShell, {
+		children: createElement( BlockShellInner, {
+			maxWidth: 'wide',
+			children: [
+				createElement( BlockShellHeader, {
+					key: 'header',
+					title: context.headline || 'Studio',
+					description: context.description,
+				} ),
+				createElement( ResponsiveTabs, {
+					key: 'tabs',
+					tabs,
+					active: activeTab,
+					onChange: setActiveTab,
+					renderPanel,
+					showDesktopTabs: true,
+					// Broadcast the active Studio tab into the shared
+					// client-context registry so Roadie's chat knows
+					// which tab the team member is on. Generic — handled
+					// entirely by ResponsiveTabs; Studio just names the
+					// surface. The Compose pane layers its richer
+					// draft-specific context on top at higher priority.
+					contextSurface: 'studio',
+				} ),
+			],
+		} ),
+	} );
 };
 
 const initRoot = ( root: HTMLElement ): void => {
@@ -73,10 +72,16 @@ const initRoot = ( root: HTMLElement ): void => {
 	root.dataset.ecStudioMounted = 'true';
 
 	let socialPlatforms: string[] = [];
+	let networkSites: StudioContext[ 'networkSites' ] = [];
 	try {
 		socialPlatforms = JSON.parse( root.dataset.socialPlatforms || '[]' );
 	} catch {
 		socialPlatforms = [];
+	}
+	try {
+		networkSites = JSON.parse( root.dataset.networkSites || '[]' );
+	} catch {
+		networkSites = [];
 	}
 
 	const context: StudioContext = {
@@ -89,14 +94,19 @@ const initRoot = ( root: HTMLElement ): void => {
 		description: root.dataset.description || '',
 		socialPlatforms,
 		canBrandSocials: root.dataset.canBrandSocials === 'true',
+		networkSites,
 	};
 
-	const appMount = root.querySelector< HTMLElement >( '[data-ec-studio-app]' );
+	const appMount = root.querySelector< HTMLElement >(
+		'[data-ec-studio-app]'
+	);
 	mountComponent( appMount, createElement( StudioApp, { context } ) );
 };
 
 const init = (): void => {
-	document.querySelectorAll< HTMLElement >( ROOT_SELECTOR ).forEach( initRoot );
+	document
+		.querySelectorAll< HTMLElement >( ROOT_SELECTOR )
+		.forEach( initRoot );
 };
 
 if ( document.readyState === 'loading' ) {


### PR DESCRIPTION
## Summary
- Replaces the cramped simultaneous Network report grid with one full-width report workspace, so each report has usable desktop and mobile space.
- Reuses the existing `@extrachill/components` `ResponsiveTabs`; no new shared primitive was introduced.
- Adds exact 4-, 12-, and 52-week ranges plus live multisite site selection for Sessions and Retention. Growth remains explicitly fixed to its five measured publishing surfaces; Conversion remains explicitly fixed to main-blog journeys into Events, Community, and Artist.
- Resets report loading state on filter changes, requests enough GA rows for every range, sorts GA dates before rendering, and avoids presenting low-volume conversion rows as meaningful results.

## Analytics Semantics
Retention's selected site filters the site-scoped return/cohort metrics, while its cross-site-return metric remains explicitly network-wide by definition. The existing backend correctness work remains separate and visible: [#163](https://github.com/Extra-Chill/extrachill-analytics/issues/163), [#164](https://github.com/Extra-Chill/extrachill-analytics/issues/164), and [#165](https://github.com/Extra-Chill/extrachill-analytics/issues/165). This UI work does not hide or claim to resolve those issues.

## Verification
- `npm run typecheck`
- `npx wp-scripts lint-js \"src/blocks/studio/{view.ts,tabs/network/*.tsx,types/studio.ts}\"`
- `php -l src/blocks/studio/render.php`
- `npm run build`
- `git diff --check`

`homeboy review extrachill-studio --changed-only --summary` was not run because Homeboy refused the local-only review under its hot-machine resource policy (load average 130).

Closes #122