### PR TITLE
feat: add real Compose post preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"private": true,
 	"scripts": {
 		"build": "wp-scripts build && cp src/blocks/studio/style.css build/blocks/studio/",
+		"test:unit": "wp-scripts test-unit-js",
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {

--- a/src/blocks/studio/tabs/compose/index.ts
+++ b/src/blocks/studio/tabs/compose/index.ts
@@ -11,6 +11,8 @@ import { ActionRow, FieldGroup, InlineStatus, Panel, PanelHeader } from '@extrac
 import type { StudioPaneProps } from '../../types/studio';
 import { markComposeRequest, registerComposeInstance } from './cross-site-middleware';
 import { installChatRefreshAdapter } from './refresh-adapter';
+import { openComposePreview } from './preview';
+import type { AutosavePreviewResponse, ComposeSnapshot } from './preview';
 
 /**
  * apiFetch wrapper that tags a request as Compose-pane-originated so the
@@ -101,6 +103,7 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 
 	const [ title, setTitle ] = useState( '' );
 	const [ isSubmitting, setIsSubmitting ] = useState( false );
+	const [ isPreviewing, setIsPreviewing ] = useState( false );
 	const [ isSwitching, setIsSwitching ] = useState( false );
 	const [ status, setStatus ] = useState( '' );
 	const [ error, setError ] = useState( '' );
@@ -118,6 +121,8 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 	const isAutosavingRef = useRef( false );
 	const inFlightPromiseRef = useRef< Promise< void > | null >( null );
 	const pendingRerunRef = useRef( false );
+	const isPreviewingRef = useRef( false );
+	const manualSavePromiseRef = useRef< Promise< void > | null >( null );
 	const consecutiveFailuresRef = useRef( 0 );
 	const autosaveErrorActiveRef = useRef( false );
 	// Set while an external-edit refresh is applying (Roadie accept → BE
@@ -488,6 +493,9 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 	}, [ flushCurrentDraft, scheduleClientContextUpdate ] );
 
 	const startNew = useCallback( async (): Promise< void > => {
+		if ( isPreviewingRef.current ) {
+			return;
+		}
 		await switchToDraft( null );
 	}, [ switchToDraft ] );
 
@@ -503,6 +511,13 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 		// NOT set pendingRerunRef: the refresh's onRefreshed makes the editor
 		// the new baseline, so there is nothing stale left to flush afterward.
 		if ( isRefreshingRef.current ) {
+			return;
+		}
+
+		// Preview owns a complete live snapshot write. Queue normal autosave so
+		// it cannot race the preview autosave or duplicate a first draft create.
+		if ( isPreviewingRef.current ) {
+			pendingRerunRef.current = true;
 			return;
 		}
 
@@ -833,7 +848,90 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 		};
 	}, [ restNonce ] );
 
+	const previewPost = async (): Promise< void > => {
+		// This ref changes synchronously, unlike button disabled state, so a fast
+		// double click cannot create two first drafts or two preview writes.
+		if ( isPreviewingRef.current ) {
+			return;
+		}
+
+		isPreviewingRef.current = true;
+		setIsPreviewing( true );
+		setError( '' );
+		setStatus( __( 'Preparing preview…', 'extrachill-studio' ) );
+
+		try {
+			const result = await openComposePreview( {
+				openWindow: () => window.open( '', 'ec-studio-compose-preview' ),
+				cancelPendingSave: () => {
+					if ( autosaveTimerRef.current ) {
+						clearTimeout( autosaveTimerRef.current );
+						autosaveTimerRef.current = null;
+					}
+				},
+				waitForPendingSaves: async () => {
+					// An autosave can schedule one trailing rerun in its finally block.
+					// Drain the live refs until both write paths are quiescent.
+					while ( inFlightPromiseRef.current || manualSavePromiseRef.current ) {
+						await ( inFlightPromiseRef.current || manualSavePromiseRef.current );
+					}
+				},
+				getSnapshot: (): ComposeSnapshot => ( {
+					title: titleRef.current.trim(),
+					content: getContent().trim(),
+				} ),
+				getParentId: () => activePostIdRef.current,
+				createDraft: async ( snapshot ) => {
+					const post = await composeApiFetch< WpPost >( {
+						path: '/wp/v2/posts',
+						method: 'POST',
+						data: { ...snapshot, status: 'draft' },
+					} );
+					return post.id;
+				},
+				setParentId: ( postId ) => {
+					activePostIdRef.current = postId;
+					setActivePostId( postId );
+				},
+				createAutosave: ( postId, snapshot ) => composeApiFetch< AutosavePreviewResponse >( {
+					path: `/wp/v2/posts/${ postId }/autosaves`,
+					method: 'POST',
+					data: snapshot,
+				} ),
+			} );
+
+			const savedPayload = JSON.stringify( result.snapshot );
+			const currentPayload = JSON.stringify( {
+				title: titleRef.current.trim(),
+				content: getContent().trim(),
+			} );
+			lastSavedPayloadRef.current = savedPayload;
+			setHasUnsavedChanges( currentPayload !== savedPayload );
+			if ( currentPayload !== savedPayload ) {
+				pendingRerunRef.current = true;
+			}
+			setStatus( __( 'Preview opened in a new tab.', 'extrachill-studio' ) );
+		} catch ( previewError ) {
+			setStatus( '' );
+			setError(
+				( previewError as Error )?.message ||
+				__( 'Failed to open the post preview. Try again.', 'extrachill-studio' )
+			);
+		} finally {
+			isPreviewingRef.current = false;
+			setIsPreviewing( false );
+			if ( pendingRerunRef.current ) {
+				pendingRerunRef.current = false;
+				performAutosave();
+			}
+		}
+	};
+
 	const submitForReview = async (): Promise< void > => {
+		if ( isPreviewingRef.current ) {
+			return;
+		}
+
 		const content = getContent();
 
 		if ( ! title.trim() ) {
@@ -888,9 +986,14 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 	};
 
 	const saveDraft = async (): Promise< void > => {
-		const content = getContent();
+		if ( isPreviewingRef.current ) {
+			return;
+		}
 
-		if ( ! title.trim() && ! content.trim() ) {
+		const content = getContent();
+		const currentTitle = titleRef.current.trim();
+
+		if ( ! currentTitle && ! content.trim() ) {
 			setError( __( 'Add a title or content before saving.', 'extrachill-studio' ) );
 			setStatus( '' );
 			return;
@@ -905,34 +1008,45 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 		setError( '' );
 		setStatus( __( 'Saving…', 'extrachill-studio' ) );
 
-		try {
-			const path = activePostId ? `/wp/v2/posts/${ activePostId }` : '/wp/v2/posts';
-			const post = await composeApiFetch< WpPost >( {
-				path,
-				method: 'POST',
-				data: { title: title.trim(), content, status: 'draft' },
-			} );
+		const operation = ( async (): Promise< void > => {
+			try {
+				const postId = activePostIdRef.current;
+				const path = postId ? `/wp/v2/posts/${ postId }` : '/wp/v2/posts';
+				const post = await composeApiFetch< WpPost >( {
+					path,
+					method: 'POST',
+					data: { title: currentTitle, content, status: 'draft' },
+				} );
 
-			activePostIdRef.current = post.id;
-			titleRef.current = title.trim();
-			contentSnapshotRef.current = content;
-			setActivePostId( post.id );
-			lastSavedPayloadRef.current = JSON.stringify( { title: title.trim(), content } );
-			setHasUnsavedChanges( false );
-			setStatus( __( 'Draft saved.', 'extrachill-studio' ) );
+				activePostIdRef.current = post.id;
+				titleRef.current = currentTitle;
+				contentSnapshotRef.current = content;
+				setActivePostId( post.id );
+				lastSavedPayloadRef.current = JSON.stringify( { title: currentTitle, content } );
+				setHasUnsavedChanges( false );
+				setStatus( __( 'Draft saved.', 'extrachill-studio' ) );
 
-			const refreshed = await loadDrafts();
-			setDrafts( refreshed );
-			scheduleClientContextUpdate();
-		} catch ( saveError ) {
-			setStatus( '' );
-			setError( ( saveError as Error )?.message || __( 'Failed to save draft.', 'extrachill-studio' ) );
-		} finally {
-			setIsSubmitting( false );
-		}
+				const refreshed = await loadDrafts();
+				setDrafts( refreshed );
+				scheduleClientContextUpdate();
+			} catch ( saveError ) {
+				setStatus( '' );
+				setError( ( saveError as Error )?.message || __( 'Failed to save draft.', 'extrachill-studio' ) );
+			} finally {
+				setIsSubmitting( false );
+				manualSavePromiseRef.current = null;
+			}
+		} )();
+
+		manualSavePromiseRef.current = operation;
+		await operation;
 	};
 
 	const onDraftSelect = async ( e: ChangeEvent< HTMLSelectElement > ): Promise< void > => {
+		if ( isPreviewingRef.current ) {
+			return;
+		}
+
 		const value = e.target.value;
 
 		// "New draft" selected.
@@ -974,7 +1088,7 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 			className: 'ec-studio-compose-draft-picker',
 			value: activePostId || 'new',
 			onChange: onDraftSelect,
-			disabled: isLoadingDrafts || isSwitching,
+			disabled: isLoadingDrafts || isSwitching || isPreviewing,
 		},
 		createElement(
 			'option',
@@ -1016,7 +1130,7 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 									type: 'button',
 									className: 'button-1 button-small',
 									onClick: startNew,
-									disabled: isSubmitting || isSwitching || ! activePostId,
+									disabled: isSubmitting || isSwitching || isPreviewing || ! activePostId,
 								},
 								__( 'New', 'extrachill-studio' )
 							),
@@ -1058,26 +1172,37 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 					createElement(
 						'button',
 						{
-						type: 'button',
-						className: 'button-1 button-medium',
-						onClick: submitForReview,
-						disabled: isSubmitting || isSwitching || ! editorReady,
-					},
-					isSubmitting ? __( 'Submitting…', 'extrachill-studio' ) : __( 'Submit for Review', 'extrachill-studio' )
-				),
-				createElement(
-					'button',
-					{
-						type: 'button',
-						className: 'button-1 button-medium button-secondary',
-						onClick: saveDraft,
-						disabled: isSubmitting || isSwitching || ! editorReady,
-					},
-					isSubmitting ? __( 'Saving…', 'extrachill-studio' ) : (
-						activePostId
-							? __( 'Update Draft', 'extrachill-studio' )
-							: __( 'Save Draft', 'extrachill-studio' )
-					)
+							type: 'button',
+							className: 'button-1 button-medium',
+							onClick: submitForReview,
+							disabled: isSubmitting || isSwitching || isPreviewing || ! editorReady,
+						},
+						isSubmitting ? __( 'Submitting…', 'extrachill-studio' ) : __( 'Submit for Review', 'extrachill-studio' )
+					),
+					createElement(
+						'button',
+						{
+							type: 'button',
+							className: 'button-1 button-medium button-secondary',
+							onClick: previewPost,
+							disabled: isSubmitting || isSwitching || isPreviewing || ! editorReady,
+							'aria-label': __( 'Preview post on extrachill.com in a new tab', 'extrachill-studio' ),
+						},
+						isPreviewing ? __( 'Preparing Preview…', 'extrachill-studio' ) : __( 'Preview in New Tab', 'extrachill-studio' )
+					),
+					createElement(
+						'button',
+						{
+							type: 'button',
+							className: 'button-1 button-medium button-secondary',
+							onClick: saveDraft,
+							disabled: isSubmitting || isSwitching || isPreviewing || ! editorReady,
+						},
+						isSubmitting ? __( 'Saving…', 'extrachill-studio' ) : (
+							activePostId
+								? __( 'Update Draft', 'extrachill-studio' )
+								: __( 'Save Draft', 'extrachill-studio' )
+						)
 					)
 				)
 			),

--- a/src/blocks/studio/tabs/compose/preview.test.js
+++ b/src/blocks/studio/tabs/compose/preview.test.js
@@ -1,0 +1,187 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { openComposePreview } from './preview';
+
+const previewLink =
+	'https://extrachill.com/example/?preview_id=42&preview_nonce=nonce&preview=true';
+
+function setup( overrides = {} ) {
+	const previewWindow = {
+		close: jest.fn(),
+		location: { replace: jest.fn() },
+	};
+	let parentId = 42;
+	const dependencies = {
+		openWindow: jest.fn( () => previewWindow ),
+		cancelPendingSave: jest.fn(),
+		waitForPendingSaves: jest.fn( async () => {} ),
+		getSnapshot: jest.fn( () => ( {
+			title: 'Live title',
+			content: '<!-- wp:paragraph -->Body',
+		} ) ),
+		getParentId: jest.fn( () => parentId ),
+		createDraft: jest.fn( async () => 84 ),
+		setParentId: jest.fn( ( id ) => {
+			parentId = id;
+		} ),
+		createAutosave: jest.fn( async ( postId ) => ( {
+			id: 900,
+			parent: postId,
+			preview_link: previewLink,
+		} ) ),
+		...overrides,
+	};
+
+	return { dependencies, previewWindow };
+}
+
+describe( 'openComposePreview', () => {
+	it( 'opens synchronously, waits, then previews the latest existing draft snapshot', async () => {
+		let releaseSave;
+		const waiting = new Promise( ( resolve ) => {
+			releaseSave = resolve;
+		} );
+		const { dependencies, previewWindow } = setup( {
+			waitForPendingSaves: jest.fn( () => waiting ),
+		} );
+
+		const operation = openComposePreview( dependencies );
+		expect( dependencies.openWindow ).toHaveBeenCalledTimes( 1 );
+		expect( dependencies.getSnapshot ).not.toHaveBeenCalled();
+
+		releaseSave();
+		await operation;
+
+		expect( dependencies.cancelPendingSave ).toHaveBeenCalledTimes( 1 );
+		expect( dependencies.getSnapshot ).toHaveBeenCalledTimes( 1 );
+		expect( dependencies.createAutosave ).toHaveBeenCalledWith( 42, {
+			title: 'Live title',
+			content: '<!-- wp:paragraph -->Body',
+		} );
+		expect( previewWindow.location.replace ).toHaveBeenCalledWith(
+			previewLink
+		);
+	} );
+
+	it( 'creates one parent draft before requesting its autosave preview', async () => {
+		const { dependencies } = setup( {
+			getParentId: jest.fn( () => null ),
+		} );
+
+		await openComposePreview( dependencies );
+
+		expect( dependencies.createDraft ).toHaveBeenCalledTimes( 1 );
+		expect( dependencies.setParentId ).toHaveBeenCalledWith( 84 );
+		expect( dependencies.createAutosave ).toHaveBeenCalledWith(
+			84,
+			expect.any( Object )
+		);
+	} );
+
+	it( 'reads the live selected parent and immediate title at preview time', async () => {
+		const { dependencies } = setup( {
+			getParentId: jest.fn( () => 77 ),
+			getSnapshot: jest.fn( () => ( {
+				title: 'Just typed',
+				content: 'Draft B',
+			} ) ),
+		} );
+
+		await openComposePreview( dependencies );
+
+		expect( dependencies.createAutosave ).toHaveBeenCalledWith( 77, {
+			title: 'Just typed',
+			content: 'Draft B',
+		} );
+	} );
+
+	it( 'never treats the autosave revision ID as the parent ID', async () => {
+		const { dependencies } = setup();
+
+		await openComposePreview( dependencies );
+
+		expect( dependencies.setParentId ).not.toHaveBeenCalled();
+		expect( dependencies.createAutosave ).toHaveBeenCalledWith(
+			42,
+			expect.any( Object )
+		);
+	} );
+
+	it( 'reports a blocked popup before starting network work', async () => {
+		const { dependencies } = setup( { openWindow: jest.fn( () => null ) } );
+
+		await expect( openComposePreview( dependencies ) ).rejects.toThrow(
+			'Allow pop-ups'
+		);
+		expect( dependencies.waitForPendingSaves ).not.toHaveBeenCalled();
+	} );
+
+	it.each( [
+		[
+			'request failure',
+			{
+				createAutosave: jest.fn( async () => {
+					throw new Error( 'Forbidden' );
+				} ),
+			},
+			'Forbidden',
+		],
+		[
+			'missing link',
+			{
+				createAutosave: jest.fn( async () => ( {
+					id: 900,
+					parent: 42,
+				} ) ),
+			},
+			'did not return a preview link',
+		],
+		[
+			'wrong host',
+			{
+				createAutosave: jest.fn( async () => ( {
+					id: 900,
+					parent: 42,
+					preview_link: 'https://studio.extrachill.com/?preview=true',
+				} ) ),
+			},
+			'wrong site',
+		],
+	] )(
+		'closes the temporary tab on %s',
+		async ( label, overrides, message ) => {
+			const { dependencies, previewWindow } = setup( overrides );
+
+			await expect( openComposePreview( dependencies ) ).rejects.toThrow(
+				message
+			);
+			expect( previewWindow.close ).toHaveBeenCalledTimes( 1 );
+		}
+	);
+} );
+
+describe( 'Compose autosave proxy contract', () => {
+	it( 'relays the complete core autosave response without filtering preview_link', () => {
+		const source = fs.readFileSync(
+			path.resolve( __dirname, '../../../../../inc/compose/rest.php' ),
+			'utf8'
+		);
+		const start = source.indexOf(
+			'function ec_studio_compose_create_autosave'
+		);
+		const handler = source.slice(
+			start,
+			source.indexOf( '/**\n * Sanitize the post params', start )
+		);
+
+		expect( handler ).toContain(
+			"'/wp/v2/posts/' . $post_id . '/autosaves'"
+		);
+		expect( handler ).toContain(
+			'return ec_studio_compose_relay_response( $response );'
+		);
+		expect( handler ).not.toMatch(
+			/preview_link.*unset|array_intersect_key/
+		);
+	} );
+} );

--- a/src/blocks/studio/tabs/compose/preview.ts
+++ b/src/blocks/studio/tabs/compose/preview.ts
@@ -1,0 +1,105 @@
+export interface ComposeSnapshot {
+	title: string;
+	content: string;
+}
+
+export interface AutosavePreviewResponse {
+	id: number;
+	parent: number;
+	preview_link?: string;
+}
+
+export interface ComposePreviewResult {
+	parentId: number;
+	snapshot: ComposeSnapshot;
+}
+
+interface PreviewWindow {
+	close: () => void;
+	location: {
+		replace: ( url: string ) => void;
+	};
+}
+
+interface PreviewDependencies {
+	openWindow: () => PreviewWindow | null;
+	cancelPendingSave: () => void;
+	waitForPendingSaves: () => Promise< void >;
+	getSnapshot: () => ComposeSnapshot;
+	getParentId: () => number | null;
+	createDraft: ( snapshot: ComposeSnapshot ) => Promise< number >;
+	setParentId: ( postId: number ) => void;
+	createAutosave: (
+		postId: number,
+		snapshot: ComposeSnapshot
+	) => Promise< AutosavePreviewResponse >;
+}
+
+function getPreviewUrl( response: AutosavePreviewResponse ): string {
+	if ( ! response.preview_link ) {
+		throw new Error( 'WordPress did not return a preview link.' );
+	}
+
+	let previewUrl: URL;
+	try {
+		previewUrl = new URL( response.preview_link );
+	} catch {
+		throw new Error( 'WordPress returned an invalid preview link.' );
+	}
+
+	if (
+		previewUrl.protocol !== 'https:' ||
+		previewUrl.hostname !== 'extrachill.com'
+	) {
+		throw new Error(
+			'WordPress returned a preview link for the wrong site.'
+		);
+	}
+
+	return previewUrl.toString();
+}
+
+/**
+ * Open a real WordPress frontend preview from Studio's live editor state.
+ *
+ * @param dependencies Browser and persistence operations supplied by Compose.
+ */
+export async function openComposePreview(
+	dependencies: PreviewDependencies
+): Promise< ComposePreviewResult > {
+	const previewWindow = dependencies.openWindow();
+	if ( ! previewWindow ) {
+		throw new Error(
+			'Preview was blocked. Allow pop-ups for Studio and try again.'
+		);
+	}
+
+	try {
+		dependencies.cancelPendingSave();
+		await dependencies.waitForPendingSaves();
+
+		const snapshot = dependencies.getSnapshot();
+		if ( ! snapshot.title && ! snapshot.content ) {
+			throw new Error( 'Add a title or content before previewing.' );
+		}
+
+		let parentId = dependencies.getParentId();
+		if ( ! parentId ) {
+			parentId = await dependencies.createDraft( snapshot );
+			if ( ! parentId ) {
+				throw new Error( 'WordPress did not return the new draft ID.' );
+			}
+			dependencies.setParentId( parentId );
+		}
+
+		const autosave = await dependencies.createAutosave(
+			parentId,
+			snapshot
+		);
+		previewWindow.location.replace( getPreviewUrl( autosave ) );
+		return { parentId, snapshot };
+	} catch ( error ) {
+		previewWindow.close();
+		throw error;
+	}
+}


### PR DESCRIPTION
## Summary
- add a Studio-owned **Preview in New Tab** action that snapshots the live external title and Blocks Everywhere content, then opens WordPress core's real blog-1 frontend preview
- serialize Preview with debounced, in-flight, and manual saves; preserve the parent post ID when core returns an autosave revision; queue edits that land during preview
- add focused orchestration tests plus a source contract proving the cross-site autosave proxy relays core's response without filtering `preview_link`

## Architecture
Studio Compose intentionally does not enable Blocks Everywhere canonical `postEntity` preview. Compose mounts Blocks Everywhere once, hot-swaps drafts, and owns title and cross-site autosave state; BE's mount-captured identity and autosave monitor would become stale or compete with Studio after draft switching and first-draft creation.

Instead, the host action reuses WordPress core's `POST /wp/v2/posts/<parent-id>/autosaves` primitive through `composeApiFetch`. Core returns the nonce-bearing edit-context `preview_link`, which runs through the real `extrachill.com` permalink, theme, dynamic blocks, filters, and native draft authorization.

## Race And Error Handling
- opens the named blank window synchronously before any await
- cancels the debounce and drains active autosave/manual-save promises before taking a fresh snapshot
- creates one native blog-1 draft only when the live parent-ID ref is empty
- suppresses competing autosaves and draft switching while Preview owns the write, then resumes queued edits
- validates the returned HTTPS `extrachill.com` URL without ever assigning the autosave revision ID as the parent
- closes the temporary window and surfaces popup, authorization, request, missing-link, invalid-link, and wrong-site failures

## Verification
- `npm run typecheck` - passed
- `npm run test:unit -- --runInBand` - passed, 9 tests
- `npm run build` - passed
- `npx wp-scripts lint-js src/blocks/studio/tabs/compose/preview.ts src/blocks/studio/tabs/compose/preview.test.js` - passed
- `php -l inc/compose/rest.php` - passed
- `git diff --check` - passed
- `homeboy review --path /var/lib/datamachine/workspace/extrachill-studio@issue-130-compose-preview --changed-only --summary extrachill-studio` - not run by Homeboy; its hot-machine resource policy refused local execution at load 135.5 across 8 CPUs, and the safety gate was not overridden

Closes #130