### PR TITLE
fix: restore newer autosave on initial compose load

### DIFF
--- a/src/blocks/studio/tabs/compose/draft-recovery.test.js
+++ b/src/blocks/studio/tabs/compose/draft-recovery.test.js
@@ -1,0 +1,96 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { recoverDraftContent } from './draft-recovery';
+
+const parent = {
+	id: 42,
+	title: { rendered: 'Parent title', raw: 'Parent title' },
+	content: { rendered: 'Parent content', raw: 'Parent content' },
+	status: 'draft',
+	date: '2026-08-02T18:00:00',
+	modified: '2026-08-02T18:00:00',
+	modified_gmt: '2026-08-02T18:00:00',
+};
+
+describe( 'recoverDraftContent', () => {
+	it( 'prefers a newer autosave belonging to the current user', async () => {
+		const loadAutosaves = jest.fn( async () => [
+			{
+				id: 100,
+				parent: 42,
+				author: 7,
+				title: { raw: 'Recovered title', rendered: 'Recovered title' },
+				content: {
+					raw: 'Recovered content',
+					rendered: 'Recovered content',
+				},
+				modified_gmt: '2026-08-02T18:05:00',
+			},
+		] );
+
+		await expect(
+			recoverDraftContent( parent, 7, loadAutosaves )
+		).resolves.toEqual( {
+			title: 'Recovered title',
+			content: 'Recovered content',
+		} );
+		expect( loadAutosaves ).toHaveBeenCalledWith( 42 );
+	} );
+
+	it.each( [
+		[ 'no autosave exists', [] ],
+		[
+			'only another user has a newer autosave',
+			[
+				{
+					id: 102,
+					parent: 42,
+					author: 8,
+					title: { raw: 'Other title', rendered: 'Other title' },
+					content: {
+						raw: 'Other content',
+						rendered: 'Other content',
+					},
+					modified_gmt: '2026-08-02T18:10:00',
+				},
+			],
+		],
+		[
+			'the current-user autosave is not newer',
+			[
+				{
+					id: 101,
+					parent: 42,
+					author: 7,
+					title: { raw: 'Older title', rendered: 'Older title' },
+					content: {
+						raw: 'Older content',
+						rendered: 'Older content',
+					},
+					modified_gmt: '2026-08-02T17:55:00',
+				},
+			],
+		],
+	] )( 'retains the parent when %s', async ( label, autosaves ) => {
+		await expect(
+			recoverDraftContent( parent, 7, async () => autosaves )
+		).resolves.toEqual( {
+			title: 'Parent title',
+			content: 'Parent content',
+		} );
+	} );
+} );
+
+describe( 'Compose draft hydration contract', () => {
+	it( 'uses the shared autosave recovery for initial load and explicit switching', () => {
+		const source = fs.readFileSync(
+			path.resolve( __dirname, 'index.ts' ),
+			'utf8'
+		);
+
+		expect( source ).toContain(
+			'const initialDraft = result.length > 0\n\t\t\t\t? await loadDraftContent( result[ 0 ] )'
+		);
+		expect( source ).toContain( '} = await loadDraftContent( post );' );
+	} );
+} );

--- a/src/blocks/studio/tabs/compose/draft-recovery.ts
+++ b/src/blocks/studio/tabs/compose/draft-recovery.ts
@@ -1,0 +1,67 @@
+export interface WpPost {
+	id: number;
+	title: { rendered: string; raw?: string };
+	content: { rendered: string; raw?: string };
+	status: string;
+	date: string;
+	modified: string;
+	modified_gmt?: string;
+}
+
+export interface WpAutosave {
+	id: number;
+	parent: number;
+	author: number;
+	title?: { rendered: string; raw?: string };
+	content?: { rendered: string; raw?: string };
+	modified?: string;
+	modified_gmt?: string;
+}
+
+interface DraftContent {
+	title: string;
+	content: string;
+}
+
+/**
+ * Prefer the current user's newer autosave, falling back to the parent draft.
+ *
+ * @param post          Parent draft returned by the posts endpoint.
+ * @param currentUserId Current WordPress user ID.
+ * @param loadAutosaves Fetches autosaves for the parent draft.
+ */
+export async function recoverDraftContent(
+	post: WpPost,
+	currentUserId: number | undefined,
+	loadAutosaves: ( postId: number ) => Promise< WpAutosave[] >
+): Promise< DraftContent > {
+	let title = post.title.raw || post.title.rendered || '';
+	let content = post.content.raw || post.content.rendered || '';
+
+	if ( ! currentUserId ) {
+		return { title, content };
+	}
+
+	try {
+		const autosaves = await loadAutosaves( post.id );
+		const userAutosave = Array.isArray( autosaves )
+			? autosaves.find(
+					( autosave ) => autosave?.author === currentUserId
+			  )
+			: null;
+
+		if (
+			userAutosave &&
+			userAutosave.modified_gmt &&
+			post.modified_gmt &&
+			userAutosave.modified_gmt > post.modified_gmt
+		) {
+			title = userAutosave.title?.raw || title;
+			content = userAutosave.content?.raw || content;
+		}
+	} catch {
+		// Best-effort recovery: an unavailable autosave must not block the draft.
+	}
+
+	return { title, content };
+}

--- a/src/blocks/studio/tabs/compose/index.ts
+++ b/src/blocks/studio/tabs/compose/index.ts
@@ -13,6 +13,8 @@ import { markComposeRequest, registerComposeInstance } from './cross-site-middle
 import { installChatRefreshAdapter } from './refresh-adapter';
 import { openComposePreview } from './preview';
 import type { AutosavePreviewResponse, ComposeSnapshot } from './preview';
+import { recoverDraftContent } from './draft-recovery';
+import type { WpAutosave, WpPost } from './draft-recovery';
 
 /**
  * apiFetch wrapper that tags a request as Compose-pane-originated so the
@@ -45,26 +47,6 @@ interface BlocksEverywhereContentApi {
 	replaceContent: ( html: string ) => void;
 	getContent: () => string;
 	getBlocks: () => object[];
-}
-
-interface WpPost {
-	id: number;
-	title: { rendered: string; raw?: string };
-	content: { rendered: string; raw?: string };
-	status: string;
-	date: string;
-	modified: string;
-	modified_gmt?: string;
-}
-
-interface WpAutosave {
-	id: number;
-	parent: number;
-	author: number;
-	title?: { rendered: string; raw?: string };
-	content?: { rendered: string; raw?: string };
-	modified?: string;
-	modified_gmt?: string;
 }
 
 /** Autosave debounce interval in milliseconds. */
@@ -347,6 +329,20 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 		}
 	}, [] );
 
+	const loadDraftContent = useCallback( async ( post: WpPost ) => {
+		const currentUser = (
+			select( 'core' ) as {
+				getCurrentUser?: () => { id?: number } | undefined;
+			}
+		).getCurrentUser?.();
+
+		return recoverDraftContent( post, currentUser?.id, ( postId ) =>
+			composeApiFetch< WpAutosave[] >( {
+				path: `/wp/v2/posts/${ postId }/autosaves?context=edit`,
+			} )
+		);
+	}, [] );
+
 	/**
 	 * Flush any unsaved changes for the current draft before switching away.
 	 * Creates a new draft on first save if no active post ID exists.
@@ -444,38 +440,19 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 			// is stale relative to in-flight typing. Check for a user autosave
 			// newer than the parent and prefer it. Falls back to parent on any
 			// error so the picker always works.
-			let title = post.title.raw || post.title.rendered || '';
-			let content = post.content.raw || post.content.rendered || '';
-			try {
-				const currentUser = ( select( 'core' ) as { getCurrentUser?: () => { id?: number } | undefined } )
-					.getCurrentUser?.();
-				const currentUserId = currentUser?.id;
-				if ( currentUserId ) {
-					const autosaves = await composeApiFetch< WpAutosave[] >( {
-						path: `/wp/v2/posts/${ post.id }/autosaves?context=edit`,
-					} );
-					const userAutosave = Array.isArray( autosaves )
-						? autosaves.find( ( a ) => a?.author === currentUserId )
-						: null;
-					if (
-						userAutosave &&
-						userAutosave.modified_gmt &&
-						post.modified_gmt &&
-						userAutosave.modified_gmt > post.modified_gmt
-					) {
-						title = userAutosave.title?.raw || title;
-						content = userAutosave.content?.raw || content;
-					}
-				}
-			} catch {
-				// Best-effort recovery — fall back to parent content silently.
-			}
+			const {
+				title: recoveredTitle,
+				content: recoveredContent,
+			} = await loadDraftContent( post );
 
-			titleRef.current = title;
-			setTitle( title );
-			contentSnapshotRef.current = content;
-			replaceEditorContent( content );
-			lastSavedPayloadRef.current = JSON.stringify( { title, content } );
+			titleRef.current = recoveredTitle;
+			setTitle( recoveredTitle );
+			contentSnapshotRef.current = recoveredContent;
+			replaceEditorContent( recoveredContent );
+			lastSavedPayloadRef.current = JSON.stringify( {
+				title: recoveredTitle,
+				content: recoveredContent,
+			} );
 		} else {
 			activePostIdRef.current = null;
 			titleRef.current = '';
@@ -490,7 +467,7 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 		setError( '' );
 		setStatus( '' );
 		scheduleClientContextUpdate();
-	}, [ flushCurrentDraft, scheduleClientContextUpdate ] );
+	}, [ flushCurrentDraft, loadDraftContent, scheduleClientContextUpdate ] );
 
 	const startNew = useCallback( async (): Promise< void > => {
 		if ( isPreviewingRef.current ) {
@@ -701,6 +678,9 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 			// Fetch drafts first so we can pre-fill the textarea before mounting the editor.
 			setIsLoadingDrafts( true );
 			const result = await loadDrafts();
+			const initialDraft = result.length > 0
+				? await loadDraftContent( result[ 0 ] )
+				: null;
 
 			if ( cancelled ) {
 				return;
@@ -712,15 +692,16 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 			// Pre-fill textarea with the most recent draft.
 			if ( result.length > 0 && textareaRef.current ) {
 				const post = result[ 0 ];
+				const { title: initialTitle, content: initialContent } = initialDraft!;
 				activePostIdRef.current = post.id;
-				titleRef.current = post.title.raw || post.title.rendered || '';
+				titleRef.current = initialTitle;
 				setActivePostId( post.id );
-				setTitle( post.title.raw || post.title.rendered || '' );
-				textareaRef.current.value = post.content.raw || post.content.rendered || '';
-				contentSnapshotRef.current = post.content.raw || post.content.rendered || '';
+				setTitle( initialTitle );
+				textareaRef.current.value = initialContent;
+				contentSnapshotRef.current = initialContent;
 				lastSavedPayloadRef.current = JSON.stringify( {
-					title: post.title.raw || post.title.rendered || '',
-					content: post.content.raw || post.content.rendered || '',
+					title: initialTitle,
+					content: initialContent,
 				} );
 			} else {
 				activePostIdRef.current = null;
@@ -755,7 +736,7 @@ const ComposePane = ( props: StudioPaneProps ): ReactElement => {
 		return () => {
 			cancelled = true;
 		};
-	}, [ loadDrafts, scheduleClientContextUpdate ] );
+	}, [ loadDraftContent, loadDrafts, scheduleClientContextUpdate ] );
 
 
 


### PR DESCRIPTION
## Summary
- route initial Compose hydration through the same current-user autosave recovery used by explicit draft switching
- retain parent draft content when no newer current-user autosave exists or autosave recovery fails
- add focused recovery and shared-hydration regression coverage

## Root cause
The initial mount path copied title and content directly from the newest parent draft returned by `/wp/v2/posts`, while explicit draft switching separately queried the per-user autosave endpoint. A browser session ending after a newer autosave therefore reopened with stale parent content until the writer switched drafts.

## Recovery behavior
Before: explicit draft selection preferred a newer current-user autosave, but automatic initial hydration always displayed the parent draft.

After: both paths call one shared recovery function. It selects only the current user's autosave when its `modified_gmt` is newer than the parent; otherwise, including request failures, it preserves the parent title and content. Existing autosave concurrency and status-preservation paths are unchanged.

## Regression tests
- newer current-user autosave replaces parent title and content
- absent, older, or another user's autosave retains the parent
- initial hydration and explicit switching are wired to the shared recovery path

## Commands run
- `npm run test:unit -- --runInBand`
- `npm run typecheck`
- `npm run build`
- `npx wp-scripts lint-js src/blocks/studio/tabs/compose/draft-recovery.ts src/blocks/studio/tabs/compose/draft-recovery.test.js`
- `git diff --check`

Note: linting the full legacy `index.ts` remains blocked by its existing repository-wide formatting and hook-rule violations; the new recovery module and tests pass focused lint.

Closes #138