### PR TITLE
fix: proxy Compose post reads to main

### DIFF
--- a/inc/compose/rest.php
+++ b/inc/compose/rest.php
@@ -24,6 +24,7 @@
  * Routes (all under the team-gated permission check):
  *   - GET  /extrachill/v1/studio/compose/posts                 List the user's drafts on main.
  *   - POST /extrachill/v1/studio/compose/posts                 Create a draft on main.
+ *   - GET  /extrachill/v1/studio/compose/posts/<id>            Fetch a post from main.
  *   - POST /extrachill/v1/studio/compose/posts/<id>            Update / submit-for-review on main.
  *   - GET  /extrachill/v1/studio/compose/posts/<id>/autosaves  List autosaves for a draft on main.
  *   - POST /extrachill/v1/studio/compose/posts/<id>/autosaves  Autosave a draft on main (status omitted).
@@ -38,14 +39,15 @@
  * problem #75 set out to remove.
  *
  * Two dispatch strategies, by necessity:
- *   - JSON routes (posts, autosaves, single-media GET) forward via
+ *   - JSON write/list routes (posts, autosaves, single-media GET) forward via
  *     `ec_cross_site_rest_request( 'main', ... )` and guard on that helper
  *     being available (`ec_studio_compose_require_cross_site()`).
- *   - File/header-sensitive routes (media upload, media browse) do their own
- *     `switch_to_blog( main )`: a multipart `$_FILES` upload can't ride the
- *     in-process rest_do_request cleanly, and the browse grid needs the
- *     core controller's X-WP-Total pagination headers, which the cross-site
- *     helper strips. These guard on `ec_get_blog_id()` instead.
+ *   - Header-sensitive reads and file routes (single-post GET, media upload,
+ *     media browse) do their own `switch_to_blog( main )`: the post read must
+ *     preserve core response headers, a multipart `$_FILES` upload can't ride
+ *     the in-process rest_do_request cleanly, and the browse grid needs the
+ *     core controller's X-WP-Total pagination headers. These guard on
+ *     `ec_get_blog_id()` instead.
  *
  * @package    ExtraChillStudio
  * @subpackage Compose
@@ -89,6 +91,18 @@ function ec_studio_compose_register_routes(): void {
 		EC_STUDIO_COMPOSE_NAMESPACE,
 		'/' . EC_STUDIO_COMPOSE_ROUTE . '/posts/(?P<id>\d+)',
 		array(
+			array(
+				'methods'             => 'GET',
+				'callback'            => 'ec_studio_compose_get_post',
+				'permission_callback' => 'ec_studio_compose_permission_check',
+				'args'                => array(
+					'id' => array(
+						'required'          => true,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
+				),
+			),
 			array(
 				'methods'             => 'POST',
 				'callback'            => 'ec_studio_compose_update_post',
@@ -496,6 +510,62 @@ function ec_studio_compose_create_post( \WP_REST_Request $request ) {
 	);
 
 	return ec_studio_compose_relay_response( $response );
+}
+
+/**
+ * Fetch an existing post from main extrachill.com.
+ *
+ * Dispatches through main's native posts controller so context=edit and
+ * per-post read/edit permissions are enforced by WordPress core. Returning the
+ * native response preserves its status and headers; native errors are relayed
+ * as WP_Error like the other compose proxy routes.
+ *
+ * @param \WP_REST_Request $request REST request.
+ * @return \WP_REST_Response|\WP_Error
+ */
+function ec_studio_compose_get_post( \WP_REST_Request $request ) {
+	if ( ! function_exists( 'ec_get_blog_id' ) ) {
+		return new \WP_Error(
+			'multisite_helper_missing',
+			__( 'extrachill-multisite is required for cross-site compose.', 'extrachill-studio' ),
+			array( 'status' => 500 )
+		);
+	}
+
+	$main_blog_id = (int) ec_get_blog_id( 'main' );
+	if ( $main_blog_id <= 0 ) {
+		return new \WP_Error(
+			'main_blog_unresolved',
+			__( 'Could not resolve the main site for compose.', 'extrachill-studio' ),
+			array( 'status' => 500 )
+		);
+	}
+
+	$post_id = (int) $request['id'];
+	$query   = $request->get_query_params();
+	$query   = is_array( $query )
+		? array_intersect_key(
+			$query,
+			array_flip( array( 'context', 'password', 'excerpt_length', '_fields', '_embed' ) )
+		)
+		: array();
+	$result  = null;
+
+	switch_to_blog( $main_blog_id );
+	try {
+		$sub_request = new \WP_REST_Request( 'GET', '/wp/v2/posts/' . $post_id );
+		$sub_request->set_query_params( $query );
+		$sub_request->add_header( 'X-EC-Forwarded', '1' );
+
+		$response = rest_do_request( $sub_request );
+		$result   = $response->is_error()
+			? $response->as_error()
+			: ec_studio_compose_relay_response( $response );
+	} finally {
+		restore_current_blog();
+	}
+
+	return $result;
 }
 
 /**

--- a/src/blocks/studio/tabs/compose/item-get.test.js
+++ b/src/blocks/studio/tabs/compose/item-get.test.js
@@ -1,0 +1,98 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const source = fs.readFileSync(
+	path.resolve( __dirname, '../../../../../inc/compose/rest.php' ),
+	'utf8'
+);
+const routeStart = source.indexOf(
+	"'/' . EC_STUDIO_COMPOSE_ROUTE . '/posts/(?P<id>\\d+)'"
+);
+const route = source.slice(
+	routeStart,
+	source.indexOf( 'register_rest_route(', routeStart + 1 )
+);
+const handlerStart = source.indexOf( 'function ec_studio_compose_get_post' );
+const handler = source.slice(
+	handlerStart,
+	source.indexOf( '/**\n * Update an existing post', handlerStart )
+);
+const permissionStart = source.indexOf(
+	'function ec_studio_compose_permission_check'
+);
+const permissionHandler = source.slice(
+	permissionStart,
+	source.indexOf( '/**\n * Guard that extrachill-multisite', permissionStart )
+);
+
+describe( 'Compose item GET proxy contract', () => {
+	it( 'registers GET and POST separately behind the existing team gate', () => {
+		expect( route ).toContain( "'methods'             => 'GET'" );
+		expect( route ).toContain(
+			"'callback'            => 'ec_studio_compose_get_post'"
+		);
+		expect( route ).toContain( "'methods'             => 'POST'" );
+		expect(
+			route.match( /ec_studio_compose_permission_check/g )
+		).toHaveLength( 2 );
+	} );
+
+	it( 'fails closed when the requester is not an authorized team member', () => {
+		expect( permissionHandler ).toContain( '! is_user_logged_in()' );
+		expect( permissionHandler ).toContain(
+			"! function_exists( 'ec_is_team_member' ) || ! ec_is_team_member()"
+		);
+		expect( permissionHandler ).toContain( "array( 'status' => 403 )" );
+	} );
+
+	it( 'preserves context=edit and other core item query parameters', () => {
+		expect( handler ).toContain(
+			'$query   = $request->get_query_params();'
+		);
+		expect( handler ).toContain(
+			"array( 'context', 'password', 'excerpt_length', '_fields', '_embed' )"
+		);
+		expect( handler ).toContain(
+			'$sub_request->set_query_params( $query );'
+		);
+	} );
+
+	it( 'dispatches to the native main-site posts controller', () => {
+		expect( handler ).toContain( "ec_get_blog_id( 'main' )" );
+		expect( handler ).toContain(
+			"new \\WP_REST_Request( 'GET', '/wp/v2/posts/' . $post_id )"
+		);
+		expect( handler ).toContain( 'rest_do_request( $sub_request )' );
+	} );
+
+	it( 'relays native missing-post and access errors as WP_Error', () => {
+		expect( handler ).toContain( '$response->is_error()' );
+		expect( handler ).toContain( '$response->as_error()' );
+	} );
+
+	it( 'preserves the successful core response status and headers', () => {
+		expect( handler ).toContain(
+			'ec_studio_compose_relay_response( $response )'
+		);
+	} );
+} );
+
+describe( 'Compose external-edit refresh route', () => {
+	it( 'fetches the active post with edit context through the rewritten item path', () => {
+		const composeSource = fs.readFileSync(
+			path.resolve( __dirname, 'index.ts' ),
+			'utf8'
+		);
+		const middlewareSource = fs.readFileSync(
+			path.resolve( __dirname, 'cross-site-middleware.ts' ),
+			'utf8'
+		);
+
+		expect( composeSource ).toContain(
+			'path: `/wp/v2/posts/${ postId }?context=edit`'
+		);
+		expect( middlewareSource ).toContain(
+			'return `${ PROXY_PREFIX }/posts/${ postMatch[ 1 ] }${ query }`;'
+		);
+	} );
+} );


### PR DESCRIPTION
## Summary
- add the missing team-gated `GET /extrachill/v1/studio/compose/posts/<id>` route
- dispatch reads through blog 1's native posts controller under the requesting user
- preserve safe item query parameters, native response status/headers, and WordPress errors

## Root Cause
Compose's apiFetch middleware already rewrote `GET /wp/v2/posts/<id>?context=edit` to the Studio item proxy for external-edit refreshes. The proxy item route registered only POST, so the rewritten GET had no matching callback.

## Route Contract
Before: `/studio/compose/posts/<id>` accepted POST updates only.

After: the same item route accepts GET reads and POST updates through separate callbacks. GET forwards `context`, `password`, `excerpt_length`, `_fields`, and `_embed` to `/wp/v2/posts/<id>` on blog 1. The existing middleware keeps `context=edit` intact across the rewrite.

## Authorization
The outer route uses the existing fail-closed `ec_studio_compose_permission_check` team gate. The inner request runs through WordPress core's posts controller on blog 1 under the current user, so missing posts and native read/edit capability failures retain core behavior. Successful native REST responses are returned without flattening, preserving status and relevant headers; error responses are relayed as `WP_Error`.

## Regression Coverage
- successful item GET with `context=edit` and safe query forwarding
- missing-post and native access errors relayed as `WP_Error`
- logged-out/non-team authorization remains fail closed
- GET and POST method routing coexist on the item route
- external-edit fetch path still rewrites the item URL with its query string

## Verification
- `npm run test:unit -- --runInBand` (21 tests passed)
- `npm run typecheck`
- `npm run build`
- `npx wp-scripts lint-js src/blocks/studio/tabs/compose/item-get.test.js`
- `php -l inc/compose/rest.php`
- `git diff --check`
- PHPCS was not runnable because this repository/workspace has no PHPCS executable or configuration

Closes #129