### PR TITLE
docs: document team contribution flow

### DIFF
--- a/docs/user/team-contribution-guide.md
+++ b/docs/user/team-contribution-guide.md
@@ -1,0 +1,56 @@
+# Contributing Blog Posts in Studio
+
+Studio is the Extra Chill team workspace for drafting blog posts and handing them to an editor. Your writing is saved directly to the main Extra Chill site from the first draft, even though you work at Studio.
+
+## Before You Start
+
+You need an Extra Chill account with team access. Sign in at [studio.extrachill.com](https://studio.extrachill.com/) and open the **Blog** tab.
+
+Studio Compose is intentionally focused on the story itself. You write the title and body; an editor handles categories, artists, venues, locations, the featured image, SEO details, and publication settings during review.
+
+## Start or Continue a Draft
+
+1. Open the **Blog** tab in Studio.
+2. Choose **+ New draft** or select one of your recent drafts from the draft picker.
+3. Add the post title.
+4. Write the story in the block editor. Use the block inserter to add paragraphs, headings, images, galleries, lists, quotes, separators, or embeds.
+5. Select **Save Draft** when you want to save explicitly. After the first save, the button reads **Update Draft**.
+
+Studio also autosaves after you make changes. The first meaningful autosave creates your draft on `extrachill.com`; an empty editor does not create a post. Only your own draft posts appear in the Studio picker.
+
+## Preview Your Post
+
+Select **Preview in New Tab** to see the latest title and body on the Extra Chill site. Studio saves the current editor state before opening the preview, so the preview should match what you are writing even if you have not selected **Update Draft** first.
+
+Allow popups for Studio if the preview tab does not open.
+
+## Submit for Editorial Review
+
+1. Make sure the post has both a title and body content.
+2. Select **Submit for Review**.
+3. Wait for the confirmation before leaving the page.
+
+Submission changes the post from a draft to a pending post on the main Extra Chill site. The editor clears, and the post disappears from your Studio draft picker because that picker only shows active drafts.
+
+Studio does not currently provide a submitted-post list, withdrawal button, or revision conversation. Contact an editor if you need to change something after submission.
+
+## What Editors Do Next
+
+Editors can find pending posts at **Studio wp-admin → Posts → Studio Submissions**. Contributors without editorial permissions do not see this queue.
+
+From the queue, an editor can preview the submission or open it in the main Extra Chill editor. The editor reviews the writing, adds the required editorial metadata and featured image, and then publishes or schedules the post through the normal WordPress publishing flow.
+
+## When Your Post Goes Live
+
+You receive an Extra Chill notification when an editor publishes your Studio submission. The notification includes the post title and links to the live article. Depending on your notification preferences, it may also be delivered by email or digest.
+
+Studio does not currently send a separate notification while a post is waiting, when an editor requests revisions, or when a post is scheduled.
+
+## Quick Checklist
+
+- Write a clear title and complete story.
+- Use headings and blocks to make the post easy to read.
+- Preview the post before submitting.
+- Select **Submit for Review** only when the draft is ready for an editor.
+- Contact an editor directly if you need to revise a submitted post.
+- Watch for the publication notification and check the live article.

--- a/src/blocks/studio/tabs/compose/index.ts
+++ b/src/blocks/studio/tabs/compose/index.ts
@@ -1123,6 +1123,16 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 						createElement(
 							'div',
 							{ className: 'ec-studio-compose-toolbar__controls' },
+							createElement(
+								'a',
+								{
+									className: 'button-1 button-small button-secondary',
+									href: 'https://docs.extrachill.com/studio/team-contribution-guide/',
+									target: '_blank',
+									rel: 'noopener noreferrer',
+								},
+								__( 'Contribution Guide', 'extrachill-studio' )
+							),
 							draftPicker,
 							createElement(
 								'button',


### PR DESCRIPTION
## Summary
- add the canonical team guide for drafting, previewing, submitting, reviewing, and publishing blog posts through Studio
- document current limitations so contributors know when to contact an editor
- link the guide directly from the Blog compose toolbar for team discoverability

## Testing
- `npm run typecheck`
- `npm run test:unit -- --runInBand` (9 tests passed)
- `npm run build`
- `git diff --check`

## Dependency
The guide is already present as a private page on docs.extrachill.com. Durable private sync and team access are implemented in the companion Extra-Chill/extrachill-docs pull request.