### PR TITLE
fix: fail closed for missing team helper

### DIFF
--- a/inc/compose/rest.php
+++ b/inc/compose/rest.php
@@ -356,7 +356,7 @@ function ec_studio_compose_permission_check() {
 		);
 	}
 
-	if ( ! current_user_can( 'manage_options' ) && function_exists( 'ec_is_team_member' ) && ! ec_is_team_member() ) {
+	if ( ! current_user_can( 'manage_options' ) && ( ! function_exists( 'ec_is_team_member' ) || ! ec_is_team_member() ) ) {
 		return new \WP_Error(
 			'rest_forbidden',
 			__( 'Studio is available to Extra Chill team members only.', 'extrachill-studio' ),


### PR DESCRIPTION
## Summary
- fail closed when the Extra Chill team-membership helper is unavailable
- preserve administrator access through the existing `manage_options` bypass

## Root cause
The Compose REST permission callback only evaluated a negative team-membership result when `ec_is_team_member()` existed. For authenticated non-administrators, a missing helper made the entire rejection condition false and allowed the route-level team check to pass.

## Authorization behavior
Before:
- unauthenticated callers received `401`
- administrators were allowed
- authenticated non-administrators were denied only when `ec_is_team_member()` existed and returned false
- authenticated non-administrators were allowed through the route-level gate when the helper was unavailable

After:
- unauthenticated callers still receive `401`
- administrators remain allowed
- authenticated non-administrators are allowed only when `ec_is_team_member()` exists and returns true
- authenticated non-administrators receive `403` when the helper is unavailable or returns false

## Regression coverage
The repository has no PHP test harness or existing PHP test pattern, so no focused automated PHP regression test was added. The one-condition change matches the existing fail-closed homepage gate and was validated with PHP syntax checking plus the repository's full available unit, typecheck, and build commands.

## Commands run
- `git diff --check`
- `php -l inc/compose/rest.php`
- `npm run test:unit` (9 tests passed)
- `npm run typecheck`
- `npm run build`

Closes #137