### PR TITLE
fix: clear Compose REST lint error

### DIFF
--- a/inc/compose/rest.php
+++ b/inc/compose/rest.php
@@ -170,7 +170,6 @@ function ec_studio_compose_register_routes(): void {
 			),
 		)
 	);
-
 }
 add_action( 'rest_api_init', 'ec_studio_compose_register_routes' );
 


### PR DESCRIPTION
## Summary
- remove release-blocking blank-line spacing before the route registration function close

## Verification
- Homeboy changed-file PHPCS passes with zero findings
- git diff check passes

Closes #132