### PR TITLE
fix: declare Studio release scope

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -4,6 +4,13 @@
   "extensions": {
     "wordpress": {}
   },
+  "scopes": {
+    "release": {
+      "exclude": [
+        "webpack.config.js"
+      ]
+    }
+  },
   "version_targets": [
     {
       "file": "extrachill-studio.php",


### PR DESCRIPTION
## Summary
- Mark build-only `webpack.config.js` as intentionally excluded from WordPress release artifacts.
- Keep Homeboy package validation active for runtime files.

## Verification
- Valid JSON configuration.
- Homeboy release package preflight after merge.

Closes #124